### PR TITLE
Mvvm helpers refactoring

### DIFF
--- a/Source/Wpf/Prism.Mef.Wpf/Modularity/MefModuleManager.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Modularity/MefModuleManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Windows;
@@ -11,7 +12,6 @@ using Prism.IocContainer.Wpf.Tests.Support.Mocks;
 using Prism.Logging;
 using Prism.Modularity;
 using Prism.Regions;
-using System;
 
 namespace Prism.Unity.Wpf.Tests
 {

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
@@ -11,6 +11,7 @@ using Prism.IocContainer.Wpf.Tests.Support.Mocks;
 using Prism.Logging;
 using Prism.Modularity;
 using Prism.Regions;
+using System;
 
 namespace Prism.Unity.Wpf.Tests
 {

--- a/Source/Wpf/Prism.Wpf.Tests/ListDictionaryFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/ListDictionaryFixture.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prism.Common;
 
 namespace Prism.Wpf.Tests
 {

--- a/Source/Wpf/Prism.Wpf.Tests/Modularity/FileModuleTypeLoaderFixture.Desktop.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Modularity/FileModuleTypeLoaderFixture.Desktop.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Modularity;

--- a/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleCatalogFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleCatalogFixture.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleInitializerFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleInitializerFixture.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Microsoft.Practices.ServiceLocation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleManagerFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleManagerFixture.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Wpf.Tests/Regions/Behaviors/SyncRegionContextWithHostBehaviorFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/Behaviors/SyncRegionContextWithHostBehaviorFixture.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Regions;
 using Prism.Regions.Behaviors;
 using Prism.Wpf.Tests.Mocks;
+using Prism.Common;
 
 namespace Prism.Wpf.Tests.Regions.Behaviors
 {

--- a/Source/Wpf/Prism.Wpf/Common/ListDictionary.cs
+++ b/Source/Wpf/Prism.Wpf/Common/ListDictionary.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Prism
+namespace Prism.Common
 {
     /// <summary>
     /// A dictionary of lists.

--- a/Source/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/Source/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace Prism.Common
+{
+    public static class MvvmHelpers
+    {
+        public static void ViewAndViewModelAction<T>(object view, Action<T> action) where T : class
+        {
+            T viewAsT = view as T;
+            if (viewAsT != null)
+                action(viewAsT);
+            var element = view as FrameworkElement;
+            if (element != null)
+            {
+                var viewModelAsT = element.DataContext as T;
+                if (viewModelAsT != null)
+                {
+                    action(viewModelAsT);
+                }
+            }
+        }
+
+        public static T GetImplementerFromViewOrViewModel<T>(object view) where T : class
+        {
+            T viewAsT = view as T;
+            if (viewAsT != null)
+            {
+                return viewAsT;
+            }
+
+            var element = view as FrameworkElement;
+            if (element != null)
+            {
+                var vmAsT = element.DataContext as T;
+                return vmAsT;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Common/ObservableObject.cs
+++ b/Source/Wpf/Prism.Wpf/Common/ObservableObject.cs
@@ -3,7 +3,7 @@
 using System.ComponentModel;
 using System.Windows;
 
-namespace Prism
+namespace Prism.Common
 {
     /// <summary>
     /// Class that wraps an object, so that other classes can notify for Change events. Typically, this class is set as 

--- a/Source/Wpf/Prism.Wpf/Common/UriParsingHelper.cs
+++ b/Source/Wpf/Prism.Wpf/Common/UriParsingHelper.cs
@@ -3,7 +3,7 @@
 using System;
 using Prism.Regions;
 
-namespace Prism
+namespace Prism.Common
 {
     /// <summary>
     /// Helper class for parsing <see cref="Uri"/> instances.

--- a/Source/Wpf/Prism.Wpf/Extensions/CollectionExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Extensions/CollectionExtensions.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
-namespace Prism
+namespace System.Collections.ObjectModel
 {
     /// <summary>
     /// Class that provides extension methods to Collection

--- a/Source/Wpf/Prism.Wpf/Extensions/ExceptionExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Extensions/ExceptionExtensions.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
-namespace Prism
+namespace System
 {
     /// <summary>
     /// Class that provides extension methods for the Exception class. These extension methods provide

--- a/Source/Wpf/Prism.Wpf/Extensions/ServiceLocatorExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Extensions/ServiceLocatorExtensions.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Practices.ServiceLocation;
 
-namespace Prism
+namespace Microsoft.Practices.ServiceLocation
 {
     /// <summary>
     /// Defines extension methods for the <see cref="ServiceLocator"/> class.

--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
+using Prism.Common;
 using Prism.Interactivity.DefaultPopupWindows;
 using Prism.Interactivity.InteractionRequest;
 using System;
@@ -179,23 +180,13 @@ namespace Prism.Interactivity
             // We set the WindowContent as the content of the window. 
             wrapperWindow.Content = this.WindowContent;
 
-            IInteractionRequestAware interactionAware;
-
-            // If the WindowContent implements IInteractionRequestAware we set the corresponding properties.
-            interactionAware = this.WindowContent as IInteractionRequestAware;
-            if (interactionAware != null)
+            Action<IInteractionRequestAware> setNotificationAndClose = (iira) =>
             {
-                interactionAware.Notification = notification;
-                interactionAware.FinishInteraction = () => wrapperWindow.Close();
-            }
+                iira.Notification = notification;
+                iira.FinishInteraction = () => wrapperWindow.Close();
+            };
 
-            // If the WindowContent's DataContext implements IInteractionRequestAware we set the corresponding properties.
-            interactionAware = this.WindowContent.DataContext as IInteractionRequestAware;
-            if (interactionAware != null)
-            {
-                interactionAware.Notification = notification;
-                interactionAware.FinishInteraction = () => wrapperWindow.Close();
-            }
+            MvvmHelpers.ViewAndViewModelAction(this.WindowContent, setNotificationAndClose);
         }
 
         /// <summary>

--- a/Source/Wpf/Prism.Wpf/Modularity/ConfigurationModuleCatalog.Desktop.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/ConfigurationModuleCatalog.Desktop.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using Prism.Properties;

--- a/Source/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.Desktop.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.Desktop.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/Source/Wpf/Prism.Wpf/Modularity/ModuleDependencySolver.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/ModuleDependencySolver.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Prism.Properties;
+using Prism.Common;
 
 namespace Prism.Modularity
 {

--- a/Source/Wpf/Prism.Wpf/Modularity/ModuleInfoGroupExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/ModuleInfoGroupExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 
 namespace Prism.Modularity
 {

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -55,9 +55,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bootstrapper.cs" />
-    <Compile Include="CollectionExtensions.cs" />
+    <Compile Include="Common\MvvmHelpers.cs" />
+    <Compile Include="Extensions\CollectionExtensions.cs" />
     <Compile Include="Events\WeakDelegatesManager.cs" />
-    <Compile Include="ExceptionExtensions.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Interactivity\CommandBehaviorBase.cs" />
     <Compile Include="Interactivity\DefaultPopupWindows\DefaultConfirmationWindow.xaml.cs">
       <DependentUpon>DefaultConfirmationWindow.xaml</DependentUpon>
@@ -76,7 +77,7 @@
     <Compile Include="Interactivity\InteractionRequest\Notification.cs" />
     <Compile Include="Interactivity\InvokeCommandAction.cs" />
     <Compile Include="Interactivity\PopupWindowAction.cs" />
-    <Compile Include="ListDictionary.cs" />
+    <Compile Include="Common\ListDictionary.cs" />
     <Compile Include="Logging\TextLogger.cs" />
     <Compile Include="Logging\TraceLogger.cs" />
     <Compile Include="Modularity\AssemblyResolver.Desktop.cs" />
@@ -127,7 +128,7 @@
     <Compile Include="Modularity\ModuleTypeLoadingException.cs" />
     <Compile Include="Modularity\ModuleTypeLoadingException.Desktop.cs" />
     <Compile Include="Mvvm\ViewModelLocator.cs" />
-    <Compile Include="ObservableObject.cs" />
+    <Compile Include="Common\ObservableObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -208,8 +209,8 @@
     <Compile Include="Regions\ViewsCollection.cs" />
     <Compile Include="Regions\ViewsCollection.Desktop.cs" />
     <Compile Include="Regions\ViewSortHintAttribute.cs" />
-    <Compile Include="ServiceLocatorExtensions.cs" />
-    <Compile Include="UriParsingHelper.cs" />
+    <Compile Include="Extensions\ServiceLocatorExtensions.cs" />
+    <Compile Include="Common\UriParsingHelper.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/Source/Wpf/Prism.Wpf/Regions/Behaviors/BindRegionContextToDependencyObjectBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Behaviors/BindRegionContextToDependencyObjectBehavior.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
+using Prism.Common;
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;

--- a/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionActiveAwareBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionActiveAwareBehavior.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Windows;
 using System.Linq;
 using System.Reflection;
+using Prism.Common;
 
 namespace Prism.Regions.Behaviors
 {
@@ -54,25 +55,6 @@ namespace Prism.Regions.Behaviors
             }
         }
         
-        private static void InvokeOnActiveAwareElement(object item, Action<IActiveAware> invocation)
-        {
-            var activeAware = item as IActiveAware;
-            if (activeAware != null)
-            {
-                invocation(activeAware);
-            }
-
-            var frameworkElement = item as FrameworkElement;
-            if (frameworkElement != null)
-            {
-                var activeAwareDataContext = frameworkElement.DataContext as IActiveAware;
-                if (activeAwareDataContext != null)
-                {
-                    invocation(activeAwareDataContext);
-                }
-            }
-        }
-
         private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
@@ -81,7 +63,7 @@ namespace Prism.Regions.Behaviors
                 {
                     Action<IActiveAware> invocation = activeAware => activeAware.IsActive = true;
 
-                    InvokeOnActiveAwareElement(item, invocation);
+                    MvvmHelpers.ViewAndViewModelAction(item, invocation);
                     InvokeOnSynchronizedActiveAwareChildren(item, invocation);
                 }
             }
@@ -91,7 +73,7 @@ namespace Prism.Regions.Behaviors
                 {
                     Action<IActiveAware> invocation = activeAware => activeAware.IsActive = false;
 
-                    InvokeOnActiveAwareElement(item, invocation);
+                    MvvmHelpers.ViewAndViewModelAction(item, invocation);
                     InvokeOnSynchronizedActiveAwareChildren(item, invocation);
                 }
             }
@@ -119,10 +101,11 @@ namespace Prism.Regions.Behaviors
 
                 foreach (var syncActiveView in syncActiveViews)
                 {
-                    InvokeOnActiveAwareElement(syncActiveView, invocation);
+                    MvvmHelpers.ViewAndViewModelAction(syncActiveView, invocation);
                 }
             }
         }
+
 
         private bool ShouldSyncActiveState(object view)
         {

--- a/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionActiveAwareBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionActiveAwareBehavior.cs
@@ -106,7 +106,6 @@ namespace Prism.Regions.Behaviors
             }
         }
 
-
         private bool ShouldSyncActiveState(object view)
         {
             if (Attribute.IsDefined(view.GetType(), typeof(SyncActiveStateAttribute)))

--- a/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Specialized;
+using Prism.Common;
 
 namespace Prism.Regions.Behaviors
 {
@@ -65,7 +66,7 @@ namespace Prism.Regions.Behaviors
 
         private static bool ShouldKeepAlive(object inactiveView)
         {
-            IRegionMemberLifetime lifetime = GetItemOrContextLifetime(inactiveView);
+            IRegionMemberLifetime lifetime = MvvmHelpers.GetImplementerFromViewOrViewModel<IRegionMemberLifetime>(inactiveView);
             if (lifetime != null)
             {
                 return lifetime.KeepAlive;
@@ -95,23 +96,6 @@ namespace Prism.Regions.Behaviors
                 var contextLifetimeAttribute =
                     GetCustomAttributes<RegionMemberLifetimeAttribute>(dataContext.GetType()).FirstOrDefault();
                 return contextLifetimeAttribute;
-            }
-
-            return null;
-        }
-
-        private static IRegionMemberLifetime GetItemOrContextLifetime(object inactiveView)
-        {
-            var regionLifetime = inactiveView as IRegionMemberLifetime;
-            if (regionLifetime != null)
-            {
-                return regionLifetime;
-            }
-
-            var frameworkElement = inactiveView as System.Windows.FrameworkElement;
-            if (frameworkElement != null)
-            {
-                return frameworkElement.DataContext as IRegionMemberLifetime;
             }
 
             return null;

--- a/Source/Wpf/Prism.Wpf/Regions/Behaviors/SyncRegionContextWithHostBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Behaviors/SyncRegionContextWithHostBehavior.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Windows;
 using Prism.Properties;
+using Prism.Common;
 
 namespace Prism.Regions.Behaviors
 {

--- a/Source/Wpf/Prism.Wpf/Regions/NavigationContext.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/NavigationContext.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 
+using Prism.Common;
 using System;
 using System.Collections.Generic;
 

--- a/Source/Wpf/Prism.Wpf/Regions/RegionContext.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Windows;
 using Prism.Regions.Behaviors;
+using Prism.Common;
 
 namespace Prism.Regions
 {

--- a/Source/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -13,6 +13,7 @@ using Prism.Events;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
 using Microsoft.Practices.ServiceLocation;
+using Prism.Common;
 
 namespace Prism.Regions
 {

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Windows;
 using Prism.Properties;
 using Microsoft.Practices.ServiceLocation;
+using Prism.Common;
 
 namespace Prism.Regions
 {

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Windows;
 using Prism.Properties;
 using Microsoft.Practices.ServiceLocation;
+using Prism.Common;
 
 namespace Prism.Regions
 {
@@ -271,7 +272,8 @@ namespace Prism.Regions
                 this.journal.RecordNavigation(journalEntry);
 
                 // The view can be informed of navigation
-                InvokeOnNavigationAwareElement(view, (n) => n.OnNavigatedTo(navigationContext));
+                Action<INavigationAware> action = (n) => n.OnNavigatedTo(navigationContext);
+                MvvmHelpers.ViewAndViewModelAction(view, action);
 
                 navigationCallback(new NavigationResult(navigationContext, true));
 
@@ -302,26 +304,7 @@ namespace Prism.Regions
         {
             foreach (var item in items)
             {
-                InvokeOnNavigationAwareElement(item, invocation);
-            }
-        }
-
-        private static void InvokeOnNavigationAwareElement(object item, Action<INavigationAware> invocation)
-        {
-            var navigationAwareItem = item as INavigationAware;
-            if (navigationAwareItem != null)
-            {
-                invocation(navigationAwareItem);
-            }
-
-            FrameworkElement frameworkElement = item as FrameworkElement;
-            if (frameworkElement != null)
-            {
-                INavigationAware navigationAwareDataContext = frameworkElement.DataContext as INavigationAware;
-                if (navigationAwareDataContext != null)
-                {
-                    invocation(navigationAwareDataContext);
-                }
+                MvvmHelpers.ViewAndViewModelAction(item, invocation);
             }
         }
     }

--- a/Source/Wpf/Prism.Wpf/Regions/RegionViewRegistry.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionViewRegistry.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Prism.Events;
 using Prism.Properties;
 using Microsoft.Practices.ServiceLocation;
+using Prism.Common;
 
 namespace Prism.Regions
 {


### PR DESCRIPTION
Moved common files from project root into \Common and \Extensions folders, added MVVM helper to inspect view and ViewModel and use interface on them if they implement, removed duplicate code using that pattern throughout Prism where applicable.