### PR TITLE
Get System.Windows.Interactivity from NuGet instead of GAC for Prism.WPF

### DIFF
--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -56,7 +56,10 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Expression.Blend.Sdk.1.0.2\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/Source/Wpf/Prism.Wpf/packages.config
+++ b/Source/Wpf/Prism.Wpf/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="Expression.Blend.Sdk" version="1.0.2" targetFramework="net45" />
 </packages>

--- a/Source/nuspecs/Prism.Wpf.nuspec
+++ b/Source/nuspecs/Prism.Wpf.nuspec
@@ -21,11 +21,9 @@ Prism.Wpf helps you more easily design and build rich, flexible, and easy to mai
       <group targetFramework=".NETFramework4.5">
         <dependency id="CommonServiceLocator" version="1.3" />
         <dependency id="Prism.Core" version="$coreVersion$" />
+        <dependency id="Expression.Blend.Sdk" version="1.0.2" />
       </group>
     </dependencies>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Windows.Interactivity" targetFramework=".NETFramework4.5" />
-    </frameworkAssemblies>
   </metadata>
   <files>
     <file src="..\Wpf\Prism.Wpf\bin\Release-Signed\Prism.Wpf.*" target="lib\net45\" exclude="**\*.pdb" />


### PR DESCRIPTION
Implementing option 2 in #433.

Changes the Prism.WPF project to fetch System.Windows.Interactivity from NuGet instead of from the GAC.

Adds a package dependency on Expression.Blend.Sdk v1.0.2 to the Prism.WPF nuspec.

Removes the FrameworkDependency on System.Windows.Interactivity from the Prism.WPF nuspec.