### PR TITLE
View model navigation contraints

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
@@ -1,8 +1,9 @@
-﻿using Prism.Navigation;
+﻿using Prism.Mvvm;
+using Prism.Navigation;
 
 namespace Prism.Forms.Tests.Mocks.ViewModels
 {
-    public class ViewModelBase : INavigationAware
+    public class ViewModelBase : BindableBase, INavigationAware
     {
         public NavigationParameters NavigatedToParameters { get; private set; }
         public NavigationParameters NavigatedFromParameters { get; private set; }

--- a/Source/Xamarin/Prism.Forms/Navigation/INavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/INavigationService.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Threading.Tasks;
+using Prism.Mvvm;
 
 namespace Prism.Navigation
 {
@@ -17,13 +18,14 @@ namespace Prism.Navigation
         Task GoBackAsync(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true);
 
         /// <summary>
-        /// Initiates navigation to the target specified by the <typeparamref name="T"/>.
+        /// Initiates navigation to the target specified by the <typeparamref name="TViewModel"/>.
         /// </summary>
-        /// <typeparam name="T">The type which will be used to identify the name of the navigation target.</typeparam>
+        /// <typeparam name="TViewModel">The type which will be used to identify the name of the navigation target. Must derive from BindableBase.</typeparam>
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        Task NavigateAsync<T>(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true);
+        Task NavigateAsync<TViewModel>(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+            where TViewModel : BindableBase;
 
         /// <summary>
         /// Initiates navigation to the target specified by the <paramref name="uri"/>.

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Prism.Mvvm;
 #if TEST
 using Application = Prism.FormsApplication;
 #endif
@@ -56,15 +57,16 @@ namespace Prism.Navigation
         }
 
         /// <summary>
-        /// Initiates navigation to the target specified by the <typeparamref name="T"/>.
+        /// Initiates navigation to the target specified by the <typeparamref name="TViewModel"/>.
         /// </summary>
-        /// <typeparam name="T">The type which will be used to identify the name of the navigation target.</typeparam>
+        /// <typeparam name="TViewModel">The type which will be used to identify the name of the navigation target.</typeparam>
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        public virtual async Task NavigateAsync<T>(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+        public virtual async Task NavigateAsync<TViewModel>(NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+            where TViewModel : BindableBase
         {
-            await NavigateAsync(typeof(T).FullName, parameters, useModalNavigation, animated);
+            await NavigateAsync(typeof(TViewModel).FullName, parameters, useModalNavigation, animated);
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Ninject.Forms/NinjectExtensions.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/NinjectExtensions.cs
@@ -2,6 +2,7 @@
 using Ninject;
 using Xamarin.Forms;
 using Prism.Common;
+using Prism.Mvvm;
 
 namespace Prism.Ninject
 {
@@ -10,20 +11,20 @@ namespace Prism.Ninject
         /// <summary>
         /// Registers a Page for navigation using a convention based approach, which uses the name of the Type being passed in as the unique name.
         /// </summary>
-        /// <typeparam name="T">The Type of Page to register</typeparam>
-        public static void RegisterTypeForNavigation<T>(this IKernel kernel) where T : Page
+        /// <typeparam name="TView">The Type of Page to register</typeparam>
+        public static void RegisterTypeForNavigation<TView>(this IKernel kernel) where TView : Page
         {
-            kernel.RegisterTypeForNavigation<T>(typeof(T).Name);
+            kernel.RegisterTypeForNavigation<TView>(typeof(TView).Name);
         }
 
         /// <summary>
         /// Registers a Page for navigation.
         /// </summary>
-        /// <typeparam name="T">The Type of Page to register</typeparam>
+        /// <typeparam name="TView">The Type of Page to register</typeparam>
         /// <param name="name">The unique name to register with the Page</param>
-        public static void RegisterTypeForNavigation<T>(this IKernel kernel, string name) where T : Page
+        public static void RegisterTypeForNavigation<TView>(this IKernel kernel, string name) where TView : Page
         {
-            Type type = typeof(T);
+            Type type = typeof(TView);
             kernel.Bind<object>().To(type).Named(name);
 
             PageNavigationRegistry.Register(name, type);
@@ -32,15 +33,15 @@ namespace Prism.Ninject
         /// <summary>
         /// Registers a Page for navigation.
         /// </summary>
-        /// <typeparam name="T">The Type of Page to register</typeparam>
-        /// <typeparam name="C">The Class to use as the unique name for the Page</typeparam>
+        /// <typeparam name="TView">The Type of Page to register</typeparam>
+        /// <typeparam name="TViewModel">The BindableBase ViewModel to use as the unique name for the Page</typeparam>
         /// <param name="kernel"></param>
-        public static void RegisterTypeForNavigation<T, C>(this IKernel kernel)
-            where T : Page
-            where C : class
+        public static void RegisterTypeForNavigation<TView, TViewModel>(this IKernel kernel)
+            where TView : Page
+            where TViewModel : BindableBase
         {
-            Type type = typeof(T);
-            string name = typeof(C).FullName;
+            Type type = typeof(TView);
+            string name = typeof(TViewModel).FullName;
 
             kernel.Bind<object>().To(type).Named(name);
 

--- a/Source/Xamarin/Prism.Unity.Forms/UnityExtensions.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Microsoft.Practices.Unity;
 using Xamarin.Forms;
-using Prism.Navigation;
 using Prism.Common;
+using Prism.Mvvm;
 
 namespace Prism.Unity
 {
@@ -11,20 +11,20 @@ namespace Prism.Unity
         /// <summary>
         /// Registers a Page for navigation using a convention based approach, which uses the name of the Type being passed in as the unique name.
         /// </summary>
-        /// <typeparam name="T">The Type of Page to register</typeparam>
-        public static void RegisterTypeForNavigation<T>(this IUnityContainer container) where T : Page
+        /// <typeparam name="TView">The Type of Page to register</typeparam>
+        public static void RegisterTypeForNavigation<TView>(this IUnityContainer container) where TView : Page
         {
-            container.RegisterTypeForNavigation<T>(typeof(T).Name);
+            container.RegisterTypeForNavigation<TView>(typeof(TView).Name);
         }
 
         /// <summary>
         /// Registers a Page for navigation.
         /// </summary>
-        /// <typeparam name="T">The Type of Page to register</typeparam>
+        /// <typeparam name="TView">The Type of Page to register</typeparam>
         /// <param name="name">The unique name to register with the Page</param>
-        public static void RegisterTypeForNavigation<T>(this IUnityContainer container, string name) where T : Page
+        public static void RegisterTypeForNavigation<TView>(this IUnityContainer container, string name) where TView : Page
         {
-            Type type = typeof(T);
+            Type type = typeof(TView);
 
             container.RegisterType(typeof(object), type, name);
 
@@ -34,15 +34,15 @@ namespace Prism.Unity
         /// <summary>
         /// Registers a Page for navigation.
         /// </summary>
-        /// <typeparam name="T">The Type of Page to register</typeparam>
-        /// <typeparam name="C">The Class to use as the unique name for the Page</typeparam>
+        /// <typeparam name="TView">The Type of Page to register</typeparam>
+        /// <typeparam name="TViewModel">The BindableBase ViewModel to use as the unique name for the Page</typeparam>
         /// <param name="container"></param>
-        public static void RegisterTypeForNavigation<T, C>(this IUnityContainer container)
-            where T : Page
-            where C : class
+        public static void RegisterTypeForNavigation<TView, TViewModel>(this IUnityContainer container)
+            where TView : Page
+            where TViewModel : BindableBase
         {
-            Type type = typeof(T);
-            string name = typeof(C).FullName;
+            Type type = typeof(TView);
+            string name = typeof(TViewModel).FullName;
 
             container.RegisterType(typeof(object), type, name);
 


### PR DESCRIPTION
Updates Generic Type names across DI Navigation extensions, and INavigationService so that generic type is either TView or TViewModel so as to be more descriptive for developers. Requires TViewModel to derive from BindableBase.