### PR TITLE
Update target platform for Universal Windows projects

### DIFF
--- a/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
+++ b/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
+++ b/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Prism.Autofac.Windows</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -180,7 +180,7 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DocumentationFile>bin\Release-Signed\Prism.Autofac.Windows.xml</DocumentationFile>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
-	<SignAssembly>true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\..\prism.pfx</AssemblyOriginatorKeyFile>

--- a/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
+++ b/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Prism.SimpleInjector.Windows</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -178,7 +178,7 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DocumentationFile>bin\Release-Signed\Prism.Autofac.Windows.xml</DocumentationFile>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
-	<SignAssembly>true</SignAssembly>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\..\prism.pfx</AssemblyOriginatorKeyFile>

--- a/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
+++ b/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Prism.Unity.Windows</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Source/Windows10/Prism.Windows.Tests/Prism.Windows.Tests.csproj
+++ b/Source/Windows10/Prism.Windows.Tests/Prism.Windows.Tests.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Prism.Windows.Tests</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Prism.Windows</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -168,10 +168,10 @@
     <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=10.0.10240.0">
+    <SDKReference Include="WindowsDesktop, Version=10.0.10586.0">
       <Name>Windows Desktop Extensions for the UWP</Name>
     </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=10.0.10240.0">
+    <SDKReference Include="WindowsMobile, Version=10.0.10586.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>


### PR DESCRIPTION
I would like to be able to build prism without having old sdk installed. I don't know any reason to use outdated 10.0.10240.0 and I guess it's ok to increase target version.