### PR TITLE
removed deep link animation logic

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -7,7 +7,7 @@ namespace HelloWorld
     {
         protected override void OnInitialized()
         {
-            NavigationService.Navigate("MyMasterDetail/MyNavigationPage/ViewA");
+            NavigationService.Navigate("MyMasterDetail/MyNavigationPage/ViewA/ViewB", animated: false);
         }
 
         protected override void RegisterTypes()

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -82,12 +82,11 @@ namespace Prism.Navigation
         public async Task Navigate(Uri uri, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             var navigationSegments = UriParsingHelper.GetUriSegments(uri);
-            var isDeepLink = navigationSegments.Count > 1;
 
             if (uri.IsAbsoluteUri)
-                await ProcessNavigationForAbsoulteUri(navigationSegments, parameters, useModalNavigation, isDeepLink ? false : animated);
+                await ProcessNavigationForAbsoulteUri(navigationSegments, parameters, useModalNavigation, animated);
             else
-                await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, isDeepLink ? false : animated);
+                await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
         }
 
         async Task ProcessNavigation(Page currentPage, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)


### PR DESCRIPTION
removed the logic in the PageNavigationService that tried to
automatically detect if a deep link was being used and turned animation
off.  This causes unexpected behavior in some scenario and also disables
the ability to control the animation with the animated parameter which
is not a good API design.