### PR TITLE
made the INavigationService more extensible

### DIFF
--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -31,7 +31,7 @@ namespace Prism.Navigation
         /// </summary>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        public async Task GoBackAsync(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+        public virtual async Task GoBackAsync(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             var page = GetCurrentPage();
             var segmentParameters = GetSegmentParameters(null, parameters);
@@ -58,7 +58,7 @@ namespace Prism.Navigation
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        public async Task NavigateAsync<T>(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+        public virtual async Task NavigateAsync<T>(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             await NavigateAsync(typeof(T).FullName, parameters, useModalNavigation, animated);
         }
@@ -70,7 +70,7 @@ namespace Prism.Navigation
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        public async Task NavigateAsync(string name, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+        public virtual async Task NavigateAsync(string name, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             await NavigateAsync(new Uri(name, UriKind.RelativeOrAbsolute), parameters, useModalNavigation, animated);
         }
@@ -86,7 +86,7 @@ namespace Prism.Navigation
         /// <example>
         /// Navigate(new Uri("MainPage?id=3&name=brian", UriKind.RelativeSource), parameters);
         /// </example>
-        public async Task NavigateAsync(Uri uri, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+        public virtual async Task NavigateAsync(Uri uri, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             var navigationSegments = UriParsingHelper.GetUriSegments(uri);
 

--- a/Source/Xamarin/Prism.Ninject.Forms/Navigation/NinjectPageNavigationService.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/Navigation/NinjectPageNavigationService.cs
@@ -5,11 +5,11 @@ using Xamarin.Forms;
 
 namespace Prism.Ninject.Navigation
 {
-    public class NinjectNavigationService : PageNavigationService
+    public class NinjectPageNavigationService : PageNavigationService
     {
         IKernel _kernel;
 
-        public NinjectNavigationService(IKernel kernel, IApplicationProvider applicationProvider)
+        public NinjectPageNavigationService(IKernel kernel, IApplicationProvider applicationProvider)
             : base (applicationProvider)
         {
             _kernel = kernel;

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -56,7 +56,7 @@
     <Compile Include="Extensions\DependencyServiceBindingResolver.cs" />
     <Compile Include="Extensions\DependencyServiceProvider.cs" />
     <Compile Include="Modularity\NinjectModuleInitializer.cs" />
-    <Compile Include="Navigation\NinjectNavigationService.cs" />
+    <Compile Include="Navigation\NinjectPageNavigationService.cs" />
     <Compile Include="PrismApplication.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NinjectExtensions.cs" />

--- a/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
@@ -19,6 +19,8 @@ namespace Prism.Ninject
 {
     public abstract class PrismApplication : PrismApplicationBase
     {
+        const string _navigationServiceName = "NinjectPageNavigationService";
+
         /// <summary>
         /// The Ninject Kernel
         /// </summary>
@@ -52,7 +54,7 @@ namespace Prism.Ninject
                 var page = view as Page;
                 if (page != null)
                 {
-                    var navService = Kernel.Get<NinjectNavigationService>();
+                    var navService = Kernel.Get<INavigationService>(_navigationServiceName);
                     ((IPageAware)navService).Page = page;
 
                     overrides = new IParameter[]
@@ -87,6 +89,7 @@ namespace Prism.Ninject
             Kernel.Bind<IModuleCatalog>().ToConstant(ModuleCatalog).InSingletonScope();
 
             Kernel.Bind<IApplicationProvider>().To<ApplicationProvider>().InSingletonScope();
+            Kernel.Bind<INavigationService>().To<NinjectPageNavigationService>().Named(_navigationServiceName);
             Kernel.Bind<IModuleManager>().To<ModuleManager>().InSingletonScope();
             Kernel.Bind<IModuleInitializer>().To<NinjectModuleInitializer>().InSingletonScope();
             Kernel.Bind<IEventAggregator>().To<EventAggregator>().InSingletonScope();
@@ -96,7 +99,7 @@ namespace Prism.Ninject
 
         protected override INavigationService CreateNavigationService()
         {
-            return Kernel.Get<NinjectNavigationService>();
+            return Kernel.Get<INavigationService>(_navigationServiceName);
         }
 
         protected override void InitializeModules()

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -17,6 +17,8 @@ namespace Prism.Unity
 {
     public abstract class PrismApplication : PrismApplicationBase
     {
+        const string _navigationServiceName = "UnityPageNavigationService";
+
         public IUnityContainer Container { get; protected set; }
 
         public override void Initialize()
@@ -46,7 +48,7 @@ namespace Prism.Unity
                 var page = view as Page;
                 if (page != null)
                 {
-                    var navService = Container.Resolve<UnityPageNavigationService>();
+                    var navService = Container.Resolve<INavigationService>(_navigationServiceName);
                     ((IPageAware)navService).Page = page;
 
                     overrides = new ParameterOverrides
@@ -66,7 +68,7 @@ namespace Prism.Unity
 
         protected override INavigationService CreateNavigationService()
         {
-            return Container.Resolve<UnityPageNavigationService>();
+            return Container.Resolve<INavigationService>(_navigationServiceName);
         }
 
         protected virtual void ConfigureContainer()
@@ -77,6 +79,7 @@ namespace Prism.Unity
             Container.RegisterInstance<IModuleCatalog>(ModuleCatalog);
 
             Container.RegisterType<IApplicationProvider, ApplicationProvider>(new ContainerControlledLifetimeManager());
+            Container.RegisterType<INavigationService, UnityPageNavigationService>(_navigationServiceName);
             Container.RegisterType<IModuleManager, ModuleManager>(new ContainerControlledLifetimeManager());
             Container.RegisterType<IModuleInitializer, UnityModuleInitializer>(new ContainerControlledLifetimeManager());
             Container.RegisterType<IEventAggregator, EventAggregator>(new ContainerControlledLifetimeManager());


### PR DESCRIPTION
made the INavigationService methods virtual, and added a named registration for the service so that it is easier to override Prism's implementation.