### PR TITLE
RegionMemberLifetimeBehavior - conditional check for removing views

### DIFF
--- a/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
@@ -59,7 +59,8 @@ namespace Prism.Regions.Behaviors
             {
                 if (!ShouldKeepAlive(inactiveView))
                 {
-                    this.Region.Remove(inactiveView);
+                    if (Region.Views.Contains(inactiveView))
+                        Region.Remove(inactiveView);
                 }
             }
         }


### PR DESCRIPTION
Added a conditional check to see if the view being removed exists in the region before trying to remove it.  This can happen if using the IRegionMemberLifetime interface or attribute and manually removing views from a region by calling Region.Remove.