### PR TITLE
Inject current page in pageDialogService

### DIFF
--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -6,15 +6,8 @@ using Xamarin.Forms;
 
 namespace Prism.Services
 {
-    public class PageDialogService : IPageDialogService, IPageAware
+    public class PageDialogService : IPageDialogService
     {
-        Page _page;
-        Page IPageAware.Page
-        {
-            get { return _page ?? (_page = Application.Current.MainPage); }
-            set { _page = value; }
-        }
-
         /// <summary>
         /// Presents an alert dialog to the application user with an accept and a cancel button.
         /// </summary>
@@ -28,7 +21,7 @@ namespace Prism.Services
         /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
         public virtual async Task<bool> DisplayAlert(string title, string message, string acceptButton, string cancelButton)
         {
-            return await _page.DisplayAlert(title, message, acceptButton, cancelButton);
+            return await Application.Current.MainPage.DisplayAlert(title, message, acceptButton, cancelButton);
         }
 
         /// <summary>
@@ -43,7 +36,7 @@ namespace Prism.Services
         /// <returns></returns>
         public virtual async Task DisplayAlert(string title, string message, string cancelButton)
         {
-            await _page.DisplayAlert(title, message, cancelButton);
+            await Application.Current.MainPage.DisplayAlert(title, message, cancelButton);
         }
 
         /// <summary>
@@ -56,7 +49,7 @@ namespace Prism.Services
         /// <returns>Text for the pressed button</returns>
         public virtual async Task<string> DisplayActionSheet(string title, string cancelButton, string destroyButton, params string[] otherButtons)
         {
-            return await _page.DisplayActionSheet(title, cancelButton, destroyButton, otherButtons);
+            return await Application.Current.MainPage.DisplayActionSheet(title, cancelButton, destroyButton, otherButtons);
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Unity.Forms/UnityBootstrapper.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityBootstrapper.cs
@@ -42,13 +42,9 @@ namespace Prism.Unity
                     var navService = new PageNavigationService();
                     ((IPageAware)navService).Page = page;
 
-                    var pageDialogService = new PageDialogService();
-                    ((IPageAware)pageDialogService).Page = page;
-
                     overrides = new ParameterOverrides
                     {
-                        { "navigationService", navService },
-                        { "pageDialogService", pageDialogService }
+                        { "navigationService", navService }
                     };
                 }
 

--- a/Source/Xamarin/Prism.Unity.Forms/UnityBootstrapper.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityBootstrapper.cs
@@ -42,9 +42,13 @@ namespace Prism.Unity
                     var navService = new PageNavigationService();
                     ((IPageAware)navService).Page = page;
 
+                    var pageDialogService = new PageDialogService();
+                    ((IPageAware)pageDialogService).Page = page;
+
                     overrides = new ParameterOverrides
                     {
-                        { "navigationService", navService }
+                        { "navigationService", navService },
+                        { "pageDialogService", pageDialogService }
                     };
                 }
 


### PR DESCRIPTION
For the PageDialogService to work properly it needs to know the current page. This fix expands on the current solution for the NavigationService to the PageDialogService.

fixes #254