### PR TITLE
Module Rename Wizard

### DIFF
--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Wpf/PrismModule/Module.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Wpf/PrismModule/Module.cs
@@ -4,11 +4,11 @@ using System;
 
 namespace $safeprojectname$
 {
-    public class $safeprojectname$Module : IModule
+    public class Module : IModule
     {
         IRegionManager _regionManager;
 
-        public $safeprojectname$Module(RegionManager regionManager)
+        public Module(RegionManager regionManager)
         {
             _regionManager = regionManager;
         }

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Wpf/PrismModule/PrismModule.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Wpf/PrismModule/PrismModule.vstemplate
@@ -24,13 +24,17 @@
       </Folder>      
       <Folder Name="ViewModels" TargetFolderName="ViewModels" />
       <Folder Name="Views" TargetFolderName="Views" />
-      <ProjectItem ReplaceParameters="true" OpenInEditor="true" TargetFileName="$safeprojectname$Module.cs">Module.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" OpenInEditor="true" TargetFileName="Module.cs">Module.cs</ProjectItem>
     </Project>
   </TemplateContent>
 
   <WizardExtension>
     <Assembly>NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
+  </WizardExtension>
+  <WizardExtension>
+    <Assembly>Prism.VisualStudio.Wizards, Version=1.0.0.0, Culture=neutral, PublicKeyToken=91a96d2a154366d8</Assembly>
+    <FullClassName>Prism.VisualStudio.Wizards.ExtractModuleFileNameWizard</FullClassName>
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Wpf/PrismModule/ProjectTemplate.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Wpf/PrismModule/ProjectTemplate.csproj
@@ -49,7 +49,7 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$safeprojectname$Module.cs" />
+    <Compile Include="Module.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Extensibility/TemplatePack/TemplatePack.sln
+++ b/Extensibility/TemplatePack/TemplatePack.sln
@@ -47,6 +47,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VsPackages", "VsPackages", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigModuleEditor", "VsPackages\ConfigModuleEditor\ConfigModuleEditor.csproj", "{104E18E6-ACD0-476B-8732-8FC772ABAEA3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VsWizards", "VsWizards", "{17975747-054F-451F-8A3B-2ECB07EC3EEB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.VisualStudio.Wizards", "VsWizards\Prism.VisualStudio.Wizards\Prism.VisualStudio.Wizards.csproj", "{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +109,10 @@ Global
 		{104E18E6-ACD0-476B-8732-8FC772ABAEA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{104E18E6-ACD0-476B-8732-8FC772ABAEA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{104E18E6-ACD0-476B-8732-8FC772ABAEA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,5 +136,6 @@ Global
 		{0487B548-C845-4CC4-8F82-8932CFC92E1F} = {D9B82372-CF98-45DA-97E9-7C84F70EA440}
 		{9DAE43F7-77D4-4191-BEAC-40EACFD9C20C} = {D9B82372-CF98-45DA-97E9-7C84F70EA440}
 		{104E18E6-ACD0-476B-8732-8FC772ABAEA3} = {00A2824E-2F0B-4BFB-9AD9-B2FE4C8CD327}
+		{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9} = {17975747-054F-451F-8A3B-2ECB07EC3EEB}
 	EndGlobalSection
 EndGlobal

--- a/Extensibility/TemplatePack/TemplatePack/TemplatePack.csproj
+++ b/Extensibility/TemplatePack/TemplatePack/TemplatePack.csproj
@@ -208,6 +208,12 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bPkgdefProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
+    <ProjectReference Include="..\VsWizards\Prism.VisualStudio.Wizards\Prism.VisualStudio.Wizards.csproj">
+      <Project>{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}</Project>
+      <Name>Prism.VisualStudio.Wizards</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/Extensibility/TemplatePack/TemplatePack/source.extension.vsixmanifest
+++ b/Extensibility/TemplatePack/TemplatePack/source.extension.vsixmanifest
@@ -44,5 +44,6 @@
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="PrismModule" d:TargetPath="|PrismModule;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="PrismUnityApp.Wpf" d:TargetPath="|PrismUnityApp.Wpf;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="ConfigModuleEditor" Path="|ConfigModuleEditor;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="Prism.VisualStudio.Wizards" Path="|Prism.VisualStudio.Wizards|" AssemblyName="|Prism.VisualStudio.Wizards;AssemblyName|" />
   </Assets>
 </PackageManifest>

--- a/Extensibility/TemplatePack/VsWizards/Prism.VisualStudio.Wizards/ExtractModuleFileNameWizard.cs
+++ b/Extensibility/TemplatePack/VsWizards/Prism.VisualStudio.Wizards/ExtractModuleFileNameWizard.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.VisualStudio.TemplateWizard;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using EnvDTE;
+
+namespace Prism.VisualStudio.Wizards
+{
+    public class ExtractModuleFileNameWizard : IWizard
+    {
+        public void BeforeOpeningFile(global::EnvDTE.ProjectItem projectItem)
+        {
+
+        }
+
+        public void ProjectFinishedGenerating(global::EnvDTE.Project project)
+        {
+            foreach (ProjectItem item in project.ProjectItems)
+            {
+                if (item.Name == "Module.cs")
+                {
+                    RenameModule(project, item);
+                    return;
+                }
+            }
+        }
+
+        void RenameModule(Project project, ProjectItem item)
+        {
+            var projectName = project.Name;
+            var moduleName = String.Format("{0}{1}", projectName.Split('.').Last(), "Module");
+            var className = String.Format("{0}.cs", moduleName);
+
+            CodeClass codeClass = GetCodeClass(item.FileCodeModel.CodeElements);
+            if (codeClass != null)
+            {
+                codeClass.Name = moduleName;
+                item.Save();
+                item.Name = className;
+            }
+        }
+
+        CodeClass GetCodeClass(CodeElements codeElements)
+        {
+            foreach (CodeElement codeElement in codeElements)
+            {
+                if (codeElement.Kind == vsCMElement.vsCMElementNamespace)
+                {
+                    CodeNamespace codeNamespace = (CodeNamespace)codeElement;
+
+                    foreach (CodeElement child in codeNamespace.Children)
+                    {
+                        if (child.Kind == vsCMElement.vsCMElementClass)
+                        {
+                            return (CodeClass)child;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public void ProjectItemFinishedGenerating(global::EnvDTE.ProjectItem projectItem)
+        {
+
+        }
+
+        public void RunFinished()
+        {
+
+        }
+
+        public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
+        {
+
+        }
+
+        public bool ShouldAddProjectItem(string filePath)
+        {
+            return true;
+        }
+    }
+}

--- a/Extensibility/TemplatePack/VsWizards/Prism.VisualStudio.Wizards/Prism.VisualStudio.Wizards.csproj
+++ b/Extensibility/TemplatePack/VsWizards/Prism.VisualStudio.Wizards/Prism.VisualStudio.Wizards.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CF820A3D-4BD3-4A92-B951-D35F3AFD6AA9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Prism.VisualStudio.Wizards</RootNamespace>
+    <AssemblyName>Prism.VisualStudio.Wizards</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>prism.pfx</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ExtractModuleFileNameWizard.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="prism.pfx" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Extensibility/TemplatePack/VsWizards/Prism.VisualStudio.Wizards/Properties/AssemblyInfo.cs
+++ b/Extensibility/TemplatePack/VsWizards/Prism.VisualStudio.Wizards/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Prism.VisualStudio.Wizards")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Prism.VisualStudio.Wizards")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cf820a3d-4bd3-4a92-b951-d35f3afd6aa9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
added a wizard to rename the module class in the Prism Module ProjectTemplate to support more complex project names such as "Prism.Modules.Admin".  This will result in a class being call AdminModule