### PR TITLE
Add CLSCompliance to Prism and Prism.WPF assemblies

### DIFF
--- a/Source/Prism/Commands/DelegateCommandBase.cs
+++ b/Source/Prism/Commands/DelegateCommandBase.cs
@@ -20,7 +20,9 @@ namespace Prism.Commands
         readonly HashSet<string> _propertiesToObserve = new HashSet<string>();
         private INotifyPropertyChanged _inpc;
 
+        [CLSCompliant(false)] // Non-private identifier beginning with underscore breaks compliance.
         protected readonly Func<object, Task> _executeMethod;
+        [CLSCompliant(false)] // Non-private identifier beginning with underscore breaks compliance.
         protected Func<object, bool> _canExecuteMethod;
 
         /// <summary>

--- a/Source/Prism/Properties/AssemblyInfo.cs
+++ b/Source/Prism/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Resources;
+﻿using System;
+using System.Resources;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -15,6 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
+[assembly: CLSCompliant(true)]
 
 [assembly: AssemblyVersion("6.1")]
 [assembly: AssemblyFileVersion("6.1.0")]

--- a/Source/Wpf/Prism.Autofac.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -13,6 +14,7 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Source/Wpf/Prism.Mef.Wpf/Modularity/ModuleExportAttribute.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Modularity/ModuleExportAttribute.cs
@@ -63,6 +63,7 @@ namespace Prism.Mef.Modularity
         /// <summary>
         /// Gets or sets the contract names of modules this module depends upon.
         /// </summary>
+        [CLSCompliant(false)] // Arrays as attribute arguments is not CLS-compliant.
         [DefaultValue(new string[0])]
         public string[] DependsOnModuleNames { get; set; }
 

--- a/Source/Wpf/Prism.Mef.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -15,6 +16,7 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Source/Wpf/Prism.Ninject.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -13,6 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Source/Wpf/Prism.StructureMap.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.StructureMap.Wpf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -13,6 +14,7 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Source/Wpf/Prism.Unity.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -15,6 +16,7 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Source/Wpf/Prism.Unity.Wpf/UnityBootstrapper.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityBootstrapper.cs
@@ -31,7 +31,6 @@ namespace Prism.Unity
         /// Gets the default <see cref="IUnityContainer"/> for the application.
         /// </summary>
         /// <value>The default <see cref="IUnityContainer"/> instance.</value>
-        [CLSCompliant(false)]
         public IUnityContainer Container { get; protected set; }
 
 
@@ -187,7 +186,6 @@ namespace Prism.Unity
         /// Creates the <see cref="IUnityContainer"/> that will be used as the default container.
         /// </summary>
         /// <returns>A new instance of <see cref="IUnityContainer"/>.</returns>
-        [CLSCompliant(false)]
         protected virtual IUnityContainer CreateContainer()
         {
             return new UnityContainer();

--- a/Source/Wpf/Prism.Unity.Wpf/UnityBootstrapperExtension.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityBootstrapperExtension.cs
@@ -9,7 +9,6 @@ namespace Prism.Unity
     /// <summary>
     /// Implements a <see cref="UnityContainerExtension"/> that checks if a specific type was registered with the container.
     /// </summary>
-    [CLSCompliant(false)]
     public class UnityBootstrapperExtension : UnityContainerExtension
     {
         /// <summary>

--- a/Source/Wpf/Prism.Unity.Wpf/UnityContainerHelper.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityContainerHelper.cs
@@ -8,7 +8,6 @@ namespace Prism.Unity
     /// <summary>
     /// Extensions methods to extend and facilitate the usage of <see cref="IUnityContainer"/>.
     /// </summary>
-    [CLSCompliant(false)]
     public static class UnityContainerHelper
     {
         /// <summary>

--- a/Source/Wpf/Prism.Unity.Wpf/UnityServiceLocatorAdapter.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityServiceLocatorAdapter.cs
@@ -19,7 +19,6 @@ namespace Prism.Unity
         /// </summary>
         /// <param name="unityContainer">The <see cref="IUnityContainer"/> that will be used
         /// by the <see cref="DoGetInstance"/> and <see cref="DoGetAllInstances"/> methods.</param>
-        [CLSCompliant(false)]
         public UnityServiceLocatorAdapter(IUnityContainer unityContainer)
         {
             _unityContainer = unityContainer;


### PR DESCRIPTION
Mark the core and WPF assemblies as CLS Compliant.

There are only a few things in the assemblies that aren't CLSCompliant, so I've marked the exceptions.

This should make using Prism from a solution that is marked as CLSCompliant less painful - and has no impact on other with non compliant (or not explicitly stated compliance).
