### PR TITLE
Changed absolute URI behavior

### DIFF
--- a/Samples/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Samples/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -7,7 +7,7 @@ namespace HelloWorld
     {
         protected override void OnInitialized()
         {
-            NavigationService.Navigate("MyMasterDetail/MyNavigationPage/ViewA/MyTabbedPage/ViewB");
+            NavigationService.Navigate("MyNavigationPage/ViewA/ViewB/MainPage");
         }
 
         protected override void RegisterTypes()

--- a/Samples/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/MainPageViewModel.cs
+++ b/Samples/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/MainPageViewModel.cs
@@ -31,13 +31,13 @@ namespace HelloWorld.ViewModels
 
         void Navigate()
         {
-            var basic = "MyTabbedPage?selectedItem=Orangutan";
+            var basic = "http://www.brianlagunas.com/MyNavigationPage/ViewA/ViewC/";
 
             var nonHttp = "MyMasterDetail?id=1/MyNavigationPage?id=Nav/ViewA?id=A/ViewB?id=B";
 
-            var uri = new Uri(nonHttp, UriKind.Relative);
+            //var uri = new Uri(basic, UriKind.Relative);
 
-            _navigationService.Navigate(uri);
+            _navigationService.Navigate(basic);
         }
 
         public override void OnNavigatedFrom(NavigationParameters parameters)

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -95,19 +95,6 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public void Navigate_ToContentPage_ByAbsoluteUri()
-        {
-            var navigationService = new PageNavigationServiceMock(_container);
-            var rootPage = new Xamarin.Forms.ContentPage();
-            ((IPageAware)navigationService).Page = rootPage;
-
-            navigationService.Navigate(new Uri("http://brianlagunas.com/ContentPage", UriKind.Absolute));
-
-            Assert.True(rootPage.Navigation.ModalStack.Count == 1);
-            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.ModalStack[0]);
-        }
-
-        [Fact]
         public void Navigate_ToContentPage_ByObject()
         {
             var navigationService = new PageNavigationServiceMock(_container);

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -25,7 +25,7 @@ namespace Prism.Navigation
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
         public async void GoBack(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
-            var page = GetRootPage();
+            var page = GetCurrentPage();
             var navParameters = GetSegmentParameters(null, parameters);
 
             if (!CanNavigate(page, navParameters))
@@ -82,7 +82,10 @@ namespace Prism.Navigation
             var navigationSegments = UriParsingHelper.GetUriSegments(uri);
             var isDeepLink = navigationSegments.Count > 1;
 
-            ProcessNavigation(GetRootPage(), navigationSegments, parameters, useModalNavigation, isDeepLink ? false : animated);
+            if (uri.IsAbsoluteUri)
+                ProcessNavigationForAbsoulteUri(navigationSegments, parameters, useModalNavigation, isDeepLink ? false : animated);
+            else
+                ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, isDeepLink ? false : animated);
         }
 
         void ProcessNavigation(Page currentPage, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
@@ -118,6 +121,11 @@ namespace Prism.Navigation
             {
                 ProcessNavigationForMasterDetailPage((MasterDetailPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
             }
+        }
+
+        void ProcessNavigationForAbsoulteUri(Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        {
+            ProcessNavigation(null, segments, parameters, useModalNavigation, animated);
         }
 
         void ProcessNavigationForRootPage(string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
@@ -180,7 +188,7 @@ namespace Prism.Navigation
                 {
                     DoPush(currentPage, newRoot, false, animated);
                     currentPage.Navigation.RemovePage(currentNavRoot);
-                });                
+                });
                 return;
             }
         }
@@ -344,7 +352,7 @@ namespace Prism.Navigation
             if (page == null)
                 return;
 
-            if (currentPage == null && Application.Current.MainPage == null)
+            if (currentPage == null)
             {
                 Application.Current.MainPage = page;
             }
@@ -441,7 +449,7 @@ namespace Prism.Navigation
             return navParameters;
         }
 
-        Page GetRootPage()
+        Page GetCurrentPage()
         {
             return _page != null ? _page : Application.Current.MainPage;
         }


### PR DESCRIPTION
When using an absolute URI the entire navigation stack will be replaced no matter where you are currently in the application.