### PR TITLE
Extended ViewModelLocator to override conventions

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -1,5 +1,7 @@
-﻿using HelloWorld.Views;
+﻿using HelloWorld.ViewModels;
+using HelloWorld.Views;
 using Prism.Modularity;
+using Prism.Mvvm;
 using Prism.Unity;
 
 namespace HelloWorld
@@ -16,6 +18,9 @@ namespace HelloWorld
             Container.RegisterTypeForNavigation<MainPage>();
             Container.RegisterTypeForNavigation<MyNavigationPage>();
             Container.RegisterTypeForNavigation<MyMasterDetail>();
+
+            //override ViewModelLocator conventions and use a ViewModel based on its type
+            ViewModelLocationProvider.Register<MainPage, SomeOtherViewModel>();
         }
 
         protected override void ConfigureModuleCatalog()

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Converters\NonNullToBooleanConverter.cs" />
     <Compile Include="Interfaces\IMessageService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ViewModels\SomeOtherViewModel.cs" />
     <Compile Include="ViewModels\MainPageViewModel.cs" />
     <Compile Include="ViewModels\MyMasterDetailViewModel.cs" />
     <Compile Include="ViewModels\MyNavigationPageViewModel.cs" />

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/MainPageViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/MainPageViewModel.cs
@@ -27,7 +27,7 @@ namespace HelloWorld.ViewModels
 
         void LoadModuleA()
         {
-            _moduleManager.LoadModule("ModuleA");
+            //_moduleManager.LoadModule("ModuleA");
         }
     }
 }

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/SomeOtherViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/SomeOtherViewModel.cs
@@ -1,0 +1,34 @@
+﻿using HelloWorld.Interfaces;
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Modularity;
+using System;
+using Prism.Services;
+
+namespace HelloWorld.ViewModels
+{
+    public class SomeOtherViewModel : ViewModelBase
+    {
+        IPageDialogService _dialogService;
+
+        string _title = "Some Other ViewModel that doesn't follow the ViewModelLocatorRules";
+        public string Title
+        {
+            get { return _title; }
+            set { SetProperty(ref _title, value); }
+        }
+
+        public DelegateCommand LoadModuleACommand { get; set; }
+
+        public SomeOtherViewModel(IPageDialogService dialogService)
+        {
+            _dialogService = dialogService;
+            LoadModuleACommand = new DelegateCommand(ShowDialog);
+        }
+
+        void ShowDialog()
+        {
+            _dialogService.DisplayAlert("Hello from SomeOtherViewModel", "This is a message from an exception to the ViewModelLocator rules.", "Cool");
+        }
+    }
+}

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MainPage.xaml
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MainPage.xaml
@@ -7,7 +7,7 @@
              Title="MainPage">
   <StackLayout>
     <Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
-    <!--<Button Command="{Binding LoadModuleACommand}" Text="Load Module A" />-->
+    <Button Command="{Binding LoadModuleACommand}" Text="Load Module A" />
   </StackLayout>
 
 </ContentPage>

--- a/Source/Prism.Tests/Mvvm/ViewModelLocationProviderFixture.cs
+++ b/Source/Prism.Tests/Mvvm/ViewModelLocationProviderFixture.cs
@@ -108,6 +108,58 @@ namespace Prism.Tests.Mvvm
                 });
         }
 
+        [Fact]
+        public void ShouldUseCustomFactoryWhenSet_Generic()
+        {
+            ResetViewModelLocationProvider();
+
+            var view = new Mock();
+
+            string viewModel = "Test String";
+            ViewModelLocationProvider.Register<Mock>(() => viewModel);
+
+            ViewModelLocationProvider.AutoWireViewModelChanged(view, (v, vm) =>
+            {
+                Assert.NotNull(v);
+                Assert.NotNull(vm);
+                Assert.Equal(viewModel, vm);
+            });
+        }
+
+        [Fact]
+        public void ShouldUseCustomTypeWhenSet()
+        {
+            ResetViewModelLocationProvider();
+
+            var view = new Mock();
+
+            ViewModelLocationProvider.Register(view.GetType().ToString(), typeof(ViewModelLocationProviderFixture));
+
+            ViewModelLocationProvider.AutoWireViewModelChanged(view, (v, vm) =>
+            {
+                Assert.NotNull(v);
+                Assert.NotNull(vm);
+                Assert.IsType<ViewModelLocationProviderFixture>(vm);
+            });
+        }
+
+        [Fact]
+        public void ShouldUseCustomTypeWhenSet_Generic()
+        {
+            ResetViewModelLocationProvider();
+
+            var view = new Mock();
+
+            ViewModelLocationProvider.Register<Mock, ViewModelLocationProviderFixture>();
+
+            ViewModelLocationProvider.AutoWireViewModelChanged(view, (v, vm) =>
+            {
+                Assert.NotNull(v);
+                Assert.NotNull(vm);
+                Assert.IsType<ViewModelLocationProviderFixture>(vm);
+            });
+        }
+
         private static void ResetViewModelLocationProvider()
         {
             Type staticType = typeof(ViewModelLocationProvider);


### PR DESCRIPTION
The ViewModelLocationProvider has a new Register method which allows a developer to decide which ViewModel to use based on a VM type.  This means that the conventions can be bypassed, and the dev can supply which ViewModel to use instead.