### PR TITLE
Non-generic PubSubEvent

### DIFF
--- a/Source/Prism.Tests/Events/BackgroundEventSubscriptionFixture.cs
+++ b/Source/Prism.Tests/Events/BackgroundEventSubscriptionFixture.cs
@@ -32,7 +32,35 @@ namespace Prism.Tests.Events
             publishAction.Invoke(null);
 
             completeEvent.WaitOne(5000);
-            
+
+            Assert.NotEqual(SynchronizationContext.Current, calledSyncContext);
+        }
+
+        [Fact]
+        public void ShouldReceiveDelegateOnDifferentThreadNonGeneric()
+        {
+            ManualResetEvent completeEvent = new ManualResetEvent(false);
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            SynchronizationContext calledSyncContext = null;
+            Action action = delegate
+            {
+                calledSyncContext = SynchronizationContext.Current;
+                completeEvent.Set();
+            };
+
+            IDelegateReference actionDelegateReference = new MockDelegateReference() { Target = action };
+
+            var eventSubscription = new BackgroundEventSubscription(actionDelegateReference);
+
+
+            var publishAction = eventSubscription.GetExecutionStrategy();
+
+            Assert.NotNull(publishAction);
+
+            publishAction.Invoke(null);
+
+            completeEvent.WaitOne(5000);
+
             Assert.NotEqual(SynchronizationContext.Current, calledSyncContext);
         }
     }

--- a/Source/Prism.Tests/Events/BackgroundEventSubscriptionFixture.cs
+++ b/Source/Prism.Tests/Events/BackgroundEventSubscriptionFixture.cs
@@ -39,7 +39,7 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldReceiveDelegateOnDifferentThreadNonGeneric()
         {
-            ManualResetEvent completeEvent = new ManualResetEvent(false);
+            var completeEvent = new ManualResetEvent(false);
             SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
             SynchronizationContext calledSyncContext = null;
             Action action = delegate
@@ -51,7 +51,6 @@ namespace Prism.Tests.Events
             IDelegateReference actionDelegateReference = new MockDelegateReference() { Target = action };
 
             var eventSubscription = new BackgroundEventSubscription(actionDelegateReference);
-
 
             var publishAction = eventSubscription.GetExecutionStrategy();
 

--- a/Source/Prism.Tests/Events/DispatcherEventSubscriptionFixture.cs
+++ b/Source/Prism.Tests/Events/DispatcherEventSubscriptionFixture.cs
@@ -34,6 +34,26 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
+        public void ShouldCallInvokeOnDispatcherNonGeneric()
+        {
+            DispatcherEventSubscription eventSubscription = null;
+
+            IDelegateReference actionDelegateReference = new MockDelegateReference()
+            {
+                Target = (Action)(() =>
+                { })
+            };
+
+            var mockSyncContext = new MockSynchronizationContext();
+
+            eventSubscription = new DispatcherEventSubscription(actionDelegateReference, mockSyncContext);
+
+            eventSubscription.GetExecutionStrategy().Invoke(new object[0]);
+
+            Assert.True(mockSyncContext.InvokeCalled);
+        }
+
+        [Fact]
         public void ShouldPassParametersCorrectly()
         {
             IDelegateReference actionDelegateReference = new MockDelegateReference()

--- a/Source/Prism.Tests/Events/EventSubscriptionFixture.cs
+++ b/Source/Prism.Tests/Events/EventSubscriptionFixture.cs
@@ -30,6 +30,19 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
+        public void NullTargetInActionThrowsNonGeneric()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var actionDelegateReference = new MockDelegateReference()
+                {
+                    Target = null
+                };
+                var eventSubscription = new EventSubscription(actionDelegateReference);
+            });
+        }
+
+        [Fact]
         public void DifferentTargetTypeInActionThrows()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -51,6 +64,20 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
+        public void DifferentTargetTypeInActionThrowsNonGeneric()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var actionDelegateReference = new MockDelegateReference()
+                {
+                    Target = (Action<int>)delegate { }
+                };
+
+                var eventSubscription = new EventSubscription(actionDelegateReference);
+            });
+        }
+
+        [Fact]
         public void NullActionThrows()
         {
             Assert.Throws<ArgumentNullException>(() =>
@@ -63,6 +90,15 @@ namespace Prism.Tests.Events
                     })
                 };
                 var eventSubscription = new EventSubscription<object>(null, filterDelegateReference);
+            });
+        }
+
+        [Fact]
+        public void NullActionThrowsNonGeneric()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var eventSubscription = new EventSubscription(null);
             });
         }
 
@@ -141,6 +177,20 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
+        public void CanInitEventSubscriptionNonGeneric()
+        {
+            var actionDelegateReference = new MockDelegateReference((Action)delegate { });
+            var eventSubscription = new EventSubscription(actionDelegateReference);
+
+            var subscriptionToken = new SubscriptionToken(t => { });
+
+            eventSubscription.SubscriptionToken = subscriptionToken;
+
+            Assert.Same(actionDelegateReference.Target, eventSubscription.Action);
+            Assert.Same(subscriptionToken, eventSubscription.SubscriptionToken);
+        }
+
+        [Fact]
         public void GetPublishActionReturnsDelegateThatExecutesTheFilterAndThenTheAction()
         {
             var executedDelegates = new List<string>();
@@ -148,11 +198,11 @@ namespace Prism.Tests.Events
                 new MockDelegateReference((Action<object>)delegate { executedDelegates.Add("Action"); });
 
             var filterDelegateReference = new MockDelegateReference((Predicate<object>)delegate
-                                                {
-                                                    executedDelegates.Add(
-                                                        "Filter");
-                                                    return true;
-                                                });
+            {
+                executedDelegates.Add(
+                    "Filter");
+                return true;
+            });
 
             var eventSubscription = new EventSubscription<object>(actionDelegateReference, filterDelegateReference);
 
@@ -175,6 +225,24 @@ namespace Prism.Tests.Events
             var filterDelegateReference = new MockDelegateReference((Predicate<object>)delegate { return true; });
 
             var eventSubscription = new EventSubscription<object>(actionDelegateReference, filterDelegateReference);
+
+            var publishAction = eventSubscription.GetExecutionStrategy();
+
+            Assert.NotNull(publishAction);
+
+            actionDelegateReference.Target = null;
+
+            publishAction = eventSubscription.GetExecutionStrategy();
+
+            Assert.Null(publishAction);
+        }
+
+        [Fact]
+        public void GetPublishActionReturnsNullIfActionIsNullNonGeneric()
+        {
+            var actionDelegateReference = new MockDelegateReference((Action)delegate { });
+
+            var eventSubscription = new EventSubscription(actionDelegateReference);
 
             var publishAction = eventSubscription.GetExecutionStrategy();
 

--- a/Source/Prism.Tests/Events/PubSubEventFixture.cs
+++ b/Source/Prism.Tests/Events/PubSubEventFixture.cs
@@ -23,7 +23,7 @@ namespace Prism.Tests.Events
         [Fact]
         public void CanSubscribeAndRaiseEventNonGeneric()
         {
-            TestablePubSubEvent pubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
             bool published = false;
             pubSubEvent.Subscribe(delegate { published = true; }, ThreadOption.PublisherThread, true);
             pubSubEvent.Publish();
@@ -160,16 +160,16 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldUnsubscribeFromPublisherThreadNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
 
             var actionEvent = new ActionHelper();
-            PubSubEvent.Subscribe(
+            pubSubEvent.Subscribe(
                 actionEvent.Action,
                 ThreadOption.PublisherThread);
 
-            Assert.True(PubSubEvent.Contains(actionEvent.Action));
-            PubSubEvent.Unsubscribe(actionEvent.Action);
-            Assert.False(PubSubEvent.Contains(actionEvent.Action));
+            Assert.True(pubSubEvent.Contains(actionEvent.Action));
+            pubSubEvent.Unsubscribe(actionEvent.Action);
+            Assert.False(pubSubEvent.Contains(actionEvent.Action));
         }
 
         [Fact]
@@ -208,16 +208,16 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldUnsubscribeFromBackgroundThreadNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
 
             var actionEvent = new ActionHelper();
-            PubSubEvent.Subscribe(
+            pubSubEvent.Subscribe(
                 actionEvent.Action,
                 ThreadOption.BackgroundThread);
 
-            Assert.True(PubSubEvent.Contains(actionEvent.Action));
-            PubSubEvent.Unsubscribe(actionEvent.Action);
-            Assert.False(PubSubEvent.Contains(actionEvent.Action));
+            Assert.True(pubSubEvent.Contains(actionEvent.Action));
+            pubSubEvent.Unsubscribe(actionEvent.Action);
+            Assert.False(pubSubEvent.Contains(actionEvent.Action));
         }
 
         [Fact]
@@ -239,17 +239,17 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldUnsubscribeFromUIThreadNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
-            PubSubEvent.SynchronizationContext = new SynchronizationContext();
+            var pubSubEvent = new TestablePubSubEvent();
+            pubSubEvent.SynchronizationContext = new SynchronizationContext();
 
             var actionEvent = new ActionHelper();
-            PubSubEvent.Subscribe(
+            pubSubEvent.Subscribe(
                 actionEvent.Action,
                 ThreadOption.UIThread);
 
-            Assert.True(PubSubEvent.Contains(actionEvent.Action));
-            PubSubEvent.Unsubscribe(actionEvent.Action);
-            Assert.False(PubSubEvent.Contains(actionEvent.Action));
+            Assert.True(pubSubEvent.Contains(actionEvent.Action));
+            pubSubEvent.Unsubscribe(actionEvent.Action);
+            Assert.False(pubSubEvent.Contains(actionEvent.Action));
         }
 
         [Fact]
@@ -275,20 +275,20 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldUnsubscribeASingleDelegateNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
 
             int callCount = 0;
 
             var actionEvent = new ActionHelper() { ActionToExecute = () => callCount++ };
-            PubSubEvent.Subscribe(actionEvent.Action);
-            PubSubEvent.Subscribe(actionEvent.Action);
+            pubSubEvent.Subscribe(actionEvent.Action);
+            pubSubEvent.Subscribe(actionEvent.Action);
 
-            PubSubEvent.Publish();
+            pubSubEvent.Publish();
             Assert.Equal<int>(2, callCount);
 
             callCount = 0;
-            PubSubEvent.Unsubscribe(actionEvent.Action);
-            PubSubEvent.Publish();
+            pubSubEvent.Unsubscribe(actionEvent.Action);
+            pubSubEvent.Publish();
             Assert.Equal<int>(1, callCount);
         }
 
@@ -314,20 +314,20 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldNotExecuteOnGarbageCollectedDelegateReferenceWhenNotKeepAliveNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
 
-            ExternalAction externalAction = new ExternalAction();
-            PubSubEvent.Subscribe(externalAction.ExecuteAction);
+            var externalAction = new ExternalAction();
+            pubSubEvent.Subscribe(externalAction.ExecuteAction);
 
-            PubSubEvent.Publish();
+            pubSubEvent.Publish();
             Assert.True(externalAction.Executed);
 
-            WeakReference actionEventReference = new WeakReference(externalAction);
+            var actionEventReference = new WeakReference(externalAction);
             externalAction = null;
             GC.Collect();
             Assert.False(actionEventReference.IsAlive);
 
-            PubSubEvent.Publish();
+            pubSubEvent.Publish();
         }
 
         [Fact]
@@ -379,23 +379,23 @@ namespace Prism.Tests.Events
         [Fact]
         public void CanAddSubscriptionWhileEventIsFiringNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
 
             var emptyAction = new ActionHelper();
             var subscriptionAction = new ActionHelper
             {
                 ActionToExecute = (() =>
-                                                  PubSubEvent.Subscribe(
-                                                      emptyAction.Action))
+                                          pubSubEvent.Subscribe(
+                                          emptyAction.Action))
             };
 
-            PubSubEvent.Subscribe(subscriptionAction.Action);
+            pubSubEvent.Subscribe(subscriptionAction.Action);
 
-            Assert.False(PubSubEvent.Contains(emptyAction.Action));
+            Assert.False(pubSubEvent.Contains(emptyAction.Action));
 
-            PubSubEvent.Publish();
+            pubSubEvent.Publish();
 
-            Assert.True((PubSubEvent.Contains(emptyAction.Action)));
+            Assert.True((pubSubEvent.Contains(emptyAction.Action)));
         }
 
         [Fact]
@@ -413,11 +413,11 @@ namespace Prism.Tests.Events
         [Fact]
         public void InlineDelegateDeclarationsDoesNotGetCollectedIncorrectlyWithWeakReferencesNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
             bool published = false;
-            PubSubEvent.Subscribe(delegate { published = true; }, ThreadOption.PublisherThread, false);
+            pubSubEvent.Subscribe(delegate { published = true; }, ThreadOption.PublisherThread, false);
             GC.Collect();
-            PubSubEvent.Publish();
+            pubSubEvent.Publish();
 
             Assert.True(published);
         }
@@ -444,10 +444,10 @@ namespace Prism.Tests.Events
         [Fact]
         public void ShouldNotGarbageCollectDelegateReferenceWhenUsingKeepAliveNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
 
             var externalAction = new ExternalAction();
-            PubSubEvent.Subscribe(externalAction.ExecuteAction, ThreadOption.PublisherThread, true);
+            pubSubEvent.Subscribe(externalAction.ExecuteAction, ThreadOption.PublisherThread, true);
 
             WeakReference actionEventReference = new WeakReference(externalAction);
             externalAction = null;
@@ -455,7 +455,7 @@ namespace Prism.Tests.Events
             GC.Collect();
             Assert.True(actionEventReference.IsAlive);
 
-            PubSubEvent.Publish();
+            pubSubEvent.Publish();
 
             Assert.True(((ExternalAction)actionEventReference.Target).Executed);
         }
@@ -475,13 +475,13 @@ namespace Prism.Tests.Events
         [Fact]
         public void RegisterReturnsTokenThatCanBeUsedToUnsubscribeNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
             var emptyAction = new ActionHelper();
 
-            var token = PubSubEvent.Subscribe(emptyAction.Action);
-            PubSubEvent.Unsubscribe(token);
+            var token = pubSubEvent.Subscribe(emptyAction.Action);
+            pubSubEvent.Unsubscribe(token);
 
-            Assert.False(PubSubEvent.Contains(emptyAction.Action));
+            Assert.False(pubSubEvent.Contains(emptyAction.Action));
         }
 
         [Fact]
@@ -500,14 +500,14 @@ namespace Prism.Tests.Events
         [Fact]
         public void ContainsShouldSearchByTokenNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
             var emptyAction = new ActionHelper();
-            var token = PubSubEvent.Subscribe(emptyAction.Action);
+            var token = pubSubEvent.Subscribe(emptyAction.Action);
 
-            Assert.True(PubSubEvent.Contains(token));
+            Assert.True(pubSubEvent.Contains(token));
 
-            PubSubEvent.Unsubscribe(emptyAction.Action);
-            Assert.False(PubSubEvent.Contains(token));
+            pubSubEvent.Unsubscribe(emptyAction.Action);
+            Assert.False(pubSubEvent.Contains(token));
         }
 
         [Fact]
@@ -524,12 +524,12 @@ namespace Prism.Tests.Events
         [Fact]
         public void SubscribeDefaultsToPublisherThreadNonGeneric()
         {
-            var PubSubEvent = new TestablePubSubEvent();
+            var pubSubEvent = new TestablePubSubEvent();
             Action action = delegate { };
-            var token = PubSubEvent.Subscribe(action, true);
+            var token = pubSubEvent.Subscribe(action, true);
 
-            Assert.Equal(1, PubSubEvent.BaseSubscriptions.Count);
-            Assert.Equal(typeof(EventSubscription), PubSubEvent.BaseSubscriptions.ElementAt(0).GetType());
+            Assert.Equal(1, pubSubEvent.BaseSubscriptions.Count);
+            Assert.Equal(typeof(EventSubscription), pubSubEvent.BaseSubscriptions.ElementAt(0).GetType());
         }
 
         public class ExternalFilter

--- a/Source/Prism/Events/BackgroundEventSubscription.cs
+++ b/Source/Prism/Events/BackgroundEventSubscription.cs
@@ -1,12 +1,34 @@
-
-
-
-using System.Threading;
 using System;
 using System.Threading.Tasks;
 
 namespace Prism.Events
 {
+    /// <summary>
+    /// Extends <see cref="EventSubscription"/> to invoke the <see cref="EventSubscription.Action"/> delegate in a background thread.
+    /// </summary>
+    public class BackgroundEventSubscription : EventSubscription
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="BackgroundEventSubscription"/>.
+        /// </summary>
+        /// <param name="actionReference">A reference to a delegate of type <see cref="System.Action"/>.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="actionReference"/> or <see paramref="filterReference"/> are <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException">When the target of <paramref name="actionReference"/> is not of type <see cref="System.Action"/>.</exception>
+        public BackgroundEventSubscription(IDelegateReference actionReference)
+            : base(actionReference)
+        {
+        }
+
+        /// <summary>
+        /// Invokes the specified <see cref="System.Action"/> in an asynchronous thread by using a <see cref="Task"/>.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        public override void InvokeAction(Action action)
+        {
+            Task.Run(action);
+        }
+    }
+
     /// <summary>
     /// Extends <see cref="EventSubscription{TPayload}"/> to invoke the <see cref="EventSubscription{TPayload}.Action"/> delegate in a background thread.
     /// </summary>

--- a/Source/Prism/Events/DispatcherEventSubscription.cs
+++ b/Source/Prism/Events/DispatcherEventSubscription.cs
@@ -1,11 +1,39 @@
-
-
-
 using System;
 using System.Threading;
 
 namespace Prism.Events
 {
+    ///<summary>
+    /// Extends <see cref="EventSubscription"/> to invoke the <see cref="EventSubscription.Action"/> delegate
+    /// in a specific <see cref="SynchronizationContext"/>.
+    ///</summary>
+    public class DispatcherEventSubscription : EventSubscription
+    {
+        private readonly SynchronizationContext syncContext;
+
+        ///<summary>
+        /// Creates a new instance of <see cref="BackgroundEventSubscription"/>.
+        ///</summary>
+        ///<param name="actionReference">A reference to a delegate of type <see cref="System.Action{TPayload}"/>.</param>
+        ///<param name="context">The synchronization context to use for UI thread dispatching.</param>
+        ///<exception cref="ArgumentNullException">When <paramref name="actionReference"/> or <see paramref="filterReference"/> are <see langword="null" />.</exception>
+        ///<exception cref="ArgumentException">When the target of <paramref name="actionReference"/> is not of type <see cref="System.Action{TPayload}"/>.</exception>
+        public DispatcherEventSubscription(IDelegateReference actionReference, SynchronizationContext context)
+            : base(actionReference)
+        {
+            syncContext = context;
+        }
+
+        /// <summary>
+        /// Invokes the specified <see cref="System.Action{TPayload}"/> asynchronously in the specified <see cref="SynchronizationContext"/>.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        public override void InvokeAction(Action action)
+        {
+            syncContext.Post((o) => action(), null);
+        }
+    }
+
     ///<summary>
     /// Extends <see cref="EventSubscription{TPayload}"/> to invoke the <see cref="EventSubscription{TPayload}.Action"/> delegate
     /// in a specific <see cref="SynchronizationContext"/>.

--- a/Source/Prism/Events/EventSubscription.cs
+++ b/Source/Prism/Events/EventSubscription.cs
@@ -1,12 +1,87 @@
-
-
-
 using System;
 using System.Globalization;
 using Prism.Properties;
 
 namespace Prism.Events
 {
+    /// <summary>
+    /// Provides a way to retrieve a <see cref="Delegate"/> to execute an action depending
+    /// on the value of a second filter predicate that returns true if the action should execute.
+    /// </summary>
+    public class EventSubscription : IEventSubscription
+    {
+        private readonly IDelegateReference _actionReference;
+
+        ///<summary>
+        /// Creates a new instance of <see cref="EventSubscription"/>.
+        ///</summary>
+        ///<param name="actionReference">A reference to a delegate of type <see cref="System.Action"/>.</param>
+        ///<exception cref="ArgumentNullException">When <paramref name="actionReference"/> or <see paramref="filterReference"/> are <see langword="null" />.</exception>
+        ///<exception cref="ArgumentException">When the target of <paramref name="actionReference"/> is not of type <see cref="System.Action"/>.</exception>
+        public EventSubscription(IDelegateReference actionReference)
+        {
+            if (actionReference == null)
+                throw new ArgumentNullException(nameof(actionReference));
+            if (!(actionReference.Target is Action))
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidDelegateRerefenceTypeException, typeof(Action).FullName), nameof(actionReference));
+
+            _actionReference = actionReference;
+        }
+
+        /// <summary>
+        /// Gets the target <see cref="System.Action"/> that is referenced by the <see cref="IDelegateReference"/>.
+        /// </summary>
+        /// <value>An <see cref="System.Action"/> or <see langword="null" /> if the referenced target is not alive.</value>
+        public Action Action
+        {
+            get { return (Action)_actionReference.Target; }
+        }
+
+        /// <summary>
+        /// Gets or sets a <see cref="SubscriptionToken"/> that identifies this <see cref="IEventSubscription"/>.
+        /// </summary>
+        /// <value>A token that identifies this <see cref="IEventSubscription"/>.</value>
+        public SubscriptionToken SubscriptionToken { get; set; }
+
+        /// <summary>
+        /// Gets the execution strategy to publish this event.
+        /// </summary>
+        /// <returns>An <see cref="System.Action"/> with the execution strategy, or <see langword="null" /> if the <see cref="IEventSubscription"/> is no longer valid.</returns>
+        /// <remarks>
+        /// If <see cref="Action"/>is no longer valid because it was
+        /// garbage collected, this method will return <see langword="null" />.
+        /// Otherwise it will return a delegate that evaluates the <see cref="Filter"/> and if it
+        /// returns <see langword="true" /> will then call <see cref="InvokeAction"/>. The returned
+        /// delegate holds a hard reference to the <see cref="Action"/> target
+        /// <see cref="Delegate">delegates</see>. As long as the returned delegate is not garbage collected,
+        /// the <see cref="Action"/> references delegates won't get collected either.
+        /// </remarks>
+        public virtual Action<object[]> GetExecutionStrategy()
+        {
+            Action action = this.Action;
+            if (action != null)
+            {
+                return arguments =>
+                {
+                    InvokeAction(action);
+                };
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Invokes the specified <see cref="System.Action{TPayload}"/> synchronously when not overridden.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <exception cref="ArgumentNullException">An <see cref="ArgumentNullException"/> is thrown if <paramref name="action"/> is null.</exception>
+        public virtual void InvokeAction(Action action)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+
+            action();
+        }
+    }
+
     /// <summary>
     /// Provides a way to retrieve a <see cref="Delegate"/> to execute an action depending
     /// on the value of a second filter predicate that returns true if the action should execute.
@@ -85,17 +160,17 @@ namespace Prism.Events
             if (action != null && filter != null)
             {
                 return arguments =>
-                           {
-                               TPayload argument = default(TPayload);
-                               if (arguments != null && arguments.Length > 0 && arguments[0] != null)
-                               {
-                                   argument = (TPayload)arguments[0];
-                               }
-                               if (filter(argument))
-                               {
-                                   InvokeAction(action, argument);
-                               }
-                           };
+                {
+                    TPayload argument = default(TPayload);
+                    if (arguments != null && arguments.Length > 0 && arguments[0] != null)
+                    {
+                        argument = (TPayload)arguments[0];
+                    }
+                    if (filter(argument))
+                    {
+                        InvokeAction(action, argument);
+                    }
+                };
             }
             return null;
         }

--- a/Source/Prism/Events/PubSubEvent.cs
+++ b/Source/Prism/Events/PubSubEvent.cs
@@ -1,12 +1,139 @@
-
-
-
 using System;
 using System.Linq;
 using Prism.Properties;
 
 namespace Prism.Events
 {
+    /// <summary>
+    /// Defines a class that manages publication and subscription to events.
+    /// </summary>
+    public class PubSubEvent : EventBase
+    {
+        /// <summary>
+        /// Subscribes a delegate to an event that will be published on the <see cref="ThreadOption.PublisherThread"/>.
+        /// <see cref="PubSubEvent"/> will maintain a <see cref="WeakReference"/> to the target of the supplied <paramref name="action"/> delegate.
+        /// </summary>
+        /// <param name="action">The delegate that gets executed when the event is published.</param>
+        /// <returns>A <see cref="SubscriptionToken"/> that uniquely identifies the added subscription.</returns>
+        /// <remarks>
+        /// The PubSubEvent collection is thread-safe.
+        /// </remarks>
+        public SubscriptionToken Subscribe(Action action)
+        {
+            return Subscribe(action, ThreadOption.PublisherThread);
+        }
+
+        /// <summary>
+        /// Subscribes a delegate to an event.
+        /// PubSubEvent will maintain a <see cref="WeakReference"/> to the Target of the supplied <paramref name="action"/> delegate.
+        /// </summary>
+        /// <param name="action">The delegate that gets executed when the event is raised.</param>
+        /// <param name="threadOption">Specifies on which thread to receive the delegate callback.</param>
+        /// <returns>A <see cref="SubscriptionToken"/> that uniquely identifies the added subscription.</returns>
+        /// <remarks>
+        /// The PubSubEvent collection is thread-safe.
+        /// </remarks>
+        public SubscriptionToken Subscribe(Action action, ThreadOption threadOption)
+        {
+            return Subscribe(action, threadOption, false);
+        }
+
+        /// <summary>
+        /// Subscribes a delegate to an event that will be published on the <see cref="ThreadOption.PublisherThread"/>.
+        /// </summary>
+        /// <param name="action">The delegate that gets executed when the event is published.</param>
+        /// <param name="keepSubscriberReferenceAlive">When <see langword="true"/>, the <see cref="PubSubEvent"/> keeps a reference to the subscriber so it does not get garbage collected.</param>
+        /// <returns>A <see cref="SubscriptionToken"/> that uniquely identifies the added subscription.</returns>
+        /// <remarks>
+        /// If <paramref name="keepSubscriberReferenceAlive"/> is set to <see langword="false" />, <see cref="PubSubEvent"/> will maintain a <see cref="WeakReference"/> to the Target of the supplied <paramref name="action"/> delegate.
+        /// If not using a WeakReference (<paramref name="keepSubscriberReferenceAlive"/> is <see langword="true" />), the user must explicitly call Unsubscribe for the event when disposing the subscriber in order to avoid memory leaks or unexpected behavior.
+        /// <para/>
+        /// The PubSubEvent collection is thread-safe.
+        /// </remarks>
+        public SubscriptionToken Subscribe(Action action, bool keepSubscriberReferenceAlive)
+        {
+            return Subscribe(action, ThreadOption.PublisherThread, keepSubscriberReferenceAlive);
+        }
+
+        /// <summary>
+        /// Subscribes a delegate to an event.
+        /// </summary>
+        /// <param name="action">The delegate that gets executed when the event is published.</param>
+        /// <param name="threadOption">Specifies on which thread to receive the delegate callback.</param>
+        /// <param name="keepSubscriberReferenceAlive">When <see langword="true"/>, the <see cref="PubSubEvent"/> keeps a reference to the subscriber so it does not get garbage collected.</param>
+        /// <returns>A <see cref="SubscriptionToken"/> that uniquely identifies the added subscription.</returns>
+        /// <remarks>
+        /// If <paramref name="keepSubscriberReferenceAlive"/> is set to <see langword="false" />, <see cref="PubSubEvent"/> will maintain a <see cref="WeakReference"/> to the Target of the supplied <paramref name="action"/> delegate.
+        /// If not using a WeakReference (<paramref name="keepSubscriberReferenceAlive"/> is <see langword="true" />), the user must explicitly call Unsubscribe for the event when disposing the subscriber in order to avoid memory leaks or unexpected behavior.
+        /// <para/>
+        /// The PubSubEvent collection is thread-safe.
+        /// </remarks>
+        public SubscriptionToken Subscribe(Action action, ThreadOption threadOption, bool keepSubscriberReferenceAlive)
+        {
+            IDelegateReference actionReference = new DelegateReference(action, keepSubscriberReferenceAlive);
+
+            EventSubscription subscription;
+            switch (threadOption)
+            {
+                case ThreadOption.PublisherThread:
+                    subscription = new EventSubscription(actionReference);
+                    break;
+                case ThreadOption.BackgroundThread:
+                    subscription = new BackgroundEventSubscription(actionReference);
+                    break;
+                case ThreadOption.UIThread:
+                    if (SynchronizationContext == null) throw new InvalidOperationException(Resources.EventAggregatorNotConstructedOnUIThread);
+                    subscription = new DispatcherEventSubscription(actionReference, SynchronizationContext);
+                    break;
+                default:
+                    subscription = new EventSubscription(actionReference);
+                    break;
+            }
+
+
+            return base.InternalSubscribe(subscription);
+        }
+
+        /// <summary>
+        /// Publishes the <see cref="PubSubEvent"/>.
+        /// </summary>
+        public virtual void Publish()
+        {
+            base.InternalPublish();
+        }
+
+        /// <summary>
+        /// Removes the first subscriber matching <see cref="Action"/> from the subscribers' list.
+        /// </summary>
+        /// <param name="subscriber">The <see cref="Action"/> used when subscribing to the event.</param>
+        public virtual void Unsubscribe(Action subscriber)
+        {
+            lock (Subscriptions)
+            {
+                IEventSubscription eventSubscription = Subscriptions.Cast<EventSubscription>().FirstOrDefault(evt => evt.Action == subscriber);
+                if (eventSubscription != null)
+                {
+                    Subscriptions.Remove(eventSubscription);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if there is a subscriber matching <see cref="Action"/>.
+        /// </summary>
+        /// <param name="subscriber">The <see cref="Action"/> used when subscribing to the event.</param>
+        /// <returns><see langword="true"/> if there is an <see cref="Action"/> that matches; otherwise <see langword="false"/>.</returns>
+        public virtual bool Contains(Action subscriber)
+        {
+            IEventSubscription eventSubscription;
+            lock (Subscriptions)
+            {
+                eventSubscription = Subscriptions.Cast<EventSubscription>().FirstOrDefault(evt => evt.Action == subscriber);
+            }
+            return eventSubscription != null;
+        }
+    }
+
     /// <summary>
     /// Defines a class that manages publication and subscription to events.
     /// </summary>
@@ -88,7 +215,7 @@ namespace Prism.Events
         /// <remarks>
         /// If <paramref name="keepSubscriberReferenceAlive"/> is set to <see langword="false" />, <see cref="PubSubEvent{TPayload}"/> will maintain a <see cref="WeakReference"/> to the Target of the supplied <paramref name="action"/> delegate.
         /// If not using a WeakReference (<paramref name="keepSubscriberReferenceAlive"/> is <see langword="true" />), the user must explicitly call Unsubscribe for the event when disposing the subscriber in order to avoid memory leaks or unexpected behavior.
-        /// 
+        ///
         /// The PubSubEvent collection is thread-safe.
         /// </remarks>
         public virtual SubscriptionToken Subscribe(Action<TPayload> action, ThreadOption threadOption, bool keepSubscriberReferenceAlive, Predicate<TPayload> filter)


### PR DESCRIPTION
The non-generic version of the PubSubEvent does not have an option for a filter predicate.
Fix for Issue #482 
