### PR TITLE
PrismApplication methods async and SettingsFlyout

### DIFF
--- a/Samples/Windows10/HelloWorld/HelloWorld.sln
+++ b/Samples/Windows10/HelloWorld/HelloWorld.sln
@@ -22,6 +22,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9A9A2EE5-E495-496E-AFD7-2FD69BD67041}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{9A9A2EE5-E495-496E-AFD7-2FD69BD67041}.Debug|Any CPU.Build.0 = Debug|x86
+		{9A9A2EE5-E495-496E-AFD7-2FD69BD67041}.Debug|Any CPU.Deploy.0 = Debug|x86
 		{9A9A2EE5-E495-496E-AFD7-2FD69BD67041}.Debug|ARM.ActiveCfg = Debug|ARM
 		{9A9A2EE5-E495-496E-AFD7-2FD69BD67041}.Debug|ARM.Build.0 = Debug|ARM
 		{9A9A2EE5-E495-496E-AFD7-2FD69BD67041}.Debug|ARM.Deploy.0 = Debug|ARM

--- a/Samples/Windows10/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Samples/Windows10/HelloWorld/HelloWorld/App.xaml.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.ApplicationSettings;
 using HelloWorld.Services;
+using HelloWorld.ViewModels;
 using HelloWorld.Views;
 using Prism.Mvvm;
 using Prism.Windows;
-using Windows.ApplicationModel.Activation;
-using HelloWorld.ViewModels;
 
 namespace HelloWorld
 {
@@ -28,7 +27,7 @@ namespace HelloWorld
         /// to the page approriate based on a search, sharing, or secondary tile launch of the app
         /// </summary>
         /// <param name="args">The launch arguments passed to the application</param>
-        protected override Task OnLaunchApplication(LaunchActivatedEventArgs args)
+        protected override Task OnLaunchApplicationAsync(LaunchActivatedEventArgs args)
         {
             // Use the logical name for the view to navigate to. The default convention
             // in the NavigationService will be to append "Page" to the name and look 
@@ -43,7 +42,7 @@ namespace HelloWorld
         /// This is the place you initialize your services and set default factory or default resolver for the view model locator
         /// </summary>
         /// <param name="args">The same launch arguments passed when the app starts.</param>
-        protected override void OnInitialize(IActivatedEventArgs args)
+        protected override Task OnInitializeAsync(IActivatedEventArgs args)
         {
             // New up the singleton data repository, and pass it the state service it depends on from the base class
             _dataRepository = new DataRepository(SessionStateService);
@@ -52,6 +51,8 @@ namespace HelloWorld
             // dependent services from the factory method here.
             ViewModelLocationProvider.Register(typeof(MainPage).ToString(), () => new MainPageViewModel(_dataRepository, NavigationService));
             ViewModelLocationProvider.Register(typeof(UserInputPage).ToString(), () => new UserInputPageViewModel(_dataRepository, NavigationService));
+
+            return base.OnInitializeAsync(args);
         }
     }
 }

--- a/Samples/Windows10/HelloWorld/HelloWorld/Converter/BooleanToVisibilityConverter.cs
+++ b/Samples/Windows10/HelloWorld/HelloWorld/Converter/BooleanToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace HelloWorld.Converter
+{
+    // Simplest implementation of converter for sample purposes
+    public class BooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value is bool && (bool)value)
+            {
+                return Visibility.Visible;
+            }
+
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Samples/Windows10/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/Samples/Windows10/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -94,6 +94,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converter\BooleanToVisibilityConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DataRepository.cs" />
     <Compile Include="Services\IDataRepository.cs" />
@@ -167,6 +168,11 @@
       <Project>{e9fe3493-adde-4e8c-b5f0-5ac1b663a27b}</Project>
       <Name>Prism.Windows</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <SDKReference Include="WindowsDesktop, Version=10.0.10158.0">
+      <Name>Windows Desktop Extensions for the UWP</Name>
+    </SDKReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Samples/Windows10/HelloWorld/HelloWorld/ViewModels/MainPageViewModel.cs
+++ b/Samples/Windows10/HelloWorld/HelloWorld/ViewModels/MainPageViewModel.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Windows.Foundation.Metadata;
+using Windows.UI.ApplicationSettings;
 using HelloWorld.Services;
 using Prism.Windows.Mvvm;
 using Prism.Windows.Interfaces;
@@ -8,14 +10,28 @@ namespace HelloWorld.ViewModels
 {
     public class MainPageViewModel : ViewModel
     {
-        IDataRepository _dataRepository;
-
+        private readonly IDataRepository _dataRepository;
+        
         public MainPageViewModel(IDataRepository dataRepository, INavigationService navService)
         {
             _dataRepository = dataRepository;
+
             NavigateCommand = new DelegateCommand(() => navService.Navigate("UserInput", null));
+            if (ApiInformation.IsTypePresent("Windows.UI.ApplicationSettings.SettingsPane"))
+            {
+                ShowSettingsCommand = new DelegateCommand(SettingsPane.Show);
+                IsSettingsPresent = true;
+            }
         }
 
+        private bool _isSettingsPresent;
+        public bool IsSettingsPresent
+        {
+            get { return _isSettingsPresent; }
+            set { SetProperty(ref _isSettingsPresent, value); }
+        }
+
+        public DelegateCommand ShowSettingsCommand { get; set; }
         public DelegateCommand NavigateCommand { get; set; }
 
         public List<string> DisplayItems

--- a/Samples/Windows10/HelloWorld/HelloWorld/Views/MainPage.xaml
+++ b/Samples/Windows10/HelloWorld/HelloWorld/Views/MainPage.xaml
@@ -2,13 +2,16 @@
                            x:Class="HelloWorld.Views.MainPage"
                            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                           xmlns:local="using:HelloWorld.Views"
-                           xmlns:common="using:HelloWorld.Common"
                            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                            xmlns:prism="using:Prism.Windows.Mvvm"
+                           xmlns:converter="using:HelloWorld.Converter"
                            mc:Ignorable="d"
                            prism:ViewModelLocator.AutoWireViewModel="true">
+    <prism:VisualStateAwarePage.Resources>
+        <converter:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+    </prism:VisualStateAwarePage.Resources>
+    
     <!--
         This grid acts as a root panel for the page that defines two rows:
         * Row 0 contains the back button and page title
@@ -41,11 +44,16 @@
                       ItemsSource="{Binding DisplayItems}"
                       Margin="20,20,0,0"
                       SelectionMode="None" />
-            <Grid>
-                <Button HorizontalAlignment="Right"
-                        Margin="0,20,120,0"
-                        Content="Navigate To User Input Page"
-                        Command="{Binding NavigateCommand}" />
+            <Grid HorizontalAlignment="Right"
+                  Margin="0,20,120,0">
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Show settings"
+                            Command="{Binding ShowSettingsCommand}"
+                            Visibility="{Binding IsSettingsPresent, Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Margin="0,0,20,0"/>
+                    <Button Content="Navigate To User Input Page"
+                            Command="{Binding NavigateCommand}" />
+                </StackPanel>
             </Grid>
         </StackPanel>
     </Grid>

--- a/Source/Windows10/Prism.Unity.Windows/PrismUnityApplication.cs
+++ b/Source/Windows10/Prism.Unity.Windows/PrismUnityApplication.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.Practices.ServiceLocation;
 using Microsoft.Practices.Unity;
 using Prism.Events;
@@ -60,11 +61,12 @@ namespace Prism.Unity.Windows
         /// Implements and seals the OnInitialize method to configure the container.
         /// </summary>
         /// <param name="args">The <see cref="IActivatedEventArgs"/> instance containing the event data.</param>
-        protected override void OnInitialize(IActivatedEventArgs args)
+        protected override Task OnInitializeAsync(IActivatedEventArgs args)
         {
             ConfigureContainer();
-
             ConfigureViewModelLocator();
+
+            return Task.FromResult<object>(null);
         }
 
         /// <summary>

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -139,6 +139,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <SDKReference Include="WindowsDesktop, Version=10.0.10158.0">
+      <Name>Windows Desktop Extensions for the UWP</Name>
+    </SDKReference>
     <SDKReference Include="WindowsMobile, Version=10.0.0.1">
       <Name>Microsoft Mobile Extension SDK for Universal App Platform</Name>
     </SDKReference>


### PR DESCRIPTION
Made PrismApplication methods async as they should be (and were in the
Converged branch in UWP).
Added the SettingsFlyout with Win10 contracts, but noted that the
SettingsPane class got an Obsolete attribute in the latest SDK, to be
checked how this goes forward.