### PR TITLE
Moved BootstrapperFixtureBase and mocks, fixes #18

### DIFF
--- a/Source/PrismLibrary_Tests.sln
+++ b/Source/PrismLibrary_Tests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism", "Prism\Prism.csproj", "{E6C50355-D01E-4CAA-884D-D7929861315C}"
 EndProject
@@ -28,6 +28,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.Mef.Wpf.Tests", "Wpf\Prism.Mef.Wpf.Tests\Prism.Mef.Wpf.Tests.csproj", "{B9BD4B23-8163-4EF3-955F-02B9578C45BA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.Wpf.Tests", "Wpf\Prism.Wpf.Tests\Prism.Wpf.Tests.csproj", "{7DB8E74D-214F-4840-B294-58372D369958}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.IocContainer.Wpf.Tests.Support", "Wpf\Prism.IocContainer.Wpf.Tests.Support\Prism.IocContainer.Wpf.Tests.Support.csproj", "{FF6F1B2C-BECC-4477-B918-B75615BAA3A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,6 +81,10 @@ Global
 		{7DB8E74D-214F-4840-B294-58372D369958}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DB8E74D-214F-4840-B294-58372D369958}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DB8E74D-214F-4840-B294-58372D369958}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF6F1B2C-BECC-4477-B918-B75615BAA3A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF6F1B2C-BECC-4477-B918-B75615BAA3A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF6F1B2C-BECC-4477-B918-B75615BAA3A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF6F1B2C-BECC-4477-B918-B75615BAA3A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,5 +99,6 @@ Global
 		{F6443399-3E76-4B51-964A-95A166239D56} = {6BED0A37-BE6B-42D2-AAF0-C612FF57D9EB}
 		{B9BD4B23-8163-4EF3-955F-02B9578C45BA} = {6BED0A37-BE6B-42D2-AAF0-C612FF57D9EB}
 		{7DB8E74D-214F-4840-B294-58372D369958} = {6BED0A37-BE6B-42D2-AAF0-C612FF57D9EB}
+		{FF6F1B2C-BECC-4477-B918-B75615BAA3A5} = {6BED0A37-BE6B-42D2-AAF0-C612FF57D9EB}
 	EndGlobalSection
 EndGlobal

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/BootstrapperFixtureBase.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/BootstrapperFixtureBase.cs
@@ -3,11 +3,10 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Prism.Wpf.Unity.Tests
+namespace Prism.IocContainer.Tests.Support
 {
     public class BootstrapperFixtureBase
     {
-        // TODO: Move to shared DLL
         protected static void AssertExceptionThrownOnRun(Bootstrapper bootstrapper, Type expectedExceptionType, string expectedExceptionMessageSubstring)
         {
             bool exceptionThrown = false;

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantA.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantA.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
-namespace Prism.Wpf.Unity.Tests.Mocks
+
+namespace Prism.IocContainer.Tests.Support.Mocks
 {
     public class DependantA : IDependantA
     {

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantB.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantB.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 
-namespace Prism.Wpf.Unity.Tests.Mocks
+namespace Prism.IocContainer.Tests.Support.Mocks
 {
     public class DependantB : IDependantB
     {

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockLoggerAdapter.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockLoggerAdapter.cs
@@ -3,9 +3,9 @@
 using System.Collections.Generic;
 using Prism.Logging;
 
-namespace Prism.Wpf.Unity.Tests.Mocks
+namespace Prism.IocContainer.Tests.Support.Mocks
 {
-    internal class MockLoggerAdapter : ILoggerFacade
+    public class MockLoggerAdapter : ILoggerFacade
     {
         public IList<string> Messages = new List<string>();
 

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockModuleLoader.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockModuleLoader.cs
@@ -2,9 +2,9 @@
 
 using Prism.Modularity;
 
-namespace Prism.Wpf.Unity.Tests.Mocks
+namespace Prism.IocContainer.Tests.Support.Mocks
 {
-    internal class MockModuleInitializer : IModuleInitializer
+    public class MockModuleInitializer : IModuleInitializer
     {
         public bool LoadCalled;
 

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockRegionManager.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockRegionManager.cs
@@ -3,9 +3,9 @@
 using System;
 using Prism.Regions;
 
-namespace Prism.Wpf.Unity.Tests.Mocks
+namespace Prism.IocContainer.Tests.Support.Mocks
 {
-    class MockRegionManager : IRegionManager
+    public class MockRegionManager : IRegionManager
     {
         #region IRegionManager Members
 

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockService.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockService.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 
-namespace Prism.Wpf.Unity.Tests.Mocks
+namespace Prism.IocContainer.Tests.Support.Mocks
 {
     public class MockService : IService
     {

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Prism.IocContainer.Wpf.Tests.Support.csproj
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Prism.IocContainer.Wpf.Tests.Support.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FF6F1B2C-BECC-4477-B918-B75615BAA3A5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Prism.IocContainer.Tests.Support</RootNamespace>
+    <AssemblyName>Prism.IocContainer.Wpf.Tests.Support</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BootstrapperFixtureBase.cs" />
+    <Compile Include="Mocks\DependantA.cs" />
+    <Compile Include="Mocks\DependantB.cs" />
+    <Compile Include="Mocks\MockLoggerAdapter.cs" />
+    <Compile Include="Mocks\MockModuleLoader.cs" />
+    <Compile Include="Mocks\MockRegionManager.cs" />
+    <Compile Include="Mocks\MockService.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Prism\Prism.csproj">
+      <Project>{e6c50355-d01e-4caa-884d-d7929861315c}</Project>
+      <Name>Prism</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Prism.Wpf\Prism.Wpf.csproj">
+      <Project>{5912ff03-c72b-4f56-baa1-8642fdbfbc26}</Project>
+      <Name>Prism.Wpf</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Prism.IocContainer.Wpf.Tests.Support")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Prism.IocContainer.Wpf.Tests.Support")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fb85c610-a3f2-4226-b12d-b2c6e7ec7812")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
@@ -100,30 +100,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Mocks\DependantA.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Mocks\DependantB.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Mocks\MockLoggerAdapter.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Mocks\MockModuleLoader.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Mocks\MockRegionManager.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Mocks\MockService.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnityBootstrapperNullModuleManagerFixture.cs" />
     <Compile Include="UnityBootstrapperFixture.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="BootstrapperFixtureBase.cs" />
     <Compile Include="UnityBootstrapperNullContainerFixture.cs" />
     <Compile Include="UnityBootstrapperNullLoggerFixture.cs" />
     <Compile Include="UnityBootstrapperNullModuleCatalogFixture.cs" />
@@ -166,6 +147,10 @@
     <ProjectReference Include="..\..\Prism\Prism.csproj">
       <Project>{e6c50355-d01e-4caa-884d-d7929861315c}</Project>
       <Name>Prism</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Prism.IocContainer.Wpf.Tests.Support\Prism.IocContainer.Wpf.Tests.Support.csproj">
+      <Project>{ff6f1b2c-becc-4477-b918-b75615baa3a5}</Project>
+      <Name>Prism.IocContainer.Wpf.Tests.Support</Name>
     </ProjectReference>
     <ProjectReference Include="..\Prism.Unity.Wpf\Prism.Unity.Wpf.csproj">
       <Project>{c1ce34c7-6ac9-4d54-bad0-8467e9f9f38d}</Project>

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
@@ -6,11 +6,12 @@ using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prism.IocContainer.Tests.Support;
+using Prism.IocContainer.Tests.Support.Mocks;
 using Prism.Logging;
 using Prism.Modularity;
 using Prism.Regions;
 using Prism.Unity;
-using Prism.Wpf.Unity.Tests.Mocks;
 
 namespace Prism.Wpf.Unity.Tests
 {

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullContainerFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullContainerFixture.cs
@@ -4,6 +4,7 @@ using System;
 using System.Windows;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prism.IocContainer.Tests.Support;
 using Prism.Unity;
 
 namespace Prism.Wpf.Unity.Tests

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullLoggerFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullLoggerFixture.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prism.IocContainer.Tests.Support;
 using Prism.Logging;
 using Prism.Unity;
 

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullModuleCatalogFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullModuleCatalogFixture.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prism.IocContainer.Tests.Support;
 using Prism.Modularity;
 using Prism.Unity;
 

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityContainerExtensionFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityContainerExtensionFixture.cs
@@ -3,8 +3,8 @@
 using System.Collections.Generic;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prism.IocContainer.Tests.Support.Mocks;
 using Prism.Unity;
-using Prism.Wpf.Unity.Tests.Mocks;
 
 namespace Prism.Wpf.Unity.Tests
 {


### PR DESCRIPTION
Currently named the shared library Prism.IocContainer.Wpf.Tests.Support, similar to the existing library Prism.Mef.Wpf.Tests.Support. Naming is open for discussion.