### PR TITLE
[Win10 UAP] DeviceGestureService for navigation and more

### DIFF
--- a/Source/Windows10/Prism.Windows/AppModel/CancelableEventArgs.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/CancelableEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Prism.Windows.AppModel
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class CancelableEventArgs : EventArgs
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Cancel { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public CancelableEventArgs() { }
+    }
+}

--- a/Source/Windows10/Prism.Windows/AppModel/DeviceGestureEventArgs.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/DeviceGestureEventArgs.cs
@@ -5,7 +5,7 @@ namespace Prism.Windows.AppModel
     /// <summary>
     /// 
     /// </summary>
-    public class DeviceGestureEventArgs : EventArgs
+    public class DeviceGestureEventArgs : CancelableEventArgs
     {
         public bool IsHardwareButton { get; set; }
 

--- a/Source/Windows10/Prism.Windows/AppModel/DeviceGestureEventArgs.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/DeviceGestureEventArgs.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Prism.Windows.AppModel
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DeviceGestureEventArgs : EventArgs
+    {
+        public bool IsHardwareButton { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DeviceGestureEventArgs() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="handled"></param>
+        public DeviceGestureEventArgs(bool handled)
+        {
+            Handled = handled;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="handled"></param>
+        public DeviceGestureEventArgs(bool handled, bool isHardwareButton)
+        {
+            Handled = handled;
+            IsHardwareButton = isHardwareButton;
+        }
+    }
+}

--- a/Source/Windows10/Prism.Windows/AppModel/DeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/DeviceGestureService.cs
@@ -20,27 +20,23 @@ namespace Prism.Windows.AppModel
 
         public event EventHandler<DeviceGestureEventArgs> GoBackRequested;
         public event EventHandler<DeviceGestureEventArgs> GoForwardRequested;
+        public event EventHandler<DeviceGestureEventArgs> CameraButtonHalfPressed;
+        public event EventHandler<DeviceGestureEventArgs> CameraButtonPressed;
+        public event EventHandler<DeviceGestureEventArgs> CameraButtonReleased;
 
         /// <summary>
-        /// 
+        /// Event helper method.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="eventHandler">The EventHandler</param>
+        /// <param name="sender"></param>
         /// <param name="args"></param>
-        protected void RaiseGoBackRequested(DeviceGestureEventArgs args)
+        private void InvokeEvent<T>(EventHandler<T> eventHandler, object sender, T args) where T : EventArgs
         {
-            EventHandler<DeviceGestureEventArgs> eventHandler = GoBackRequested;
-            if (eventHandler != null)
-                eventHandler(this, args);
-        }
+            EventHandler<T> handler = eventHandler;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="args"></param>
-        protected void RaiseGoForwardRequested(DeviceGestureEventArgs args)
-        {
-            EventHandler<DeviceGestureEventArgs> eventHandler = GoForwardRequested;
-            if (eventHandler != null)
-                eventHandler(this, args);
+            if (handler != null)
+                handler(sender, args);
         }
 
         /// <summary>
@@ -60,6 +56,13 @@ namespace Prism.Windows.AppModel
             if (IsHardwareBackButtonPresent)
                 HardwareButtons.BackPressed += OnHardwareButtonsBackPressed;
 
+            if (IsHardwareCameraButtonPresent)
+            {
+                HardwareButtons.CameraHalfPressed += OnHardwareButtonCameraHalfPressed;
+                HardwareButtons.CameraPressed += OnHardwareButtonCameraPressed;
+                HardwareButtons.CameraReleased += OnHardwareButtonCameraReleased;
+            }
+
             SystemNavigationManager.GetForCurrentView().BackRequested += OnSystemNavigationManagerBackRequested;
 
             Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += OnAcceleratorKeyActivated;
@@ -75,7 +78,7 @@ namespace Prism.Windows.AppModel
         protected virtual void OnSystemNavigationManagerBackRequested(object sender, BackRequestedEventArgs e)
         {
             e.Handled = true;
-            RaiseGoBackRequested(new DeviceGestureEventArgs(e.Handled));
+            InvokeEvent<DeviceGestureEventArgs>(GoBackRequested, this, new DeviceGestureEventArgs(e.Handled));
         }
 
         /// <summary>
@@ -86,7 +89,7 @@ namespace Prism.Windows.AppModel
         protected virtual void OnHardwareButtonsBackPressed(object sender, BackPressedEventArgs e)
         {
             e.Handled = true;
-            RaiseGoBackRequested(new DeviceGestureEventArgs(e.Handled, true));
+            InvokeEvent<DeviceGestureEventArgs>(GoBackRequested, this, new DeviceGestureEventArgs(e.Handled, true));
         }
 
         /// <summary>
@@ -116,19 +119,19 @@ namespace Prism.Windows.AppModel
                 {
                     // When the previous key or Alt+Left are pressed navigate back
                     args.Handled = true;
-                    RaiseGoBackRequested(new DeviceGestureEventArgs(args.Handled));
+                    InvokeEvent<DeviceGestureEventArgs>(GoBackRequested, this, new DeviceGestureEventArgs(args.Handled));
                 }
                 else if (virtualKey == VirtualKey.Back && winKey)
                 {
                     // When Win+Backspace is pressed navigate back
                     args.Handled = true;
-                    RaiseGoBackRequested(new DeviceGestureEventArgs(args.Handled));
+                    InvokeEvent<DeviceGestureEventArgs>(GoBackRequested, this, new DeviceGestureEventArgs(args.Handled));
                 }
                 else if (((int)virtualKey == 167 && noModifiers) || (virtualKey == VirtualKey.Right && onlyAlt))
                 {
                     // When the next key or Alt+Right are pressed navigate forward
                     args.Handled = true;
-                    RaiseGoForwardRequested(new DeviceGestureEventArgs(args.Handled));
+                    InvokeEvent<DeviceGestureEventArgs>(GoForwardRequested, this, new DeviceGestureEventArgs(args.Handled));
                 }
             }
         }
@@ -156,11 +159,41 @@ namespace Prism.Windows.AppModel
                 args.Handled = true;
 
                 if (backPressed)
-                    RaiseGoBackRequested(new DeviceGestureEventArgs(args.Handled));
+                    InvokeEvent<DeviceGestureEventArgs>(GoBackRequested, this, new DeviceGestureEventArgs(args.Handled));
 
                 if (forwardPressed)
-                    RaiseGoForwardRequested(new DeviceGestureEventArgs(args.Handled));
+                    InvokeEvent<DeviceGestureEventArgs>(GoForwardRequested, this, new DeviceGestureEventArgs(args.Handled));
             }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void OnHardwareButtonCameraHalfPressed(object sender, CameraEventArgs e)
+        {
+            InvokeEvent<DeviceGestureEventArgs>(CameraButtonHalfPressed, this, new DeviceGestureEventArgs(true, true));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void OnHardwareButtonCameraPressed(object sender, CameraEventArgs e)
+        {
+            InvokeEvent<DeviceGestureEventArgs>(CameraButtonPressed, this, new DeviceGestureEventArgs(true, true));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void OnHardwareButtonCameraReleased(object sender, CameraEventArgs e)
+        {
+            InvokeEvent<DeviceGestureEventArgs>(CameraButtonReleased, this, new DeviceGestureEventArgs(true, true));
         }
     }
 }

--- a/Source/Windows10/Prism.Windows/AppModel/DeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/DeviceGestureService.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using Prism.Windows.Interfaces;
+using Windows.Foundation.Metadata;
+using Windows.Phone.UI.Input;
+using Windows.System;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+
+namespace Prism.Windows.AppModel
+{
+    /// <summary>
+    /// The DeviceGestureService class is used for handling mouse, keyboard, hardware button and other gesture events.
+    /// </summary>
+    public class DeviceGestureService : IDeviceGestureService
+    {
+        public bool IsHardwareBackButtonPresent { get; private set; }
+        public bool IsHardwareCameraButtonPresent { get; private set; }
+
+        public bool UseTitleBarBackButton { get; set; }
+
+        public event EventHandler<DeviceGestureEventArgs> GoBackRequested;
+        public event EventHandler<DeviceGestureEventArgs> GoForwardRequested;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="args"></param>
+        protected void RaiseGoBackRequested(DeviceGestureEventArgs args)
+        {
+            EventHandler<DeviceGestureEventArgs> eventHandler = GoBackRequested;
+            if (eventHandler != null)
+                eventHandler(this, args);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="args"></param>
+        protected void RaiseGoForwardRequested(DeviceGestureEventArgs args)
+        {
+            EventHandler<DeviceGestureEventArgs> eventHandler = GoForwardRequested;
+            if (eventHandler != null)
+                eventHandler(this, args);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DeviceGestureService()
+        {
+            IsHardwareBackButtonPresent = ApiInformation.IsEventPresent("Windows.Phone.UI.Input.HardwareButtons", "BackPressed");
+            IsHardwareCameraButtonPresent = ApiInformation.IsEventPresent("Windows.Phone.UI.Input.HardwareButtons", "CameraPressed");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public virtual void InitializeEventHandlers()
+        {
+            if (IsHardwareBackButtonPresent)
+                HardwareButtons.BackPressed += OnHardwareButtonsBackPressed;
+
+            SystemNavigationManager.GetForCurrentView().BackRequested += OnSystemNavigationManagerBackRequested;
+
+            Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += OnAcceleratorKeyActivated;
+
+            Window.Current.CoreWindow.PointerPressed += OnPointerPressed;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void OnSystemNavigationManagerBackRequested(object sender, BackRequestedEventArgs e)
+        {
+            e.Handled = true;
+            RaiseGoBackRequested(new DeviceGestureEventArgs(e.Handled));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected virtual void OnHardwareButtonsBackPressed(object sender, BackPressedEventArgs e)
+        {
+            e.Handled = true;
+            RaiseGoBackRequested(new DeviceGestureEventArgs(e.Handled, true));
+        }
+
+        /// <summary>
+        /// Invoked on every keystroke, including system keys such as Alt key combinations.
+        /// Used to detect keyboard navigation between pages.
+        /// </summary>
+        /// <param name="sender">Instance that triggered the event.</param>
+        /// <param name="args">Event data describing the conditions that led to the event.</param>
+        protected virtual void OnAcceleratorKeyActivated(CoreDispatcher sender, AcceleratorKeyEventArgs args)
+        {
+            if ((args.EventType == CoreAcceleratorKeyEventType.SystemKeyDown ||
+                args.EventType == CoreAcceleratorKeyEventType.KeyDown))
+            {
+                var coreWindow = Window.Current.CoreWindow;
+                var downState = CoreVirtualKeyStates.Down;
+                var virtualKey = args.VirtualKey;
+                bool menuKey = (coreWindow.GetKeyState(VirtualKey.Menu) & downState) == downState;
+                bool winKey = ((coreWindow.GetKeyState(VirtualKey.LeftWindows) & downState) == downState || (coreWindow.GetKeyState(VirtualKey.RightWindows) & downState) == downState);
+                bool controlKey = (coreWindow.GetKeyState(VirtualKey.Control) & downState) == downState;
+                bool shiftKey = (coreWindow.GetKeyState(VirtualKey.Shift) & downState) == downState;
+                bool noModifiers = !menuKey && !controlKey && !shiftKey && !winKey;
+                bool onlyAlt = menuKey && !controlKey && !shiftKey && !winKey;
+
+                //TODO: DeviceGestureService.KeyDown event?
+
+                if (((int)virtualKey == 166 && noModifiers) || (virtualKey == VirtualKey.Left && onlyAlt))
+                {
+                    // When the previous key or Alt+Left are pressed navigate back
+                    args.Handled = true;
+                    RaiseGoBackRequested(new DeviceGestureEventArgs(args.Handled));
+                }
+                else if (virtualKey == VirtualKey.Back && winKey)
+                {
+                    // When Win+Backspace is pressed navigate back
+                    args.Handled = true;
+                    RaiseGoBackRequested(new DeviceGestureEventArgs(args.Handled));
+                }
+                else if (((int)virtualKey == 167 && noModifiers) || (virtualKey == VirtualKey.Right && onlyAlt))
+                {
+                    // When the next key or Alt+Right are pressed navigate forward
+                    args.Handled = true;
+                    RaiseGoForwardRequested(new DeviceGestureEventArgs(args.Handled));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Invoked on every mouse click, touch screen tap, or equivalent interaction.
+        /// Used to detect browser-style next and previous mouse button clicks to navigate between pages.
+        /// </summary>
+        /// <param name="sender">Instance that triggered the event.</param>
+        /// <param name="args">Event data describing the conditions that led to the event.</param>
+        protected virtual void OnPointerPressed(CoreWindow sender, PointerEventArgs args)
+        {
+            var properties = args.CurrentPoint.Properties;
+
+            // Ignore button chords with the left, right, and middle buttons
+            if (properties.IsLeftButtonPressed || properties.IsRightButtonPressed || properties.IsMiddleButtonPressed)
+                return;
+
+            // If back or foward are pressed (but not both) navigate appropriately
+            bool backPressed = properties.IsXButton1Pressed;
+            bool forwardPressed = properties.IsXButton2Pressed;
+
+            if (backPressed ^ forwardPressed)
+            {
+                args.Handled = true;
+
+                if (backPressed)
+                    RaiseGoBackRequested(new DeviceGestureEventArgs(args.Handled));
+
+                if (forwardPressed)
+                    RaiseGoForwardRequested(new DeviceGestureEventArgs(args.Handled));
+            }
+        }
+    }
+}

--- a/Source/Windows10/Prism.Windows/AppModel/FrameNavigationService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/FrameNavigationService.cs
@@ -91,6 +91,25 @@ namespace Prism.Windows.AppModel
         }
 
         /// <summary>
+        /// Goes to the next page in the navigation stack.
+        /// </summary>
+        public void GoForward()
+        {
+            _frame.GoForward();
+        }
+
+        /// <summary>
+        /// Determines whether the navigation service can navigate to the next page or not.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the navigation service can go forward; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanGoForward()
+        {
+            return _frame.CanGoForward();
+        }
+
+        /// <summary>
         /// Clears the navigation history.
         /// </summary>
         public void ClearHistory()

--- a/Source/Windows10/Prism.Windows/Interfaces/IDeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/Interfaces/IDeviceGestureService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Prism.Windows.AppModel;
+using Windows.Phone.UI.Input;
 
 namespace Prism.Windows.Interfaces
 {
@@ -32,6 +33,21 @@ namespace Prism.Windows.Interfaces
         /// 
         /// </summary>
         event EventHandler<DeviceGestureEventArgs> GoForwardRequested;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        event EventHandler<DeviceGestureEventArgs> CameraButtonHalfPressed;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        event EventHandler<DeviceGestureEventArgs> CameraButtonPressed;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        event EventHandler<DeviceGestureEventArgs> CameraButtonReleased;
 
         /// <summary>
         /// 

--- a/Source/Windows10/Prism.Windows/Interfaces/IDeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/Interfaces/IDeviceGestureService.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Prism.Windows.AppModel;
-using Windows.Phone.UI.Input;
+using Windows.Devices.Input;
 
 namespace Prism.Windows.Interfaces
 {
@@ -18,6 +18,21 @@ namespace Prism.Windows.Interfaces
         /// 
         /// </summary>
         bool IsHardwareCameraButtonPresent { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        bool IsKeyboardPresent { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        bool IsMousePresent { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        bool IsTouchPresent { get; }
 
         /// <summary>
         /// 
@@ -48,6 +63,11 @@ namespace Prism.Windows.Interfaces
         /// 
         /// </summary>
         event EventHandler<DeviceGestureEventArgs> CameraButtonReleased;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        event EventHandler<MouseEventArgs> MouseMoved;
 
         /// <summary>
         /// 

--- a/Source/Windows10/Prism.Windows/Interfaces/IDeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/Interfaces/IDeviceGestureService.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Prism.Windows.AppModel;
+
+namespace Prism.Windows.Interfaces
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IDeviceGestureService
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        bool IsHardwareBackButtonPresent { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        bool IsHardwareCameraButtonPresent { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        bool UseTitleBarBackButton { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        event EventHandler<DeviceGestureEventArgs> GoBackRequested;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        event EventHandler<DeviceGestureEventArgs> GoForwardRequested;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        void InitializeEventHandlers();
+    }
+}

--- a/Source/Windows10/Prism.Windows/Interfaces/IFrameFacade.cs
+++ b/Source/Windows10/Prism.Windows/Interfaces/IFrameFacade.cs
@@ -56,6 +56,19 @@ namespace Prism.Windows.Interfaces
         int BackStackDepth { get; }
 
         /// <summary>
+        /// Goes to the next page in the navigation stack.
+        /// </summary>
+        void GoForward();
+
+        /// <summary>
+        /// Determines whether the navigation service can navigate to the next page or not.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the navigation service can go forward; otherwise, <c>false</c>.
+        /// </returns>
+        bool CanGoForward();
+
+        /// <summary>
         /// Gets a value that indicates whether there is at least one entry in back navigation history.
         /// </summary>
         /// 

--- a/Source/Windows10/Prism.Windows/Interfaces/INavigationService.cs
+++ b/Source/Windows10/Prism.Windows/Interfaces/INavigationService.cs
@@ -29,6 +29,19 @@ namespace Prism.Windows.Interfaces
         bool CanGoBack();
 
         /// <summary>
+        /// Goes to the next page in the navigation stack.
+        /// </summary>
+        void GoForward();
+
+        /// <summary>
+        /// Determines whether the navigation service can navigate to the next page or not.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the navigation service can go forward; otherwise, <c>false</c>.
+        /// </returns>
+        bool CanGoForward();
+
+        /// <summary>
         /// Clears the navigation history.
         /// </summary>
         void ClearHistory();

--- a/Source/Windows10/Prism.Windows/Mvvm/FrameFacadeAdapter.cs
+++ b/Source/Windows10/Prism.Windows/Mvvm/FrameFacadeAdapter.cs
@@ -108,6 +108,25 @@ namespace Prism.Windows.Mvvm
         }
 
         /// <summary>
+        /// Goes to the next page in the navigation stack.
+        /// </summary>
+        public void GoForward()
+        {
+            _frame.GoForward();
+        }
+
+        /// <summary>
+        /// Determines whether the navigation service can navigate to the next page or not.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the navigation service can go forward; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanGoForward()
+        {
+            return _frame.CanGoForward;
+        }
+
+        /// <summary>
         /// Occurs when the content that is being navigated to has been found and is available from the Content property, although it may not have completed loading.
         /// </summary>
         public event EventHandler<MvvmNavigatedEventArgs> Navigated

--- a/Source/Windows10/Prism.Windows/Mvvm/VisualStateAwarePage.cs
+++ b/Source/Windows10/Prism.Windows/Mvvm/VisualStateAwarePage.cs
@@ -53,37 +53,6 @@ namespace Prism.Windows.Mvvm
         {
             //Default Minimal layout width value to 500
             MinimalLayoutWidth = 500;
-
-            if (DesignMode.DesignModeEnabled) return;
-
-            // When this page is part of the visual tree make two changes:
-            // 1) Map application view state to visual state for the page
-            // 2) Handle keyboard and mouse navigation requests
-            this.Loaded += (sender, e) =>
-            {
-                this.StartLayoutUpdates(sender, e);
-
-                // Keyboard and mouse navigation only apply when occupying the entire window
-                if (this.ActualHeight == Window.Current.Bounds.Height &&
-                    this.ActualWidth == Window.Current.Bounds.Width)
-                {
-                    // Listen to the window directly so focus isn't required
-                    Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated +=
-                        CoreDispatcher_AcceleratorKeyActivated;
-                    Window.Current.CoreWindow.PointerPressed +=
-                        this.CoreWindow_PointerPressed;
-                }
-            };
-
-            // Undo the same changes when the page is no longer visible
-            this.Unloaded += (sender, e) =>
-            {
-                this.StopLayoutUpdates(sender, e);
-                Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated -=
-                    CoreDispatcher_AcceleratorKeyActivated;
-                Window.Current.CoreWindow.PointerPressed -=
-                    this.CoreWindow_PointerPressed;
-            };
         }
 
 
@@ -168,77 +137,6 @@ namespace Prism.Windows.Mvvm
         {
             // Use the navigation frame to move to the next page
             if (this.Frame != null && this.Frame.CanGoForward) this.Frame.GoForward();
-        }
-
-        /// <summary>
-        /// Invoked on every keystroke, including system keys such as Alt key combinations, when
-        /// this page is active and occupies the entire window. Used to detect keyboard navigation
-        /// between pages even when the page itself doesn't have focus.
-        /// </summary>
-        /// <param name="sender">Instance that triggered the event.</param>
-        /// <param name="args">Event data describing the conditions that led to the event.</param>
-        private void CoreDispatcher_AcceleratorKeyActivated(CoreDispatcher sender,
-            AcceleratorKeyEventArgs args)
-        {
-            var virtualKey = args.VirtualKey;
-
-            // Only investigate further when Left, Right, or the dedicated Previous or Next keys
-            // are pressed
-            if ((args.EventType == CoreAcceleratorKeyEventType.SystemKeyDown ||
-                args.EventType == CoreAcceleratorKeyEventType.KeyDown) &&
-                (virtualKey == VirtualKey.Left || virtualKey == VirtualKey.Right ||
-                (int)virtualKey == 166 || (int)virtualKey == 167))
-            {
-                var coreWindow = Window.Current.CoreWindow;
-                var downState = CoreVirtualKeyStates.Down;
-                bool menuKey = (coreWindow.GetKeyState(VirtualKey.Menu) & downState) == downState;
-                bool controlKey = (coreWindow.GetKeyState(VirtualKey.Control) & downState) == downState;
-                bool shiftKey = (coreWindow.GetKeyState(VirtualKey.Shift) & downState) == downState;
-                bool noModifiers = !menuKey && !controlKey && !shiftKey;
-                bool onlyAlt = menuKey && !controlKey && !shiftKey;
-
-                if (((int)virtualKey == 166 && noModifiers) ||
-                    (virtualKey == VirtualKey.Left && onlyAlt))
-                {
-                    // When the previous key or Alt+Left are pressed navigate back
-                    args.Handled = true;
-                    this.GoBack(this, new RoutedEventArgs());
-                }
-                else if (((int)virtualKey == 167 && noModifiers) ||
-                    (virtualKey == VirtualKey.Right && onlyAlt))
-                {
-                    // When the next key or Alt+Right are pressed navigate forward
-                    args.Handled = true;
-                    this.GoForward(this, new RoutedEventArgs());
-                }
-            }
-        }
-
-        /// <summary>
-        /// Invoked on every mouse click, touch screen tap, or equivalent interaction when this
-        /// page is active and occupies the entire window. Used to detect browser-style next and
-        /// previous mouse button clicks to navigate between pages.
-        /// </summary>
-        /// <param name="sender">Instance that triggered the event.</param>
-        /// <param name="args">Event data describing the conditions that led to the event.</param>
-        private void CoreWindow_PointerPressed(CoreWindow sender,
-            PointerEventArgs args)
-        {
-            var properties = args.CurrentPoint.Properties;
-
-            // Ignore button chords with the left, right, and middle buttons
-            if (properties.IsLeftButtonPressed || properties.IsRightButtonPressed ||
-                properties.IsMiddleButtonPressed) return;
-
-            // If back or foward are pressed (but not both) navigate appropriately
-            bool backPressed = properties.IsXButton1Pressed;
-            bool forwardPressed = properties.IsXButton2Pressed;
-            if (backPressed ^ forwardPressed)
-            {
-                args.Handled = true;
-                if (backPressed) this.GoBack(this, new RoutedEventArgs());
-                if (forwardPressed) this.GoForward(this, new RoutedEventArgs());
-            }
         }
 
         #endregion

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -110,12 +110,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AppModel\AppManifestHelper.cs" />
+    <Compile Include="AppModel\DeviceGestureService.cs" />
     <Compile Include="AppModel\FrameNavigationService.cs" />
+    <Compile Include="AppModel\DeviceGestureEventArgs.cs" />
     <Compile Include="AppModel\ResourceLoaderAdapter.cs" />
     <Compile Include="AppModel\RestorableStateAttribute.cs" />
     <Compile Include="AppModel\SessionStateService.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Interfaces\IDeviceGestureService.cs" />
     <Compile Include="Interfaces\IFrameFacade.cs" />
     <Compile Include="Interfaces\INavigationAware.cs" />
     <Compile Include="Interfaces\INavigationService.cs" />
@@ -139,8 +142,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=10.0.10158.0">
-      <Name>Windows Desktop Extensions for the UWP</Name>
+    <SDKReference Include="WindowsDesktop, Version=10.0.10069.0">
+      <Name>Microsoft Desktop Extension SDK for Universal App Platform</Name>
     </SDKReference>
     <SDKReference Include="WindowsMobile, Version=10.0.0.1">
       <Name>Microsoft Mobile Extension SDK for Universal App Platform</Name>

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -110,6 +110,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AppModel\AppManifestHelper.cs" />
+    <Compile Include="AppModel\CancelableEventArgs.cs" />
     <Compile Include="AppModel\DeviceGestureService.cs" />
     <Compile Include="AppModel\FrameNavigationService.cs" />
     <Compile Include="AppModel\DeviceGestureEventArgs.cs" />

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -282,7 +282,7 @@ namespace Prism.Windows
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnNavigated(object sender, NavigationEventArgs e)
+        protected virtual void OnNavigated(object sender, NavigationEventArgs e)
         {
             if (DeviceGestureService.UseTitleBarBackButton)
                 SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -206,11 +206,6 @@ namespace Prism.Windows
                     SettingsPane.GetForCurrentView().CommandsRequested += OnCommandsRequested;
 #pragma warning restore CS0618
                 }
-                // Register hardware back button event if present
-                if (ApiInformation.IsEventPresent("Windows.Phone.UI.Input.HardwareButtons", "BackPressed"))
-                {
-                    //HardwareButtons.BackPressed += HardwareButtonsOnBackPressed;
-                }
 
                 DeviceGestureService = CreateDeviceGestureService();
                 DeviceGestureService.InitializeEventHandlers();


### PR DESCRIPTION
First of all sorry to @ElementalNex as he has also created a pull request on this matter.

This is also related to #75 

Please don't get me wrong, I do like the overall idea proposed in #77 and I have also reused a few things from it. I do however see a few things in the navigation flow that I think can be improved. Also when taking Unity into consideration and extensibility in general.

So here's my take on it. As the title suggests I have created a service class that takes care of all the different kinds of device gestures, hence the name DeviceGestureService. Gestures from devices like mouse, keyboard, touch, camera, etc. (not all implemented yet though)

In my opinion it makes sense to have all the gesture events in one class and the idea behind DeviceGestureService is much like the FrameNavigationService class.

I also moved some code from VisualStateAwarePage to DeviceGestureService, because to me that code does not belong there. It makes sense to move it into the new DeviceGestureService class, because they basically do the same thing, which is why all back events are now channeled through one common event.

The new DeviceGestureService class will also fit nicely with Unity when that part comes along, because now the instance can be passed to every class that wants to hook onto the events. And it can easily be extended to do more stuff like camera event og keydown events.

I have used the HelloWorld as a general test and it works really well, also on the simulator, and with support for mouse forward and back and auto hide titlebar button. Its also possible to disable the titlebar button.

Anyways, as said this is just my take on it, but I do think it's the right direction. What do you think?

Note: I had a few issues with version numbers so the .csproj file is also in the commit. Also this is my first ever pull request here on GitHub so be gentle :smiley: