### PR TITLE
Refactored title bar back button handling so it's always accurate

### DIFF
--- a/Source/Windows10/Prism.Autofac.Windows/PrismAutofacApplication.cs
+++ b/Source/Windows10/Prism.Autofac.Windows/PrismAutofacApplication.cs
@@ -101,8 +101,17 @@ namespace Prism.Autofac.Windows
         protected override IDeviceGestureService OnCreateDeviceGestureService()
         {
             var svc = Container.Resolve<IDeviceGestureService>();
-            svc.UseTitleBarBackButton = true;
+            svc.EnableTitleBarBackButton(Container.Resolve<IEventAggregator>());
             return svc;
+        }
+
+        /// <summary>
+        /// Creates the IEventAggregator through the container
+        /// </summary>
+        /// <returns>IEventAggregator</returns>
+        protected override IEventAggregator OnCreateEventAggregator()
+        {
+            return Container.Resolve<IEventAggregator>();
         }
 
         /// <summary>

--- a/Source/Windows10/Prism.Unity.Windows/PrismUnityApplication.cs
+++ b/Source/Windows10/Prism.Unity.Windows/PrismUnityApplication.cs
@@ -140,8 +140,17 @@ namespace Prism.Unity.Windows
         protected override IDeviceGestureService OnCreateDeviceGestureService()
         {
             var svc = Container.Resolve<IDeviceGestureService>();
-            svc.UseTitleBarBackButton = true;
+            svc.EnableTitleBarBackButton(Container.Resolve<IEventAggregator>());
             return svc;
+        }
+
+        /// <summary>
+        /// Creates the IEventAggregator as a singleton through the container
+        /// </summary>
+        /// <returns>IEventAggregator instance</returns>
+        protected override IEventAggregator OnCreateEventAggregator()
+        {
+            return Container.Resolve<IEventAggregator>();
         }
 
         /// <summary>

--- a/Source/Windows10/Prism.Windows.Tests/DeviceGestureServiceFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/DeviceGestureServiceFixture.cs
@@ -26,7 +26,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -51,7 +51,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -127,7 +127,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -165,7 +165,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -199,7 +199,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -237,7 +237,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -271,7 +271,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -303,7 +303,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -327,7 +327,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -359,7 +359,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
@@ -391,7 +391,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
                 var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 

--- a/Source/Windows10/Prism.Windows.Tests/DeviceGestureServiceFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/DeviceGestureServiceFixture.cs
@@ -1,0 +1,417 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Prism.Events;
+using Prism.Windows.AppModel;
+using Prism.Windows.Navigation;
+using Prism.Windows.Tests.Mocks;
+using Prism.Windows.Tests.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Controls;
+
+namespace Prism.Windows.Tests
+{
+    [TestClass]
+    public class DeviceGestureServiceFixture
+    {
+        [TestMethod]
+        public async Task Navigate_To_First_Page_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+
+        [TestMethod]
+        public async Task Navigate_To_Subsequent_Page_Back_Button_Visible()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Navigate_To_Page_With_Null_Aggregator_Still_Works()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var frame = new FrameFacadeAdapter(new Frame());
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                bool result = navigationService.Navigate("Mock", 1);
+
+                Assert.IsTrue(result);
+            });
+        }
+
+        [TestMethod]
+        public async Task Navigate_To_Page_With_UseTitleBarBackButton_False_Does_Not_Change_Back_Button_Visibility()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame());
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = false };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                // If it's collapsed and we navigate, it stays collapsed
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+                navigationService.Navigate("Mock", 1);
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                // If it's visible and our back stack is emptied, it stays visible
+                navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
+                navigationService.ClearHistory();
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Navigate_Backwards_Can_Go_Back_Back_Button_Visible()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 3);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                Assert.IsTrue(navigationService.CanGoBack());
+
+                navigationService.GoBack();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Navigate_Backwards_Can_Not_Go_Back_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                Assert.IsTrue(navigationService.CanGoBack());
+
+                navigationService.GoBack();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Navigate_Forwards_Can_Go_Back_Back_Button_Visible()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                Assert.IsTrue(navigationService.CanGoBack());
+
+                navigationService.GoBack();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.GoForward();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Clear_History_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                Assert.IsTrue(navigationService.CanGoBack());
+
+                navigationService.ClearHistory();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Set_State_Empty_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                frame.SetNavigationState("1,0");
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Restore_State_Back_Button_Visible()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                frame.SetNavigationState("1,2,1,34,Prism.Windows.Tests.Mocks.MockPage,4,1,1,0,34,Prism.Windows.Tests.Mocks.MockPage,4,1,2,0");
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Remove_First_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.RemoveFirstPage();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Remove_Last_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.RemoveLastPage();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+
+        [TestMethod]
+        public async Task Remove_All_Back_Button_Collapsed()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var eventAggregator = new EventAggregator();
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+
+                // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Collapsed;
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 1);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.Navigate("Mock", 2);
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Visible, navigationManager.AppViewBackButtonVisibility);
+
+                navigationService.RemoveAllPages();
+
+                Assert.AreEqual(AppViewBackButtonVisibility.Collapsed, navigationManager.AppViewBackButtonVisibility);
+            });
+        }
+    }
+}

--- a/Source/Windows10/Prism.Windows.Tests/DeviceGestureServiceFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/DeviceGestureServiceFixture.cs
@@ -27,7 +27,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -52,7 +53,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -100,7 +102,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = false };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -128,7 +131,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -166,7 +170,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -200,7 +205,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -238,7 +244,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -272,7 +279,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -304,7 +312,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -328,7 +337,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -360,7 +370,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready
@@ -392,7 +403,8 @@ namespace Prism.Windows.Tests
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
                 var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
-                var deviceGestureService = new DeviceGestureService(eventAggregator) { UseTitleBarBackButton = true };
+                var deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(eventAggregator);
                 var navigationManager = SystemNavigationManager.GetForCurrentView();
 
                 // Reset back button visibility before running, can't do this in TestInitialize because CoreWindow sometimes isn't ready

--- a/Source/Windows10/Prism.Windows.Tests/FrameFacadeAdapterFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/FrameFacadeAdapterFixture.cs
@@ -28,7 +28,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
 
                 navigationService.Navigate("Mock", 1);
             });
@@ -64,7 +64,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
 
                 navigationService.Navigate("Mock", 1);
                 navigationService.Navigate("Mock", 2);
@@ -104,7 +104,7 @@ namespace Prism.Windows.Tests
                 var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
                 var sessionStateService = new MockSessionStateService();
                 sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
-                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService);
 
                 navigationService.Navigate("Mock", 1);
                 navigationService.Navigate("Mock", 2);

--- a/Source/Windows10/Prism.Windows.Tests/FrameFacadeAdapterFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/FrameFacadeAdapterFixture.cs
@@ -1,0 +1,155 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Prism.Events;
+using Prism.Windows.Navigation;
+using Prism.Windows.Tests.Mocks;
+using Prism.Windows.Tests.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Prism.Windows.Tests
+{
+    [TestClass]
+    public class FrameFacadeAdapterFixture
+    {
+        [TestMethod]
+        public async Task Navigate_Raises_NavigationStateChangedEvent()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var eventAggregator = new EventAggregator();
+
+            eventAggregator.GetEvent<NavigationStateChangedEvent>().Subscribe((args) => tcs.SetResult(args.StateChange == StateChangeType.Forward));
+
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+
+                navigationService.Navigate("Mock", 1);
+            });
+
+            await Task.WhenAny(tcs.Task, Task.Delay(200));
+
+            if (tcs.Task.IsCompleted)
+            {
+                Assert.IsTrue(tcs.Task.Result);
+            }
+            else
+            {
+                Assert.Fail("NavigationStateChangedEvent event wasn't raised within 200 ms.");
+            }
+        }
+
+        [TestMethod]
+        public async Task GoBack_Raises_NavigationStateChangedEvent()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var eventAggregator = new EventAggregator();
+
+            eventAggregator.GetEvent<NavigationStateChangedEvent>().Subscribe((args) =>
+            {
+                if (args.StateChange == StateChangeType.Back)
+                {
+                    tcs.SetResult(true);
+                }
+            });
+
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+
+                navigationService.Navigate("Mock", 1);
+                navigationService.Navigate("Mock", 2);
+
+                navigationService.GoBack();
+            });
+
+            await Task.WhenAny(tcs.Task, Task.Delay(200));
+
+            if (tcs.Task.IsCompleted)
+            {
+                Assert.IsTrue(tcs.Task.Result);
+            }
+            else
+            {
+                Assert.Fail("NavigationStateChangedEvent event wasn't raised within 200 ms.");
+            }
+        }
+
+        [TestMethod]
+        public async Task GoForward_Raises_NavigationStateChangedEvent()
+        {
+            int hitCount = 0;
+            var tcs = new TaskCompletionSource<bool>();
+            var eventAggregator = new EventAggregator();
+
+            eventAggregator.GetEvent<NavigationStateChangedEvent>().Subscribe((args) =>
+            {
+                if (hitCount++ > 2 && args.StateChange == StateChangeType.Forward)
+                {
+                    tcs.SetResult(true);
+                }
+            });
+
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, (pageToken) => typeof(MockPage), sessionStateService, eventAggregator);
+
+                navigationService.Navigate("Mock", 1);
+                navigationService.Navigate("Mock", 2);
+                navigationService.GoBack();
+
+                navigationService.GoForward();
+            });
+
+            await Task.WhenAny(tcs.Task, Task.Delay(200));
+
+            if (tcs.Task.IsCompleted)
+            {
+                Assert.IsTrue(tcs.Task.Result);
+            }
+            else
+            {
+                Assert.Fail("NavigationStateChangedEvent event wasn't raised within 200 ms.");
+            }
+        }
+
+        [TestMethod]
+        public async Task Set_State_Raises_NavigationStateChangedEvent()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var eventAggregator = new EventAggregator();
+
+            eventAggregator.GetEvent<NavigationStateChangedEvent>().Subscribe((args) => tcs.SetResult(true));
+
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var frame = new FrameFacadeAdapter(new Frame(), eventAggregator);
+
+                frame.SetNavigationState("1,0");
+            });
+
+            await Task.WhenAny(tcs.Task, Task.Delay(200));
+
+            if (tcs.Task.IsCompleted)
+            {
+                Assert.IsTrue(tcs.Task.Result);
+            }
+            else
+            {
+                Assert.Fail("NavigationStateChangedEvent event wasn't raised within 200 ms.");
+            }
+        }
+    }
+}

--- a/Source/Windows10/Prism.Windows.Tests/FrameNavigationServiceFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/FrameNavigationServiceFixture.cs
@@ -12,21 +12,17 @@ using Prism.Windows.Mvvm;
 using Prism.Windows.Tests.Mocks;
 using Prism.Windows.AppModel;
 using Prism.Windows.Navigation;
+using Prism.Windows.Tests.Utilities;
 
 namespace Prism.Windows.Tests
 {
     [TestClass]
     public class FrameNavigationServiceFixture
     {
-        public IAsyncAction ExecuteOnUIThread(DispatchedHandler action)
-        {
-            return CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);
-        }
-
         [TestMethod]
         public async Task Navigate_To_Valid_Page()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -45,7 +41,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task Navigate_To_Invalid_Page()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -63,7 +59,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task NavigateToCurrentViewModel_Calls_VieModel_OnNavigatedTo()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
 
@@ -97,7 +93,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task NavigateFromCurrentViewModel_Calls_VieModel_OnNavigatedFrom()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
 
@@ -132,7 +128,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task Suspending_Calls_VieModel_OnNavigatedFrom()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -157,7 +153,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task Resuming_Calls_ViewModel_OnNavigatedTo()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -182,7 +178,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task GoBack_When_CanGoBack()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -212,7 +208,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task ViewModelOnNavigatedFromCalled_WithItsOwnStateDictionary()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -237,7 +233,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task RestoreSavedNavigation_ClearsOldForwardNavigation()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();
@@ -267,7 +263,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task PageTokenThatCannotBeResolved_ThrowsMeaningfulException()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var frame = new FrameFacadeAdapter(new Frame());
                 var sessionStateService = new MockSessionStateService();

--- a/Source/Windows10/Prism.Windows.Tests/Prism.Windows.Tests.csproj
+++ b/Source/Windows10/Prism.Windows.Tests/Prism.Windows.Tests.csproj
@@ -123,6 +123,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BindableValidatorFixture.cs" />
+    <Compile Include="DeviceGestureServiceFixture.cs" />
+    <Compile Include="FrameFacadeAdapterFixture.cs" />
     <Compile Include="Mocks\MockModelWithValidation.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
@@ -149,6 +151,7 @@
     <Compile Include="Mocks\MockViewModelWithRestorableStateAttributes.cs" />
     <Compile Include="Mocks\MockViewModelWithRestorableStateCollection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\DispatcherHelper.cs" />
     <Compile Include="ViewModelBaseFixture.cs" />
     <Compile Include="ViewModelLocatorFixture.cs" />
   </ItemGroup>
@@ -194,7 +197,7 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
-<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-Signed|ARM'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-Signed|ARM'">
     <OutputPath>bin\ARM\Release-Signed\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
     <Optimize>true</Optimize>

--- a/Source/Windows10/Prism.Windows.Tests/Utilities/DispatcherHelper.cs
+++ b/Source/Windows10/Prism.Windows.Tests/Utilities/DispatcherHelper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.Foundation;
+using Windows.UI.Core;
+
+namespace Prism.Windows.Tests.Utilities
+{
+    public static class DispatcherHelper
+    {
+        public static IAsyncAction ExecuteOnUIThread(DispatchedHandler action)
+        {
+            return CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);
+        }
+    }
+}

--- a/Source/Windows10/Prism.Windows.Tests/Utilities/DispatcherHelper.cs
+++ b/Source/Windows10/Prism.Windows.Tests/Utilities/DispatcherHelper.cs
@@ -11,6 +11,11 @@ namespace Prism.Windows.Tests.Utilities
 {
     public static class DispatcherHelper
     {
+        /// <summary>
+        /// Executes the given action on the UI thread via CoreDispatcher.
+        /// </summary>
+        /// <param name="action">The action that needs to execute on the UI thread.</param>
+        /// <returns></returns>
         public static IAsyncAction ExecuteOnUIThread(DispatchedHandler action)
         {
             return CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);

--- a/Source/Windows10/Prism.Windows.Tests/ViewModelLocatorFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/ViewModelLocatorFixture.cs
@@ -7,21 +7,17 @@ using Windows.Foundation;
 using Windows.UI.Core;
 using Prism.Mvvm;
 using Prism.Windows.Mvvm;
+using Prism.Windows.Tests.Utilities;
 
 namespace Prism.Windows.Tests
 {
     [TestClass]
     public class ViewModelLocatorFixture
     {
-        public IAsyncAction ExecuteOnUIThread(DispatchedHandler action)
-        {
-            return CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);
-        }
-
         [TestMethod]
         public async Task AutoWireViewModel_With_Factory_Registration()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var page = new MockPage();
 
@@ -39,7 +35,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task AutoWireViewModel_With_Custom_Resolver()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var page = new MockPage();
 
@@ -64,7 +60,7 @@ namespace Prism.Windows.Tests
         [TestMethod]
         public async Task AutoWireViewModel_With_Custom_Resolver_And_Factory()
         {
-            await ExecuteOnUIThread(() =>
+            await DispatcherHelper.ExecuteOnUIThread(() =>
             {
                 var page = new MockPage();
 

--- a/Source/Windows10/Prism.Windows/AppModel/IDeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/IDeviceGestureService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Prism.Events;
+using System;
 using Windows.Devices.Input;
 
 namespace Prism.Windows.AppModel
@@ -34,9 +35,15 @@ namespace Prism.Windows.AppModel
         bool IsTouchPresent { get; }
 
         /// <summary>
-        /// Determines if title bar back button is shown
+        /// Enables automatic handling of the title bar back button.
         /// </summary>
-        bool UseTitleBarBackButton { get; set; }
+        /// <param name="eventAggregator">The event aggregator that is publishing the Prism framework's NavigationStateChangedEvents</param>
+        void EnableTitleBarBackButton(IEventAggregator eventAggregator);
+
+        /// <summary>
+        /// Disables automatic handling of the window chrome back buton.
+        /// </summary>
+        void DisableTitleBarBackButton();
 
         /// <summary>
         /// Raised when a navigation go back event occurs

--- a/Source/Windows10/Prism.Windows/Navigation/FrameFacadeAdapter.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/FrameFacadeAdapter.cs
@@ -1,6 +1,7 @@
 using Prism.Events;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -117,7 +118,7 @@ namespace Prism.Windows.Navigation
             get { return _frame.BackStackDepth; }
         }
 
-        public IList<PageStackEntry> BackStack => _frame.BackStack;
+        public IReadOnlyList<PageStackEntry> BackStack => _frame.BackStack.ToList();
 
         /// <summary>
         /// Gets a value that indicates whether there is at least one entry in back navigation history.
@@ -152,6 +153,35 @@ namespace Prism.Windows.Navigation
         public bool CanGoForward()
         {
             return _frame.CanGoForward;
+        }
+
+        /// <summary>
+        /// Remove a <see cref="PageStackEntry"/> from the Frame's back stack.
+        /// </summary>
+        /// <param name="entry">The <see cref="PageStackEntry"/> to remove.</param>
+        /// <returns>True if item was successfully removed from the back stack; otherwise, false. This method also returns false if item is not found in the back stack.</returns>
+        public bool RemoveBackStackEntry(PageStackEntry entry)
+        {
+            var success = _frame.BackStack.Remove(entry);
+            if (success && _navigationStateChangedEvent != null)
+            {
+                _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(this, StateChangeType.Remove));
+            }
+            
+            return success;
+        }
+
+        /// <summary>
+        /// Clears the Frame's back stack.
+        /// </summary>
+        /// <returns></returns>
+        public void ClearBackStack()
+        {
+            _frame.BackStack.Clear();
+            if(_navigationStateChangedEvent != null)
+            {
+                _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(this, StateChangeType.Clear));
+            }
         }
 
         /// <summary>

--- a/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
@@ -1,3 +1,4 @@
+using Prism.Events;
 using Prism.Windows.AppModel;
 using System;
 using System.Collections.Generic;
@@ -19,6 +20,7 @@ namespace Prism.Windows.Navigation
         private const string LastNavigationPageKey = "LastNavigationPageKey";
         private readonly IFrameFacade _frame;
         private readonly Func<string, Type> _navigationResolver;
+        private NavigationStateChangedEvent _navigationStateChangedEvent;
         private readonly ISessionStateService _sessionStateService;
 
         /// <summary>
@@ -27,11 +29,16 @@ namespace Prism.Windows.Navigation
         /// <param name="frame">The frame.</param>
         /// <param name="navigationResolver">The navigation resolver.</param>
         /// <param name="sessionStateService">The session state service.</param>
-        public FrameNavigationService(IFrameFacade frame, Func<string, Type> navigationResolver, ISessionStateService sessionStateService)
+        /// <param name="eventAggregator">The event aggregator to be used for publishing NavigationStateChangedEvents. Can be null if events aren't needed.</param>
+        public FrameNavigationService(IFrameFacade frame, Func<string, Type> navigationResolver, ISessionStateService sessionStateService, IEventAggregator eventAggregator = null)
         {
             _frame = frame;
             _navigationResolver = navigationResolver;
             _sessionStateService = sessionStateService;
+            if (eventAggregator != null)
+            {
+                _navigationStateChangedEvent = eventAggregator.GetEvent<NavigationStateChangedEvent>();
+            }
 
             if (frame != null)
             {
@@ -140,6 +147,10 @@ namespace Prism.Windows.Navigation
             if (page != null)
             {
                 _frame.BackStack.Remove(page);
+                if (_navigationStateChangedEvent != null)
+                {
+                    _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(_frame, StateChangeType.Remove));
+                }
             }
         }
 
@@ -166,6 +177,10 @@ namespace Prism.Windows.Navigation
             if (page != null)
             {
                 _frame.BackStack.Remove(page);
+                if (_navigationStateChangedEvent != null)
+                {
+                    _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(_frame, StateChangeType.Remove));
+                }
             }
         }
 
@@ -192,6 +207,11 @@ namespace Prism.Windows.Navigation
             else
             {
                 _frame.BackStack.Clear();
+            }
+
+            if (_navigationStateChangedEvent != null)
+            {
+                _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(_frame, StateChangeType.Clear));
             }
         }
 

--- a/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
@@ -20,7 +20,6 @@ namespace Prism.Windows.Navigation
         private const string LastNavigationPageKey = "LastNavigationPageKey";
         private readonly IFrameFacade _frame;
         private readonly Func<string, Type> _navigationResolver;
-        private NavigationStateChangedEvent _navigationStateChangedEvent;
         private readonly ISessionStateService _sessionStateService;
 
         /// <summary>
@@ -29,16 +28,11 @@ namespace Prism.Windows.Navigation
         /// <param name="frame">The frame.</param>
         /// <param name="navigationResolver">The navigation resolver.</param>
         /// <param name="sessionStateService">The session state service.</param>
-        /// <param name="eventAggregator">The event aggregator to be used for publishing NavigationStateChangedEvents. Can be null if events aren't needed.</param>
-        public FrameNavigationService(IFrameFacade frame, Func<string, Type> navigationResolver, ISessionStateService sessionStateService, IEventAggregator eventAggregator = null)
+        public FrameNavigationService(IFrameFacade frame, Func<string, Type> navigationResolver, ISessionStateService sessionStateService)
         {
             _frame = frame;
             _navigationResolver = navigationResolver;
             _sessionStateService = sessionStateService;
-            if (eventAggregator != null)
-            {
-                _navigationStateChangedEvent = eventAggregator.GetEvent<NavigationStateChangedEvent>();
-            }
 
             if (frame != null)
             {
@@ -146,11 +140,7 @@ namespace Prism.Windows.Navigation
 
             if (page != null)
             {
-                _frame.BackStack.Remove(page);
-                if (_navigationStateChangedEvent != null)
-                {
-                    _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(_frame, StateChangeType.Remove));
-                }
+                _frame.RemoveBackStackEntry(page);
             }
         }
 
@@ -176,11 +166,7 @@ namespace Prism.Windows.Navigation
 
             if (page != null)
             {
-                _frame.BackStack.Remove(page);
-                if (_navigationStateChangedEvent != null)
-                {
-                    _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(_frame, StateChangeType.Remove));
-                }
+                _frame.RemoveBackStackEntry(page);
             }
         }
 
@@ -201,17 +187,12 @@ namespace Prism.Windows.Navigation
 
                 foreach (var page in pages)
                 {
-                    _frame.BackStack.Remove(page);
+                    _frame.RemoveBackStackEntry(page);
                 }
             }
             else
             {
-                _frame.BackStack.Clear();
-            }
-
-            if (_navigationStateChangedEvent != null)
-            {
-                _navigationStateChangedEvent.Publish(new NavigationStateChangedEventArgs(_frame, StateChangeType.Clear));
+                _frame.ClearBackStack();
             }
         }
 

--- a/Source/Windows10/Prism.Windows/Navigation/IFrameFacade.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/IFrameFacade.cs
@@ -57,7 +57,8 @@ namespace Prism.Windows.Navigation
         /// </returns>
         int BackStackDepth { get; }
 
-        IList<PageStackEntry> BackStack { get; }
+        IReadOnlyList<PageStackEntry> BackStack { get; }
+
         /// <summary>
         /// Goes to the next page in the navigation stack.
         /// </summary>
@@ -79,6 +80,18 @@ namespace Prism.Windows.Navigation
         /// True if there is at least one entry in back navigation history; false if there are no entries in back navigation history or the Frame does not own its own navigation history.
         /// </returns>
         bool CanGoBack { get; }
+
+        /// <summary>
+        /// Remove a <see cref="PageStackEntry"/> from the Frame's back stack.
+        /// </summary>
+        /// <param name="entry">The <see cref="PageStackEntry"/> to remove.</param>
+        /// <returns>True if item was successfully removed from the back stack; otherwise, false. This method also returns false if item is not found in the back stack.</returns>
+        bool RemoveBackStackEntry(PageStackEntry entry);
+
+        /// <summary>
+        /// Clears the Frame's back stack.
+        /// </summary>
+        void ClearBackStack();
 
         /// <summary>
         /// Occurs when the content that is being navigated to has been found and is available from the Content property, although it may not have completed loading.

--- a/Source/Windows10/Prism.Windows/Navigation/NavigationStateChangedEvent.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/NavigationStateChangedEvent.cs
@@ -1,0 +1,13 @@
+﻿using Prism.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Prism.Windows.Navigation
+{
+    public class NavigationStateChangedEvent : PubSubEvent<NavigationStateChangedEventArgs>
+    {
+    }
+}

--- a/Source/Windows10/Prism.Windows/Navigation/NavigationStateChangedEventArgs.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/NavigationStateChangedEventArgs.cs
@@ -15,12 +15,20 @@ namespace Prism.Windows.Navigation
     {
         private WeakReference<IFrameFacade> _frameFacadeWeakRef;
 
+        /// <summary>
+        /// Creates a new NavigationStateChangedEventArgs instance given the frame the event pertains to and the change that occurred.
+        /// </summary>
+        /// <param name="frameFacade">The frame that is raising the event.</param>
+        /// <param name="stateChange">The type of state change that occurred.</param>
         public NavigationStateChangedEventArgs(IFrameFacade frameFacade, StateChangeType stateChange)
         {
             _frameFacadeWeakRef = new WeakReference<IFrameFacade>(frameFacade);
             StateChange = stateChange;
         }
 
+        /// <summary>
+        /// The Frame that raised the event.
+        /// </summary>
         public IFrameFacade Sender
         {
             get
@@ -35,6 +43,9 @@ namespace Prism.Windows.Navigation
             }
         }
 
+        /// <summary>
+        /// The type of state change that occurred.
+        /// </summary>
         public StateChangeType StateChange { get; private set; }
     }
 }

--- a/Source/Windows10/Prism.Windows/Navigation/NavigationStateChangedEventArgs.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/NavigationStateChangedEventArgs.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Prism.Windows.Navigation
+{
+    public enum StateChangeType
+    {
+        None, Back, Forward, Clear, Remove, Set
+    }
+
+    public class NavigationStateChangedEventArgs
+    {
+        private WeakReference<IFrameFacade> _frameFacadeWeakRef;
+
+        public NavigationStateChangedEventArgs(IFrameFacade frameFacade, StateChangeType stateChange)
+        {
+            _frameFacadeWeakRef = new WeakReference<IFrameFacade>(frameFacade);
+            StateChange = stateChange;
+        }
+
+        public IFrameFacade Sender
+        {
+            get
+            {
+                IFrameFacade frameFacade = null;
+                if (_frameFacadeWeakRef.TryGetTarget(out frameFacade))
+                {
+                    return frameFacade;
+                }
+
+                return null;
+            }
+        }
+
+        public StateChangeType StateChange { get; private set; }
+    }
+}

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -142,6 +142,8 @@
     <Compile Include="Navigation\NavigatingFromEventArgs.cs" />
     <Compile Include="Mvvm\ViewModelLocator.cs" />
     <Compile Include="Mvvm\SessionStateAwarePage.cs" />
+    <Compile Include="Navigation\NavigationStateChangedEvent.cs" />
+    <Compile Include="Navigation\NavigationStateChangedEventArgs.cs" />
     <Compile Include="PrismApplication.cs" />
     <Compile Include="Mvvm\ViewModelBase.cs" />
     <Compile Include="Validation\BindableValidator.cs" />

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -36,8 +36,6 @@ namespace Prism.Windows
             }
 
             Logger.Log("Created Logger", Category.Debug, Priority.Low);
-
-            EventAggregator = CreateEventAggregator();
         }
 
         /// <summary>
@@ -134,17 +132,6 @@ namespace Prism.Windows
         protected virtual ILoggerFacade CreateLogger()
         {
             return new DebugLogger();
-        }
-
-        /// <summary>
-        /// Create the <see cref="IEventAggregator" /> used for Prism framework events.
-        /// </summary>
-        /// <remarks>
-        /// The base implementation returns a new <see cref="EventAggregator">EventAggregator</see>.
-        /// </remarks>
-        protected virtual IEventAggregator CreateEventAggregator()
-        {
-            return new EventAggregator();
         }
 
         /// <summary>
@@ -263,6 +250,18 @@ namespace Prism.Windows
         }
 
         /// <summary>
+        /// Create the <see cref="IEventAggregator" /> used for Prism framework events.
+        /// </summary>
+        /// <returns>The initialized EventAggregator.</returns>
+        private IEventAggregator CreateEventAggregator() => OnCreateEventAggregator() ?? new EventAggregator();
+
+        /// <summary>
+        /// Create the <see cref="IEventAggregator" /> used for Prism framework events. Use this to inject your own IEventAggregator implementation.
+        /// </summary>
+        /// <returns>The initialized EventAggregator.</returns>
+        protected virtual IEventAggregator OnCreateEventAggregator() => null;
+
+        /// <summary>
         /// Creates the root frame.
         /// </summary>
         /// <returns>The initialized root frame.</returns>
@@ -294,6 +293,7 @@ namespace Prism.Windows
         protected virtual async Task<Frame> InitializeFrameAsync(IActivatedEventArgs args)
         {
             CreateAndConfigureContainer();
+            EventAggregator = CreateEventAggregator();
 
             // Create a Frame to act as the navigation context and navigate to the first page
             var rootFrame = CreateRootFrame();
@@ -397,7 +397,13 @@ namespace Prism.Windows
         /// <returns>The initialized device gesture service.</returns>
         private IDeviceGestureService CreateDeviceGestureService()
         {
-            var deviceGestureService = OnCreateDeviceGestureService() ?? new DeviceGestureService(EventAggregator) { UseTitleBarBackButton = true };
+            var deviceGestureService = OnCreateDeviceGestureService();
+            if (deviceGestureService == null)
+            {
+                deviceGestureService = new DeviceGestureService();
+                deviceGestureService.EnableTitleBarBackButton(EventAggregator);
+            }
+
             return deviceGestureService;
         }
 

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -416,7 +416,7 @@ namespace Prism.Windows
         /// <returns>The initialized navigation service.</returns>
         protected virtual INavigationService CreateNavigationService(IFrameFacade rootFrame, ISessionStateService sessionStateService)
         {
-            var navigationService = OnCreateNavigationService(rootFrame) ?? new FrameNavigationService(rootFrame, GetPageType, sessionStateService, EventAggregator);
+            var navigationService = OnCreateNavigationService(rootFrame) ?? new FrameNavigationService(rootFrame, GetPageType, sessionStateService);
             return navigationService;
         }
 


### PR DESCRIPTION
Per discussion with @briannoyes on this [thread](https://github.com/PrismLibrary/Prism/issues/67#issuecomment-151216271), I've refactored the title bar back button handling such that DeviceGestureService handles toggling the visibility of the back button by listening for navigation Pub/Sub events from the FrameFacadeAdapter.