### PR TITLE
GetWindow(this) can return null

### DIFF
--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -216,7 +216,7 @@ namespace Prism.Interactivity
                 wrapperWindow = this.CreateDefaultWindow(notification);
             }
 
-            wrapperWindow.Owner = Window.GetWindow(this) ?? Window.GetWindow(AssociatedObject);
+            wrapperWindow.Owner = Window.GetWindow(AssociatedObject);
 
             // If the user provided a Style for a Window we set it as the window's style.
             if (WindowStyle != null)

--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -216,7 +216,7 @@ namespace Prism.Interactivity
                 wrapperWindow = this.CreateDefaultWindow(notification);
             }
 
-            wrapperWindow.Owner = Window.GetWindow(this);
+            wrapperWindow.Owner = Window.GetWindow(this) ?? Window.GetWindow(AssociatedObject);
 
             // If the user provided a Style for a Window we set it as the window's style.
             if (WindowStyle != null)


### PR DESCRIPTION
In my tests GetWindow(AssociatedObject) was more reliable than GetWindow(this), but I was not sure I could not prove it definitely.  So I compromised and suggested a coalesce.