### PR TITLE
[UWP] PrismApplication - CreateShell and Cleanup

### DIFF
--- a/Samples/Windows10/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Samples/Windows10/HelloWorld/HelloWorld/App.xaml.cs
@@ -1,12 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.ApplicationSettings;
 using HelloWorld.Services;
 using HelloWorld.ViewModels;
 using HelloWorld.Views;
 using Prism.Mvvm;
 using Prism.Windows;
-using Windows.ApplicationModel.Activation;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 
 namespace HelloWorld
 {
@@ -20,16 +20,6 @@ namespace HelloWorld
         public App() : base()
         {
             InitializeComponent();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="rootFrame"></param>
-        /// <returns></returns>
-        protected override UIElement CreateShell(Frame rootFrame)
-        {
-            return rootFrame;
         }
 
         /// <summary>

--- a/Samples/Windows10/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Samples/Windows10/HelloWorld/HelloWorld/App.xaml.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Windows.ApplicationModel.Activation;
-using Windows.UI.ApplicationSettings;
+﻿using System.Threading.Tasks;
 using HelloWorld.Services;
 using HelloWorld.ViewModels;
 using HelloWorld.Views;
 using Prism.Mvvm;
 using Prism.Windows;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace HelloWorld
 {
@@ -20,6 +20,16 @@ namespace HelloWorld
         public App() : base()
         {
             InitializeComponent();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="rootFrame"></param>
+        /// <returns></returns>
+        protected override UIElement CreateShell(Frame rootFrame)
+        {
+            return rootFrame;
         }
 
         /// <summary>

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -309,7 +309,10 @@ namespace Prism.Windows
         /// </summary>
         /// <param name="rootFrame"></param>
         /// <returns>The shell of the app.</returns>
-        protected abstract UIElement CreateShell(Frame rootFrame);
+        protected virtual UIElement CreateShell(Frame rootFrame)
+        {
+            return rootFrame;
+        }
 
         /// <summary>
         /// Invoked when application execution is being suspended. Application state is saved

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -154,7 +154,6 @@ namespace Prism.Windows
                 else
                     Window.Current.Content = rootFrame;
             }
-            //var rootFrame = await InitializeFrameAsync(args);
 
             // If the app is launched via the app's primary tile, the args.TileId property
             // will have the same value as the AppUserModelId, which is set in the Package.appxmanifest.

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -189,12 +189,6 @@ namespace Prism.Windows
 
                 NavigationService = CreateNavigationService(frameFacade, SessionStateService);
 
-                // Register hardware back button event if present
-                if (ApiInformation.IsEventPresent("Windows.Phone.UI.Input.HardwareButtons", "BackPressed"))
-                {
-                    HardwareButtons.BackPressed += HardwareButtonsOnBackPressed;
-                }
-
                 DeviceGestureService = CreateDeviceGestureService();
                 DeviceGestureService.InitializeEventHandlers();
                 DeviceGestureService.GoBackRequested += OnGoBackRequested;
@@ -327,21 +321,6 @@ namespace Prism.Windows
             {
                 IsSuspending = false;
             }
-        }
-
-        /// <summary>
-        /// Handle hardware back button by navigating back if possible using the NavigationService
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void HardwareButtonsOnBackPressed(object sender, BackPressedEventArgs e)
-        {
-            if (NavigationService.CanGoBack())
-            {
-                NavigationService.GoBack();
-                e.Handled = true;
-            }
-            else Exit();
         }
     }
 }


### PR DESCRIPTION
Removed old HardwareButton code as this is part of DeviceGestureService now.

The problem with PrismApplication.OnLaunched is that it always assumes that the Window.Current.Content is a Frame. This is not the case when for example implementing the SplitView navigation pattern. When using the SplitView navigation pattern the Window.Current.Content will be a Page with a SplitView and SplitView.Content = rootFrame.

The CreateShell method is similar to the WPF version and adds support for other root elements, for example a Page. In the CreateShell method you are then in full control of the rootFrame and where it should be placed.

I'm not sure what's best though: abstract or virtual. CreateShell has the rootFrame as param which can then be returned as shown in the HelloWorld sample.

Question: In which scenario is OnLaunched called more than once?