### PR TITLE
PopupWindowAction can receive a Style for it's Window.

### DIFF
--- a/Source/Wpf/Prism.Wpf.Tests/Interactivity/PopupWindowActionFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Interactivity/PopupWindowActionFixture.cs
@@ -135,7 +135,7 @@ namespace Prism.Wpf.Tests.Interactivity
 
             Window window = popupWindowAction.GetWindow(notification);
 
-            Assert.IsNull(window.Style);
+            Assert.AreNotSame(window.Style, style);
         }
     }
 

--- a/Source/Wpf/Prism.Wpf.Tests/Interactivity/PopupWindowActionFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Interactivity/PopupWindowActionFixture.cs
@@ -1,11 +1,10 @@
-
-
-using System.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Interactivity;
 using Prism.Interactivity.DefaultPopupWindows;
 using Prism.Interactivity.InteractionRequest;
 using Prism.Wpf.Tests.Mocks;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace Prism.Wpf.Tests.Interactivity
 {
@@ -105,6 +104,38 @@ namespace Prism.Wpf.Tests.Interactivity
             Assert.IsNotNull(dataContext.Notification);
             Assert.ReferenceEquals(dataContext.Notification, notification);
             Assert.IsNotNull(dataContext.FinishInteraction);
+        }
+
+        [TestMethod]
+        public void WhenStyleForWindowIsSet_WindowShouldHaveTheStyle()
+        {
+            TestablePopupWindowAction popupWindowAction = new TestablePopupWindowAction();
+            Style style = new Style(typeof(Window));
+            popupWindowAction.WindowStyle = style;
+
+            INotification notification = new Notification();
+            notification.Title = "Title";
+            notification.Content = "Content";
+
+            Window window = popupWindowAction.GetWindow(notification);
+
+            Assert.AreSame(window.Style, style);
+        }
+
+        [TestMethod]
+        public void WhenStyleIsNotForWindowIsSet_WindowShouldNotHaveTheStyle()
+        {
+            TestablePopupWindowAction popupWindowAction = new TestablePopupWindowAction();
+            Style style = new Style(typeof(StackPanel));
+            popupWindowAction.WindowStyle = style;
+
+            INotification notification = new Notification();
+            notification.Title = "Title";
+            notification.Content = "Content";
+
+            Window window = popupWindowAction.GetWindow(notification);
+
+            Assert.IsNull(window.Style);
         }
     }
 

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultConfirmationWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultConfirmationWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="Prism.Interactivity.DefaultPopupWindows.DefaultConfirmationWindow"
            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-           MinWidth="300" MinHeight="150"
+           MinWidth="300" MinHeight="150" SizeToContent="WidthAndHeight"
            Title="{Binding Title}" >
 
     <Grid x:Name="LayoutRoot" Margin="5">

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultConfirmationWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultConfirmationWindow.xaml
@@ -1,8 +1,13 @@
 ﻿<Window x:Class="Prism.Interactivity.DefaultPopupWindows.DefaultConfirmationWindow"
            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-           MinWidth="300" MinHeight="150" SizeToContent="WidthAndHeight"
+           MinWidth="300" MinHeight="150"
            Title="{Binding Title}" >
+    <Window.Style>
+        <Style TargetType="{x:Type Window}" >
+            <Setter Property="SizeToContent" Value="WidthAndHeight" />
+        </Style>
+    </Window.Style>
 
     <Grid x:Name="LayoutRoot" Margin="5">
         <Grid.RowDefinitions>

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultNotificationWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultNotificationWindow.xaml
@@ -1,8 +1,13 @@
 ﻿<Window x:Class="Prism.Interactivity.DefaultPopupWindows.DefaultNotificationWindow"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            MinWidth="300" MinHeight="150" SizeToContent="WidthAndHeight"
+            MinWidth="300" MinHeight="150" 
             Title="{Binding Title}" >
+    <Window.Style>
+        <Style TargetType="{x:Type Window}" >
+            <Setter Property="SizeToContent" Value="WidthAndHeight" />
+        </Style>
+    </Window.Style>
 
     <Grid x:Name="LayoutRoot" Margin="5">
         <Grid.RowDefinitions>

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultNotificationWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultNotificationWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="Prism.Interactivity.DefaultPopupWindows.DefaultNotificationWindow"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            MinWidth="300" MinHeight="150" 
+            MinWidth="300" MinHeight="150" SizeToContent="WidthAndHeight"
             Title="{Binding Title}" >
 
     <Grid x:Name="LayoutRoot" Margin="5">

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultWindow.xaml
@@ -1,5 +1,9 @@
 ﻿<Window x:Class="Prism.Interactivity.DefaultPopupWindows.DefaultWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"        
-        SizeToContent="WidthAndHeight" >   
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" >   
+    <Window.Style>
+        <Style TargetType="{x:Type Window}" >
+            <Setter Property="SizeToContent" Value="WidthAndHeight" />
+        </Style>
+    </Window.Style>
 </Window>

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultWindow.xaml
@@ -1,0 +1,5 @@
+﻿<Window x:Class="Prism.Interactivity.DefaultPopupWindows.DefaultWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"        
+        SizeToContent="WidthAndHeight" >   
+</Window>

--- a/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultWindow.xaml.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/DefaultPopupWindows/DefaultWindow.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace Prism.Interactivity.DefaultPopupWindows
+{
+    /// <summary>
+    /// Interaction logic for DefaultWindow.xaml
+    /// </summary>
+    public partial class DefaultWindow : Window
+    {
+        public DefaultWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -45,6 +45,16 @@ namespace Prism.Interactivity
                 new PropertyMetadata(null));
 
         /// <summary>
+        /// If set, applies this Style to the child window.
+        /// </summary>
+        public static readonly DependencyProperty WindowStyleProperty =
+            DependencyProperty.Register(
+                "WindowStyle",
+                typeof(Style),
+                typeof(PopupWindowAction),
+                new PropertyMetadata(null));
+
+        /// <summary>
         /// Gets or sets the content of the window.
         /// </summary>
         public FrameworkElement WindowContent
@@ -72,6 +82,15 @@ namespace Prism.Interactivity
         }
 
         /// <summary>
+        /// Gets or sets the Style of the Window.
+        /// </summary>
+        public Style WindowStyle
+        {
+            get { return (Style)GetValue(WindowStyleProperty); }
+            set { SetValue(WindowStyleProperty, value); }
+        }
+
+        /// <summary>
         /// Displays the child window and collects results for <see cref="IInteractionRequest"/>.
         /// </summary>
         /// <param name="parameter">The parameter to the action. If the action does not require a parameter, the parameter may be set to a null reference.</param>
@@ -90,7 +109,6 @@ namespace Prism.Interactivity
             }
 
             Window wrapperWindow = this.GetWindow(args.Context);
-            wrapperWindow.SizeToContent = SizeToContent.WidthAndHeight;
 
             // We invoke the callback when the interaction's window is closed.
             var callback = args.Callback;
@@ -160,6 +178,12 @@ namespace Prism.Interactivity
                 wrapperWindow = this.CreateDefaultWindow(notification);
             }
 
+            // If the user provided a Style for a Window we set it as the window's style.
+            if (this.WindowStyle != null && this.WindowStyle.TargetType == typeof(Window))
+            {
+                wrapperWindow.Style = this.WindowStyle;
+            }
+
             return wrapperWindow;
         }
 
@@ -195,7 +219,7 @@ namespace Prism.Interactivity
         /// <returns>The Window</returns>
         protected virtual Window CreateWindow()
         {
-            return new Window();
+            return new DefaultWindow();
         }
 
         /// <summary>

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -65,6 +65,9 @@
     <Compile Include="Interactivity\DefaultPopupWindows\DefaultNotificationWindow.xaml.cs">
       <DependentUpon>DefaultNotificationWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Interactivity\DefaultPopupWindows\DefaultWindow.xaml.cs">
+      <DependentUpon>DefaultWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Interactivity\InteractionRequest\Confirmation.cs" />
     <Compile Include="Interactivity\InteractionRequest\IConfirmation.cs" />
     <Compile Include="Interactivity\InteractionRequest\IInteractionRequest.cs" />
@@ -229,6 +232,10 @@
     <Page Include="Interactivity\DefaultPopupWindows\DefaultNotificationWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Interactivity\DefaultPopupWindows\DefaultWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
PopupWindowAction now can receive a `Style` through it's `WindowStyle` property. The `Style` should target a `Window`.
All `Window's` customizations where moved to `xaml`.