### PR TITLE
Add RegisterTypeForNavigation to IKernel and NinjectModule

### DIFF
--- a/Source/Wpf/Prism.Ninject.Wpf/NinjectExtensions.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/NinjectExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Ninject;
+using Ninject.Modules;
 using Ninject.Parameters;
 
 namespace Prism.Ninject
@@ -39,6 +40,15 @@ namespace Prism.Ninject
             {
                 binding.InTransientScope();
             }
+        }
+        public static void RegisterTypeForNavigation<T>(this NinjectModule ninjectModule)
+        {
+            ninjectModule.Bind<object>().To<T>().Named(typeof(T).Name);
+        }
+
+        public static void RegisterTypeForNavigation<T>(this IKernel kernel)
+        {
+            kernel.Bind<object>().To<T>().Named(typeof(T).Name);
         }
     }
 }

--- a/Source/Wpf/Prism.Ninject.Wpf/NinjectExtensions.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/NinjectExtensions.cs
@@ -41,14 +41,29 @@ namespace Prism.Ninject
                 binding.InTransientScope();
             }
         }
-        public static void RegisterTypeForNavigation<T>(this NinjectModule ninjectModule)
+
+        /// <summary>
+        /// Registers an object for navigation.
+        /// </summary>
+        /// <typeparam name="T">The Type of the object to register</typeparam>
+        /// <param name="name">The unique name to register with the object.</param>
+        public static void RegisterTypeForNavigation<T>(this NinjectModule ninjectModule, string name = null)
         {
-            ninjectModule.Bind<object>().To<T>().Named(typeof(T).Name);
+            Type type = typeof(T);
+            string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
+            ninjectModule.Bind<object>().To<T>().Named(viewName);
         }
 
-        public static void RegisterTypeForNavigation<T>(this IKernel kernel)
+        /// <summary>
+        /// Registers an object for navigation.
+        /// </summary>
+        /// <typeparam name="T">The Type of the object to register</typeparam>
+        /// <param name="name">The unique name to register with the object.</param>
+        public static void RegisterTypeForNavigation<T>(this IKernel kernel, string name = null)
         {
-            kernel.Bind<object>().To<T>().Named(typeof(T).Name);
+            Type type = typeof(T);
+            string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
+            kernel.Bind<object>().To<T>().Named(viewName);
         }
     }
 }


### PR DESCRIPTION
Add extensions for RegisterTypeForNavigation to IKernel  and Ninjectmodule, similar to the method available on Container for Unity/MEF.

(in response to logged issue #534)