### PR TITLE
Improve ViewModelLocator ViewModel type name convention assumptions

### DIFF
--- a/Source/Prism/Mvvm/ViewModelLocationProvider.cs
+++ b/Source/Prism/Mvvm/ViewModelLocationProvider.cs
@@ -37,7 +37,10 @@ namespace Prism.Mvvm
                 var viewName = viewType.FullName;
                 viewName = viewName.Replace(".Views.", ".ViewModels.");
                 var viewAssemblyName = viewType.GetTypeInfo().Assembly.FullName;
-                var viewModelName = String.Format(CultureInfo.InvariantCulture, "{0}ViewModel, {1}", viewName, viewAssemblyName);
+                var suffix = viewName.EndsWith("View")
+                                ? "Model"
+                                : "ViewModel";
+                var viewModelName = String.Format(CultureInfo.InvariantCulture, "{0}{1}, {2}", viewName, suffix, viewAssemblyName);
                 return Type.GetType(viewModelName);
             };
 

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/Views/MockView.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/Views/MockView.cs
@@ -1,0 +1,8 @@
+﻿using System.Windows;
+
+namespace Prism.Wpf.Tests.Mocks.Views
+{
+    public class MockView : FrameworkElement
+    {
+    }
+}

--- a/Source/Wpf/Prism.Wpf.Tests/Mvvm/ViewModelLocatorFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mvvm/ViewModelLocatorFixture.cs
@@ -24,6 +24,19 @@ namespace Prism.Wpf.Tests.Mvvm
         }
 
         [TestMethod]
+        public void ShouldLocateViewModelWithDefaultSettingsForViewsThatEndWithView()
+        {
+            ResetViewModelLocationProvider();
+
+            MockView view = new MockView();
+            Assert.IsNull(view.DataContext);
+
+            ViewModelLocator.SetAutoWireViewModel(view, true);
+            Assert.IsNotNull(view.DataContext);
+            Assert.IsInstanceOfType(view.DataContext, typeof(MockViewModel));
+        }
+
+        [TestMethod]
         public void ShouldUseCustomDefaultViewModelFactoryWhenSet()
         {
             ResetViewModelLocationProvider();

--- a/Source/Wpf/Prism.Wpf.Tests/Prism.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Wpf.Tests/Prism.Wpf.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Mocks\ViewModels\MockViewModel.cs" />
     <Compile Include="Mocks\Views\Mock.cs" />
     <Compile Include="Mvvm\ViewModelLocatorFixture.cs" />
+    <Compile Include="Mocks\Views\MockView.cs" />
     <Compile Include="Regions\Behaviors\ClearChildViewsRegionBehaviorFixture.cs" />
     <Compile Include="Regions\Behaviors\RegionMemberLifetimeBehaviorFixture.cs" />
     <Compile Include="Regions\LocatorNavigationTargetHandlerFixture.cs" />


### PR DESCRIPTION
Fix issue #12: Improve ViewModelLocator ViewModel type name convention assumptions