### PR TITLE
Added IApplicationProvider

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ApplicationProviderMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ApplicationProviderMock.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Common;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Mocks
+{
+    public class ApplicationProviderMock : IApplicationProvider
+    {
+        public ApplicationProviderMock()
+        {
+            MainPage = new ContentPage()
+            {
+                Title = "MainPage"
+            };
+        }
+
+        public Page MainPage { get; set; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageDialogServiceMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageDialogServiceMock.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Services;
+﻿using Prism.Common;
+using Prism.Services;
 using System.Threading.Tasks;
 
 namespace Prism.Forms.Tests.Mocks
@@ -11,7 +12,8 @@ namespace Prism.Forms.Tests.Mocks
         /// Create an instance of <see cref="PageDialogServiceMock"/> with the pressed button on any alert/sheet is <paramref name="pressedButton"/>
         /// </summary>
         /// <param name="pressedButton"></param>
-        public PageDialogServiceMock(string pressedButton)
+        public PageDialogServiceMock(string pressedButton, IApplicationProvider applicationProvider)
+            : base(applicationProvider)
         {
             this.pressedButton = pressedButton;
         }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Navigation;
+﻿using Prism.Common;
+using Prism.Navigation;
 using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks
@@ -7,7 +8,8 @@ namespace Prism.Forms.Tests.Mocks
     {
         PageNavigationContainerMock _containerMock;
 
-        public PageNavigationServiceMock(PageNavigationContainerMock containerMock)
+        public PageNavigationServiceMock(PageNavigationContainerMock containerMock, IApplicationProvider applicationProviderMock)
+            : base(applicationProviderMock)
         {
             _containerMock = containerMock;
         }

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -12,6 +12,7 @@ namespace Prism.Forms.Tests.Navigation
     public class PageNavigationServiceFixture : IDisposable
     {
         PageNavigationContainerMock _container;
+        IApplicationProvider _applicationProvider;
 
         public PageNavigationServiceFixture()
         {
@@ -33,12 +34,14 @@ namespace Prism.Forms.Tests.Navigation
 
             _container.Register("TabbedPage", typeof(TabbedPageMock));
             _container.Register("CarouselPage", typeof(CarouselPageMock));
+
+            _applicationProvider = new ApplicationProviderMock();
         }
 
         [Fact]
         public void IPageAware_NullByDefault()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var page = ((IPageAware)navigationService).Page;
             Assert.Null(page);
         }
@@ -46,7 +49,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public void Navigate_ToUnregisteredPage_ByName()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -58,7 +61,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ByName()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -71,7 +74,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void NavigateAsync_ToContentPage_ByName()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.NavigationPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -84,7 +87,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ByRelativeUri()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -97,7 +100,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ByObject()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -110,7 +113,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ByName_WithNavigationParameters()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -130,10 +133,10 @@ namespace Prism.Forms.Tests.Navigation
             Assert.Equal(3, viewModel.NavigatedToParameters["id"]);
         }
 
-        [Fact(Skip = "NavigationService relies on Application.Current.MainPage which cannot be tested because it's null")]
+        [Fact]
         public async void Navigate_ToContentPage_ThenGoBack()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -147,11 +150,11 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(rootPage.Navigation.ModalStack.Count == 0);
         }
 
-        [Fact(Skip = "NavigationService relies on Application.Current.MainPage which cannot be tested because it's null")]
+        [Fact]
         public async void NavigateAsync_ToContentPage_ThenGoBack()
         {
             var pageMock = new ContentPageMock();
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             ((IPageAware)navigationService).Page = pageMock;
 
             var rootPage = new NavigationPage(pageMock);
@@ -172,7 +175,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ViewModelHasINavigationAware()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -185,9 +188,9 @@ namespace Prism.Forms.Tests.Navigation
             Assert.NotNull(viewModel);
             Assert.True(viewModel.OnNavigatedToCalled);
 
-            var nextPageNavService = new PageNavigationServiceMock(_container);
-            ((IPageAware)navigationService).Page = rootPage.Navigation.ModalStack[0];
-            await navigationService.NavigateAsync("NavigationPage");
+            var nextPageNavService = new PageNavigationServiceMock(_container, _applicationProvider);
+            ((IPageAware)nextPageNavService).Page = rootPage.Navigation.ModalStack[0];
+            await nextPageNavService.NavigateAsync("NavigationPage");
 
             Assert.True(viewModel.OnNavigatedFromCalled);
         }
@@ -195,7 +198,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_PageHasINavigationAware()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -207,10 +210,10 @@ namespace Prism.Forms.Tests.Navigation
             Assert.NotNull(contentPage);
             Assert.True(contentPage.OnNavigatedToCalled);
 
-            var nextPageNavService = new PageNavigationServiceMock(_container);
-            ((IPageAware)navigationService).Page = contentPage;
+            var nextPageNavService = new PageNavigationServiceMock(_container, _applicationProvider);
+            ((IPageAware)nextPageNavService).Page = contentPage;
 
-            await navigationService.NavigateAsync("NavigationPage");
+            await nextPageNavService.NavigateAsync("NavigationPage");
 
             Assert.True(contentPage.OnNavigatedFromCalled);
             Assert.True(contentPage.Navigation.ModalStack.Count == 1);
@@ -219,7 +222,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_PageHasIConfirmNavigation_True()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new ContentPageMock();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -234,7 +237,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_PageHasIConfirmNavigation_False()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new ContentPageMock();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -252,7 +255,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ViewModelHasIConfirmNavigation_True()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage() { BindingContext = new ContentPageMockViewModel() };
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -269,7 +272,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ViewModelHasIConfirmNavigation_False()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new ContentPage() { BindingContext = new ContentPageMockViewModel() };
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -288,7 +291,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToNavigatonPage_ViewModelHasINavigationAware()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -305,7 +308,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToMasterDetailPage_ViewModelHasINavigationAware()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -324,7 +327,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToTabbedPage_ByName_ViewModelHasINavigationAware()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -343,7 +346,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToCarouselPage_ByName_ViewModelHasINavigationAware()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -362,7 +365,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_ContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -375,7 +378,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_NavigationPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -388,7 +391,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_NavigationPage_ToContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -401,7 +404,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_EmptyNavigationPage_ToContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -414,7 +417,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_NavigationPageWithNavigationStack_ToContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -427,7 +430,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_NavigationPageWithDifferentNavigationStack_ToContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -440,7 +443,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_TabbedPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -453,7 +456,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_CarouselPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -466,7 +469,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_MasterDetailPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -479,7 +482,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_FromMasterDetailPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new MasterDetailPageMock();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -497,7 +500,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_FromMasterDetailPage_ToSamePage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new MasterDetailPageMock();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -517,7 +520,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_ToEmptyMasterDetailPage_ToContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -532,7 +535,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_ToEmptyMasterDetailPage_ToNavigationPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -547,7 +550,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_ToMasterDetailPage_ToDifferentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -562,7 +565,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_ToMasterDetailPage_ToSamePage_ToTabbedPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -580,7 +583,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_ToTabbedPage_ToPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
@@ -595,7 +598,7 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void DeepNavigate_ToCarouselPage_ToContentPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container);
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -49,13 +49,16 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public void Navigate_ToUnregisteredPage_ByName()
         {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
-            var rootPage = new Xamarin.Forms.ContentPage();
-            ((IPageAware)navigationService).Page = rootPage;
+            Assert.ThrowsAsync<NullReferenceException>(async () =>
+            {
+                var navigationService = new PageNavigationServiceMock(_container, _applicationProvider);
+                var rootPage = new Xamarin.Forms.ContentPage();
+                ((IPageAware)navigationService).Page = rootPage;
 
-            navigationService.NavigateAsync("UnregisteredPage");
+                await navigationService.NavigateAsync("UnregisteredPage");
 
-            Assert.True(rootPage.Navigation.ModalStack.Count == 0);
+                Assert.True(rootPage.Navigation.ModalStack.Count == 0);
+            });
         }
 
         [Fact]

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -47,9 +47,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BootstrapperFixture.cs" />
+    <Compile Include="Common\ApplicationProviderFixture.cs" />
     <Compile Include="Common\PageNavigationInfoFixture.cs" />
     <Compile Include="Common\PageNavigationRegistryFixture.cs" />
     <Compile Include="Common\UriParsingHelperFixture.cs" />
+    <Compile Include="Mocks\ApplicationProviderMock.cs" />
     <Compile Include="Mocks\PageNavigationContainerMock.cs" />
     <Compile Include="Mocks\PageNavigationServiceMock.cs" />
     <Compile Include="Mocks\PageDialogServiceMock.cs" />

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -47,7 +47,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BootstrapperFixture.cs" />
-    <Compile Include="Common\ApplicationProviderFixture.cs" />
     <Compile Include="Common\PageNavigationInfoFixture.cs" />
     <Compile Include="Common\PageNavigationRegistryFixture.cs" />
     <Compile Include="Common\UriParsingHelperFixture.cs" />

--- a/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Prism.Commands;
+using Prism.Common;
 using Prism.Forms.Tests.Mocks;
 using Prism.Services;
 using System;
@@ -9,10 +10,17 @@ namespace Prism.Forms.Tests.Services
 {
     public class PageDialogServiceFixture
     {
+        IApplicationProvider _applicationProvider;
+
+        public PageDialogServiceFixture()
+        {
+            _applicationProvider = new ApplicationProviderMock();
+        }
+
         [Fact]
         public async Task DisplayActionSheetNoButtons_ShouldThrowException()
         {
-            var service = new PageDialogServiceMock("cancel");
+            var service = new PageDialogServiceMock("cancel", _applicationProvider);
             var argumentException = await Assert.ThrowsAsync<ArgumentException>(() => service.DisplayActionSheet(null, null));
             Assert.Equal(typeof(ArgumentException), argumentException.GetType());
         }
@@ -20,7 +28,7 @@ namespace Prism.Forms.Tests.Services
         [Fact]
         public async Task DisplayActionSheet_CancelButtonPressed()
         {
-            var service = new PageDialogServiceMock("cancel");
+            var service = new PageDialogServiceMock("cancel", _applicationProvider);
             var cancelButtonPressed = false;
             var cancelCommand = new DelegateCommand(() => cancelButtonPressed = true);
             var button = ActionSheetButton.CreateCancelButton("cancel", cancelCommand);
@@ -31,7 +39,7 @@ namespace Prism.Forms.Tests.Services
         [Fact]
         public async Task DisplayActionSheet_DestroyButtonPressed()
         {
-            var service = new PageDialogServiceMock("destroy");
+            var service = new PageDialogServiceMock("destroy", _applicationProvider);
             var destroyButtonPressed = false;
             var cancelCommand = new DelegateCommand(() => destroyButtonPressed = false);
             var button = ActionSheetButton.CreateCancelButton("cancel", cancelCommand);
@@ -44,7 +52,7 @@ namespace Prism.Forms.Tests.Services
         [Fact]
         public async Task DisplayActionSheet_NoButtonPressed()
         {
-            var service = new PageDialogServiceMock(null);
+            var service = new PageDialogServiceMock(null, _applicationProvider);
             var buttonPressed = false;
             var cancelCommand = new DelegateCommand(() => buttonPressed = true);
             var button = ActionSheetButton.CreateCancelButton("cancel", cancelCommand);
@@ -57,7 +65,7 @@ namespace Prism.Forms.Tests.Services
         [Fact]
         public async Task DisplayActionSheet_OtherButtonPressed()
         {
-            var service = new PageDialogServiceMock("other");
+            var service = new PageDialogServiceMock("other", _applicationProvider);
             var buttonPressed = false;
             var command = new DelegateCommand(() => buttonPressed = true);
             var button = ActionSheetButton.CreateButton("other", command);
@@ -68,7 +76,7 @@ namespace Prism.Forms.Tests.Services
         [Fact]
         public async Task DisplayActionSheet_NullButtonAndOtherButtonPressed()
         {
-            var service = new PageDialogServiceMock("other");
+            var service = new PageDialogServiceMock("other", _applicationProvider);
             var buttonPressed = false;
             var command = new DelegateCommand(() => buttonPressed = true);
             var button = ActionSheetButton.CreateButton("other", command);

--- a/Source/Xamarin/Prism.Forms/Common/ApplicationProvider.cs
+++ b/Source/Xamarin/Prism.Forms/Common/ApplicationProvider.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms;
+
+namespace Prism.Common
+{
+    public class ApplicationProvider : IApplicationProvider
+    {
+        public Page MainPage
+        {
+            get { return Application.Current.MainPage; }
+            set { Application.Current.MainPage = value; }
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Common/IApplicationProvider.cs
+++ b/Source/Xamarin/Prism.Forms/Common/IApplicationProvider.cs
@@ -1,0 +1,9 @@
+﻿using Xamarin.Forms;
+
+namespace Prism.Common
+{
+    public interface IApplicationProvider
+    {
+        Page MainPage { get; set; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -321,7 +321,7 @@ namespace Prism.Navigation
             var segmentName = UriParsingHelper.GetSegmentName(segment);
             var page = CreatePage(segmentName);
             if (page == null)
-                throw new InvalidOperationException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
+                throw new NullReferenceException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
 
             return page;
         }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -12,11 +12,18 @@ namespace Prism.Navigation
     /// </summary>
     public abstract class PageNavigationService : INavigationService, IPageAware, IDisposable
     {
+        IApplicationProvider _applicationProvider;
+
         private Page _page;
         Page IPageAware.Page
         {
             get { return _page; }
             set { _page = value; }
+        }
+
+        public PageNavigationService(IApplicationProvider applicationProvider)
+        {
+            _applicationProvider = applicationProvider;
         }
 
         /// <summary>
@@ -336,7 +343,7 @@ namespace Prism.Navigation
             return useModalNavigation;
         }
 
-        static Page GetOnNavigatedToTarget(Page page, bool useModalNavigation)
+        Page GetOnNavigatedToTarget(Page page, bool useModalNavigation)
         {
             Page target = null;
 
@@ -346,7 +353,7 @@ namespace Prism.Navigation
 
                 //MainPage is not included in the navigation stack, so if we can't find the previous page above
                 //let's assume they are going back to the MainPage
-                target = GetOnNavigatedToTargetFromChild(previousPage ?? Application.Current.MainPage);
+                target = GetOnNavigatedToTargetFromChild(previousPage ?? _applicationProvider.MainPage);
             }
             else
             {
@@ -402,14 +409,14 @@ namespace Prism.Navigation
             return stackCount - 1;
         }
 
-        async static Task DoPush(Page currentPage, Page page, bool? useModalNavigation, bool animated)
+        async Task DoPush(Page currentPage, Page page, bool? useModalNavigation, bool animated)
         {
             if (page == null)
                 return;
 
             if (currentPage == null)
             {
-                Application.Current.MainPage = page;
+                _applicationProvider.MainPage = page;
             }
             else
             {
@@ -525,7 +532,7 @@ namespace Prism.Navigation
 
         Page GetCurrentPage()
         {
-            return _page != null ? _page : Application.Current.MainPage;
+            return _page != null ? _page : _applicationProvider.MainPage;
         }
 
         public void Dispose()

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -55,6 +55,8 @@
   <ItemGroup>
     <Compile Include="ApplicationBase.cs" />
     <Compile Include="Bootstrapper.cs" />
+    <Compile Include="Common\ApplicationProvider.cs" />
+    <Compile Include="Common\IApplicationProvider.cs" />
     <Compile Include="Common\PageNavigationInfo.cs" />
     <Compile Include="Common\PageNavigationRegistry.cs" />
     <Compile Include="Common\UriParsingHelper.cs" />

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Prism.Common;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Xamarin.Forms;
 
 namespace Prism.Services
 {
@@ -10,6 +10,13 @@ namespace Prism.Services
     /// </summary>
     public class PageDialogService : IPageDialogService
     {
+        IApplicationProvider _applicationProvider;
+
+        public PageDialogService(IApplicationProvider applicationProvider)
+        {
+            _applicationProvider = applicationProvider;
+        }
+
         /// <summary>
         /// Presents an alert dialog to the application user with an accept and a cancel button.
         /// </summary>
@@ -23,7 +30,7 @@ namespace Prism.Services
         /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
         public virtual async Task<bool> DisplayAlert(string title, string message, string acceptButton, string cancelButton)
         {
-            return await Application.Current.MainPage.DisplayAlert(title, message, acceptButton, cancelButton);
+            return await _applicationProvider.MainPage.DisplayAlert(title, message, acceptButton, cancelButton);
         }
 
         /// <summary>
@@ -38,7 +45,7 @@ namespace Prism.Services
         /// <returns></returns>
         public virtual async Task DisplayAlert(string title, string message, string cancelButton)
         {
-            await Application.Current.MainPage.DisplayAlert(title, message, cancelButton);
+            await _applicationProvider.MainPage.DisplayAlert(title, message, cancelButton);
         }
 
         /// <summary>
@@ -51,7 +58,7 @@ namespace Prism.Services
         /// <returns>Text for the pressed button</returns>
         public virtual async Task<string> DisplayActionSheet(string title, string cancelButton, string destroyButton, params string[] otherButtons)
         {
-            return await Application.Current.MainPage.DisplayActionSheet(title, cancelButton, destroyButton, otherButtons);
+            return await _applicationProvider.MainPage.DisplayActionSheet(title, cancelButton, destroyButton, otherButtons);
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Ninject.Forms/Navigation/NinjectNavigationService.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/Navigation/NinjectNavigationService.cs
@@ -1,4 +1,5 @@
 ﻿using Ninject;
+using Prism.Common;
 using Prism.Navigation;
 using Xamarin.Forms;
 
@@ -8,7 +9,8 @@ namespace Prism.Ninject.Navigation
     {
         IKernel _kernel;
 
-        public NinjectNavigationService(IKernel kernel)
+        public NinjectNavigationService(IKernel kernel, IApplicationProvider applicationProvider)
+            : base (applicationProvider)
         {
             _kernel = kernel;
         }

--- a/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
@@ -86,6 +86,7 @@ namespace Prism.Ninject
             Kernel.Bind<ILoggerFacade>().ToConstant(Logger).InSingletonScope();
             Kernel.Bind<IModuleCatalog>().ToConstant(ModuleCatalog).InSingletonScope();
 
+            Kernel.Bind<IApplicationProvider>().To<ApplicationProvider>().InSingletonScope();
             Kernel.Bind<IModuleManager>().To<ModuleManager>().InSingletonScope();
             Kernel.Bind<IModuleInitializer>().To<NinjectModuleInitializer>().InSingletonScope();
             Kernel.Bind<IEventAggregator>().To<EventAggregator>().InSingletonScope();

--- a/Source/Xamarin/Prism.Unity.Forms/Navigation/UnityPageNavigationService.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/Navigation/UnityPageNavigationService.cs
@@ -9,7 +9,8 @@ namespace Prism.Unity.Navigation
     {
         IUnityContainer _container;
 
-        public UnityPageNavigationService(IUnityContainer container)
+        public UnityPageNavigationService(IUnityContainer container, IApplicationProvider applicationProvider)
+            : base(applicationProvider)
         {
             _container = container;
         }

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -76,6 +76,7 @@ namespace Prism.Unity
             Container.RegisterInstance<ILoggerFacade>(Logger);
             Container.RegisterInstance<IModuleCatalog>(ModuleCatalog);
 
+            Container.RegisterType<IApplicationProvider, ApplicationProvider>(new ContainerControlledLifetimeManager());
             Container.RegisterType<IModuleManager, ModuleManager>(new ContainerControlledLifetimeManager());
             Container.RegisterType<IModuleInitializer, UnityModuleInitializer>(new ContainerControlledLifetimeManager());
             Container.RegisterType<IEventAggregator, EventAggregator>(new ContainerControlledLifetimeManager());


### PR DESCRIPTION
To help keep Prism for XF testable, I abstracted away the dependency on
Application.Current (which isn't testable) and replaced it with
IApplicationProvider.