### PR TITLE
Fixed bug with Back button event in DeviceGestureService

### DIFF
--- a/Source/Windows10/Prism.Windows/AppModel/DeviceGestureService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/DeviceGestureService.cs
@@ -34,9 +34,7 @@ namespace Prism.Windows.AppModel
             IsMousePresent = new MouseCapabilities().MousePresent != 0;
             IsTouchPresent = new TouchCapabilities().TouchPresent != 0;
 
-            if (IsHardwareBackButtonPresent)
-                HardwareButtons.BackPressed += OnHardwareButtonsBackPressed;
-
+           
             if (IsHardwareCameraButtonPresent)
             {
                 HardwareButtons.CameraHalfPressed += OnHardwareButtonCameraHalfPressed;
@@ -47,7 +45,16 @@ namespace Prism.Windows.AppModel
             if (IsMousePresent)
                 MouseDevice.GetForCurrentView().MouseMoved += OnMouseMoved;
 
-            SystemNavigationManager.GetForCurrentView().BackRequested += OnSystemNavigationManagerBackRequested;
+            if (IsHardwareBackButtonPresent)
+            {
+                HardwareButtons.BackPressed += OnHardwareButtonsBackPressed;
+
+            }
+            else
+            {
+                SystemNavigationManager.GetForCurrentView().BackRequested += OnSystemNavigationManagerBackRequested;
+
+            }
 
             Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += OnAcceleratorKeyActivated;
 


### PR DESCRIPTION
I fixed problem with DeviceGestureService. 

When I am testing my app in Mobile environment always the DeviceGestureService.GoBackRequested is executed twice when I press the back button.

I found the issue here:

```
if (IsHardwareBackButtonPresent)
                HardwareButtons.BackPressed += OnHardwareButtonsBackPressed;

            if (IsHardwareCameraButtonPresent)
            {
                HardwareButtons.CameraHalfPressed += OnHardwareButtonCameraHalfPressed;
                HardwareButtons.CameraPressed += OnHardwareButtonCameraPressed;
                HardwareButtons.CameraReleased += OnHardwareButtonCameraReleased;
            }

            if (IsMousePresent)
                MouseDevice.GetForCurrentView().MouseMoved += OnMouseMoved;

            SystemNavigationManager.GetForCurrentView().BackRequested += OnSystemNavigationManagerBackRequested;

```


This code is in the constructor of DeviceGestureService.

I replaced this code checking if there is a back button is present in the device.

```
 if (IsHardwareBackButtonPresent)
            {
                HardwareButtons.BackPressed += OnHardwareButtonsBackPressed;

            }
            else
            {
                SystemNavigationManager.GetForCurrentView().BackRequested += OnSystemNavigationManagerBackRequested;

            }
```

With this small fix I am sure that the event will be raised just one time.
