### PR TITLE
Various Improvements to Templates for Xamarin Forms

### DIFF
--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
@@ -138,8 +138,19 @@
 					<File name="Resource.designer.cs" src="UnityApp.Droid/Resource.cs" />
 					<RawFile name="AboutResources.txt" src="UnityApp.Droid/AboutResources.txt" />
 					<Directory name="layout">
+						<RawFile name="splash.axml" src="UnityApp.Droid/splash-layout.axml" />
+						<RawFile name="tabs.axml" src="UnityApp.Droid/tabs-layout.axml" />
+						<RawFile name="toolbar.axml" src="UnityApp.Droid/toolbar-layout.axml" />
 					</Directory>
 					<Directory name="values">
+						<RawFile name="colors.xml" src="UnityApp.Droid/colors-values.xml" />
+						<RawFile name="styles.xml" src="UnityApp.Droid/styles-values.xml" />
+					</Directory>
+					<Directory name="values-v19">
+						<RawFile name="styles.xml" src="UnityApp.Droid/styles-values-v19.xml" />
+					</Directory>
+					<Directory name="values-v21">
+						<RawFile name="styles.xml" src="UnityApp.Droid/styles-values-v21.xml" />
 					</Directory>
 					<Directory name ="drawable">
 						<RawFile name="icon.png" src="UnityApp.Droid/icondrawable.png" />

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
@@ -134,7 +134,7 @@
 			</References>
 			<Files>
 				<File name="MainActivity.cs" src="UnityApp.Droid/MainActivity.cs" />
-				<File name="MainActivity.cs" src="UnityApp.Droid/SplashActivity.cs" />
+				<File name="SplashActivity.cs" src="UnityApp.Droid/SplashActivity.cs" />
 				<Directory name="Resources">
 					<File name="Resource.designer.cs" src="UnityApp.Droid/Resource.cs" />
 					<RawFile name="AboutResources.txt" src="UnityApp.Droid/AboutResources.txt" />

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
@@ -134,6 +134,7 @@
 			</References>
 			<Files>
 				<File name="MainActivity.cs" src="UnityApp.Droid/MainActivity.cs" />
+				<File name="MainActivity.cs" src="UnityApp.Droid/SplashActivity.cs" />
 				<Directory name="Resources">
 					<File name="Resource.designer.cs" src="UnityApp.Droid/Resource.cs" />
 					<RawFile name="AboutResources.txt" src="UnityApp.Droid/AboutResources.txt" />

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
@@ -78,7 +78,7 @@
 
 			</Files>
 			<Packages>
-				<Package Id="Xamarin.Forms" Version="2.3.0.38-pre2"/> 
+				<Package Id="Xamarin.Forms" Version="2.3.0.46-pre3"/> 
 				<Package ID="Xamarin.Insights" Version="1.12.3" if="AddInsightsNuget"/>
 				<Package Id="Prism.Core" Version="6.1.0"/>
 				<Package Id="Prism.Forms" Version="6.1.0-pre5"/>
@@ -111,7 +111,7 @@
 			
 			</Files>
 			<Packages>
-				<Package Id="Xamarin.Forms" Version="2.3.0.38-pre2"/>
+				<Package Id="Xamarin.Forms" Version="2.3.0.46-pre3"/>
 				<Package ID="Xamarin.TestCloud.Agent" Version="0.16.2" if="CreateUITestProject"/>
 				<Package Id="Prism.Core" Version="6.1.0"/>
 				<Package Id="Prism.Forms" Version="6.1.0-pre5"/>
@@ -175,7 +175,7 @@
 			</Files>
 			<Packages>
 				<Package Id="Xamarin.Android.Support.v4" Version="23.3.0" />
-				<Package Id="Xamarin.Forms" Version="2.3.0.38-pre2"/> 
+				<Package Id="Xamarin.Forms" Version="2.3.0.46-pre3"/> 
 				<Package Id="Prism.Core" Version="6.1.0"/>
 				<Package Id="Prism.Forms" Version="6.1.0-pre5"/>
 				<Package Id="Prism.Unity.Forms" Version="6.2.0-pre5"/>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/AndroidInitializer.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/AndroidInitializer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Prism.Unity;
+
+namespace ${Namespace}
+{
+	public class AndroidInitializer : IPlatformInitializer
+	{
+		public void RegisterTypes( IUnityContainer container )
+		{
+			// Register Android specific types here.
+		}
+	}
+}
+

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
@@ -1,25 +1,27 @@
 ﻿using System;
 
 using Android.App;
-using Android.Content;
 using Android.Content.PM;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+using Xamarin.Forms.Platform.Android;
 
 namespace ${Namespace}
 {
-	[Activity (Label = "${ProjectName}", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-	public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsApplicationActivity
-	{
-		protected override void OnCreate (Bundle bundle)
-		{
-			base.OnCreate (bundle);
+    [Activity (Label = "${ProjectName}", Icon = "@drawable/icon", ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    public class MainActivity : FormsAppCompatActivity
+    {
+        protected override void OnCreate( Bundle savedInstanceState )
+        {
+            TabLayoutResource = Resource.Layout.tabs;
+            ToolbarResource = Resource.Layout.toolbar;
 
-			global::Xamarin.Forms.Forms.Init (this, bundle);
+            base.OnCreate( savedInstanceState );
 
-			LoadApplication (new App ());
-		}
-	}
+            global::Xamarin.Forms.Forms.Init( this, savedInstanceState );
+            LoadApplication( new App () );
+        }
+    }
 }

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
@@ -21,7 +21,7 @@ namespace ${Namespace}
             base.OnCreate( savedInstanceState );
 
             global::Xamarin.Forms.Forms.Init( this, savedInstanceState );
-            LoadApplication( new App () );
+			LoadApplication( new App(new AndroidInitializer()) );
         }
     }
 }

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/SplashActivity.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/SplashActivity.cs
@@ -1,0 +1,19 @@
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Support.V7.App;
+
+namespace ${Namespace}
+{
+    [Activity( Label = "${ProjectName}", MainLauncher = true, NoHistory = true, Theme = "@style/SplashTheme",
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation )]
+    public class SplashActivity : AppCompatActivity
+    {
+        protected override void OnCreate( Bundle savedInstanceState )
+        {
+            base.OnCreate( savedInstanceState );
+            var intent = new Intent( this, typeof( MainActivity ) );
+            StartActivity( intent );
+        }
+    }
+}

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/colors-values.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/colors-values.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <color name="primary">#2196F3</color>
+  <color name="primaryDark">#1976D2</color>
+  <color name="accent">#FFC107</color>
+  <color name="window_background">#F5F5F5</color>
+</resources>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/splash-layout.axml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/splash-layout.axml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:drawable="@color/primaryDark"/>
+  <item>
+    <bitmap android:gravity="center" android:src="@drawable/icon"/>
+  </item>
+</layer-list>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/styles-values-v19.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/styles-values-v19.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <style name="SplashTheme" parent="SplashTheme.Base">
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+    </style>
+</resources>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/styles-values-v21.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/styles-values-v21.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <!--
+        Base application theme for API 21+. This theme completely replaces
+        MyTheme from BOTH res/values/styles.xml on API 21+ devices.
+    -->
+    <style name="MyTheme" parent="MyTheme.Base">
+        <!--If you are using MasterDetailPage you will want to set these, else you can leave them out-->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+    <style name="SplashTheme" parent="SplashTheme.Base">
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+</resources>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/styles-values.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/styles-values.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="MyTheme" parent="MyTheme.Base">
+  </style>
+  <style name="MyTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="colorPrimary">@color/primary</item>
+    <item name="colorPrimaryDark">@color/primaryDark</item>
+    <item name="colorAccent">@color/accent</item>
+    <item name="android:windowBackground">@color/window_background</item>
+  </style>
+
+    <style name="SplashTheme" parent="SplashTheme.Base">
+    <!-- Set theme colors from http://www.google.com/design/spec/style/color.html#color-color-palette-->
+    <!-- colorPrimary is used for the default action bar background -->
+    <item name="colorPrimary">@color/primary</item>
+    <!-- colorPrimaryDark is used for the status bar -->
+    <item name="colorPrimaryDark">@color/primaryDark</item>
+    <!-- colorAccent is used as the default value for colorControlActivated
+         which is used to tint widgets -->
+    <item name="colorAccent">@color/accent</item>
+  </style>
+  <style name="SplashTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowBackground">@layout/splash</item>
+  </style>
+</resources>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/tabs-layout.axml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/tabs-layout.axml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.TabLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/sliding_tabs"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorPrimary"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:tabIndicatorColor="@android:color/white"
+    app:tabGravity="fill"
+    app:tabMode="fixed" />

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/toolbar-layout.axml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/toolbar-layout.axml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.Toolbar 
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:minHeight="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+    app:layout_scrollFlags="scroll|enterAlways" />

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/AppDelegate.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/AppDelegate.cs
@@ -20,18 +20,18 @@ namespace ${Namespace}
 		//
 		// You have 17 seconds to return from this method, or iOS will terminate your application.
 		//
-		public override bool FinishedLaunching (UIApplication app, NSDictionary options)
+		public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 		{
-			global::Xamarin.Forms.Forms.Init ();
+			global::Xamarin.Forms.Forms.Init();
 $if$ ($CreateUITestProject$ == true)
 			// Code for starting up the Xamarin Test Cloud Agent
 			#if ENABLE_TEST_CLOUD
 			Xamarin.Calabash.Start();
 			#endif
 $endif$
-			LoadApplication (new App ());
+				LoadApplication(new App(new iOSInitializer()));
 
-			return base.FinishedLaunching (app, options);
+			return base.FinishedLaunching(app, options);
 		}
 	}
 }

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/iOSInitializer.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/iOSInitializer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Prism.Unity;
+
+namespace ${Namespace}
+{
+	public class iOSInitializer : IPlatformInitializer
+	{
+		public void RegisterTypes( IUnityContainer container )
+		{
+			// Register iOS specific types here.
+		}
+	}
+}
+

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp/App.xaml.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp/App.xaml.cs
@@ -5,10 +5,13 @@ namespace ${Namespace}
 {
 	public partial class App : PrismApplication
 	{
-		protected override void OnInitialized()
+		public App(IPlatformInitializer platformInitializer) : base(platformInitializer)
 		{
 			InitializeComponent();
+		}
 
+		protected override void OnInitialized()
+		{
 			NavigationService.NavigateAsync("MainPage?title=Hello%20from%20Xamarin.Forms");
 		}
 

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
@@ -30,6 +30,8 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AddinInfo.cs" />
+    <Compile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\MainActivity.cs" />
+    <Compile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\SplashActivity.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Manifest.addin.xml" />
@@ -94,12 +96,20 @@
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\AboutResources.txt" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\AndroidManifest.xml" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\AssemblyInfo.cs" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\colors-values.xml" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\icondrawable.png" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\icondrawablehdpi.png" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\icondrawablexhdpi.png" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\icondrawablexxhdpi.png" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\MainActivity.cs" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\Resource.cs" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\splash-layout.axml" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\SplashActivity.cs" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\styles-values-v19.xml" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\styles-values-v21.xml" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\styles-values.xml" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\tabs-layout.axml" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\toolbar-layout.axml" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.UITests\AppInitializer.AppProject.cs" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.UITests\AppInitializer.UITestProject.cs" />
     <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.UITests\UITests.AppProject.cs" />

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TemplatePackXamarinStudio</RootNamespace>
     <AssemblyName>TemplatePack-XamarinStudio</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -122,5 +123,7 @@
     </AddinFile>
     <AddinFile Include="ProjectTemplates\PrismUnityApp\PrismUnityApp.xpt.xml" />
     <AddinFile Include="Snippets\PrismCodeTemplates.xml" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\AndroidInitializer.cs" />
+    <AddinFile Include="ProjectTemplates\PrismUnityApp\UnityApp.iOS\iOSInitializer.cs" />
   </ItemGroup>
 </Project>

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
@@ -29,9 +29,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\AddinInfo.cs" />
-    <Compile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\MainActivity.cs" />
-    <Compile Include="ProjectTemplates\PrismUnityApp\UnityApp.Droid\SplashActivity.cs" />
+    <Compile Include="Properties\AddinInfo.cs" />    
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Manifest.addin.xml" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/MainActivity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using Android.App;
 using Android.Content.PM;
 using Android.Runtime;
@@ -13,15 +12,15 @@ namespace $saferootprojectname$.Droid
     [Activity (Label = "$saferootprojectname$", Icon = "@drawable/icon", ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : FormsAppCompatActivity
     {
-        protected override void OnCreate (Bundle bundle)
+        protected override void OnCreate( Bundle savedInstanceState )
         {
             TabLayoutResource = Resource.Layout.tabs;
             ToolbarResource = Resource.Layout.toolbar;
 
-            base.OnCreate (bundle);
+            base.OnCreate( savedInstanceState );
 
-            global::Xamarin.Forms.Forms.Init (this, bundle);
-            LoadApplication (new App ());
+            global::Xamarin.Forms.Forms.Init( this, savedInstanceState );
+            LoadApplication( new App () );
         }
     }
 }

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/MainActivity.cs
@@ -6,11 +6,12 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+using Xamarin.Forms.Platform.Android;
 
 namespace $saferootprojectname$.Droid
 {
-    [Activity (Label = "$saferootprojectname$", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    [Activity (Label = "$saferootprojectname$", Icon = "@drawable/icon", ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    public class MainActivity : FormsAppCompatActivity
     {
         protected override void OnCreate (Bundle bundle)
         {

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectApp.Droid.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectApp.Droid.vstemplate
@@ -16,6 +16,7 @@
     <TemplateContent>
         <Project TargetFileName="$safeprojectname$.Droid.csproj" File="NinjectAppTemplate.Droid.csproj" ReplaceParameters="true">
             <ProjectItem ReplaceParameters="true" TargetFileName="MainActivity.cs">MainActivity.cs</ProjectItem>
+            <ProjectItem ReplaceParameters="true" TargetFileName="SplashActivity.cs">SplashActivity.cs</ProjectItem>
             <Folder Name="Assets" TargetFolderName="Assets">
                 <ProjectItem ReplaceParameters="false" TargetFileName="AboutAssets.txt">AboutAssets.txt</ProjectItem>
             </Folder>
@@ -37,11 +38,15 @@
                     <ProjectItem ReplaceParameters="false" TargetFileName="icon.png">icon.png</ProjectItem>
                 </Folder>
                 <Folder Name="layout" TargetFolderName="layout">
-                    <ProjectItem ReplaceParameters="false" TargetFileName="tabs.xml">tabs.xml</ProjectItem>
-                    <ProjectItem ReplaceParameters="false" TargetFileName="toolbar.xml">toolbar.xml</ProjectItem>
+                    <ProjectItem ReplaceParameters="false" TargetFileName="tabs.axml">tabs.xml</ProjectItem>
+                    <ProjectItem ReplaceParameters="false" TargetFileName="toolbar.axml">toolbar.xml</ProjectItem>
+                    <ProjectItem ReplaceParameters="false" TargetFileName="splash.axml">splash.xml</ProjectItem>
                 </Folder>
                 <Folder Name="values" TargetFolderName="values">
                     <ProjectItem ReplaceParameters="false" TargetFileName="colors.xml">colors.xml</ProjectItem>
+                    <ProjectItem ReplaceParameters="false" TargetFileName="styles.xml">styles.xml</ProjectItem>
+                </Folder>
+                <Folder Name="values-v19" TargetFolderName="values-v19">
                     <ProjectItem ReplaceParameters="false" TargetFileName="styles.xml">styles.xml</ProjectItem>
                 </Folder>
                 <Folder Name="values-v21" TargetFolderName="values-v21">

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectApp.Droid.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectApp.Droid.vstemplate
@@ -71,7 +71,7 @@
     </WizardExtension>
     <WizardData>
         <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-            <package id="Xamarin.Forms" version="2.3.0.28-pre2" />
+            <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
             <package id="Prism.Core" version="6.1.0" />
             <package id="Prism.Forms" version="6.1.0-pre5" />
             <package id="Prism.Ninject.Forms" version="6.2.0-pre5" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectAppTemplate.Droid.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectAppTemplate.Droid.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
+    <Compile Include="SplashActivity.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -69,10 +70,12 @@
     <AndroidResource Include="Resources\drawable-xxhdpi\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidResource Include="Resources\layout\tabs.xml" />
-    <AndroidResource Include="Resources\layout\toolbar.xml" />
+    <AndroidResource Include="Resources\layout\splash.axml" />
+    <AndroidResource Include="Resources\layout\tabs.axml" />
+    <AndroidResource Include="Resources\layout\toolbar.axml" />
     <AndroidResource Include="Resources\values\colors.xml" />
     <AndroidResource Include="Resources\values\styles.xml" />
+    <AndroidResource Include="Resources\values-v19\styles.xml" />
     <AndroidResource Include="Resources\values-v21\styles.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectAppTemplate.Droid.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/NinjectAppTemplate.Droid.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-	<TargetFrameworkVersion>$androidTargetFrameworkVersion$</TargetFrameworkVersion>
+    <TargetFrameworkVersion>$androidTargetFrameworkVersion$</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Properties/AndroidManifest.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.yourcompany.$safeprojectname$" android:installLocation="auto">
     <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="23" />
     <application android:label="$safeprojectname$" android:theme="@style/MyTheme" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/layout/splash.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/layout/splash.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:drawable="@color/primaryDark"/>
+  <item>
+    <bitmap android:gravity="center" android:src="@drawable/icon"/>
+  </item>
+</layer-list>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/layout/tabs.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/layout/tabs.xml
@@ -1,4 +1,5 @@
-﻿<android.support.design.widget.TabLayout
+﻿<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.TabLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/sliding_tabs"

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/layout/toolbar.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/layout/toolbar.xml
@@ -1,4 +1,5 @@
-﻿<android.support.v7.widget.Toolbar 
+﻿<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.Toolbar 
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values-v19/styles.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values-v19/styles.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <style name="SplashTheme" parent="SplashTheme.Base">
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+    </style>
+</resources>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values-v21/styles.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values-v21/styles.xml
@@ -1,8 +1,17 @@
-﻿<resources>
-  <style name="MyTheme" parent="MyTheme.Base">
-    <!--If you are using MasterDetailPage you will want to set these, else you can leave them out-->
-    <!--<item name="android:windowDrawsSystemBarBackgrounds">true</item>
-    <item name="android:statusBarColor">@android:color/transparent</item>-->
-  </style>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+        Base application theme for API 21+. This theme completely replaces
+        MyTheme from BOTH res/values/styles.xml on API 21+ devices.
+    -->
+    <style name="MyTheme" parent="MyTheme.Base">
+        <!--If you are using MasterDetailPage you will want to set these, else you can leave them out-->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+    <style name="SplashTheme" parent="SplashTheme.Base">
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
 </resources>
-

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values/colors.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values/colors.xml
@@ -1,4 +1,5 @@
-﻿<resources>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
   <color name="primary">#2196F3</color>
   <color name="primaryDark">#1976D2</color>
   <color name="accent">#FFC107</color>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values/styles.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/Resources/values/styles.xml
@@ -1,4 +1,5 @@
-﻿<resources>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
   <style name="MyTheme" parent="MyTheme.Base">
   </style>
   <style name="MyTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
@@ -7,5 +8,18 @@
     <item name="colorAccent">@color/accent</item>
     <item name="android:windowBackground">@color/window_background</item>
   </style>
-</resources>
 
+    <style name="SplashTheme" parent="SplashTheme.Base">
+    <!-- Set theme colors from http://www.google.com/design/spec/style/color.html#color-color-palette-->
+    <!-- colorPrimary is used for the default action bar background -->
+    <item name="colorPrimary">@color/primary</item>
+    <!-- colorPrimaryDark is used for the status bar -->
+    <item name="colorPrimaryDark">@color/primaryDark</item>
+    <!-- colorAccent is used as the default value for colorControlActivated
+         which is used to tint widgets -->
+    <item name="colorAccent">@color/accent</item>
+  </style>
+  <style name="SplashTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowBackground">@layout/splash</item>
+  </style>
+</resources>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/SplashActivity.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Droid/SplashActivity.cs
@@ -1,0 +1,19 @@
+﻿using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Support.V7.App;
+
+namespace $saferootprojectname$.Droid
+{
+    [Activity( Label = "$saferootprojectname$", MainLauncher = true, NoHistory = true, Theme = "@style/SplashTheme",
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation )]
+    public class SplashActivity : AppCompatActivity
+    {
+        protected override void OnCreate( Bundle savedInstanceState )
+        {
+            base.OnCreate( savedInstanceState );
+            var intent = new Intent( this, typeof( MainActivity ) );
+            StartActivity( intent );
+        }
+    }
+}

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.UWP/NinjectApp.UWP.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.UWP/NinjectApp.UWP.vstemplate
@@ -64,7 +64,7 @@
 
     <WizardData>
         <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-            <package id="Xamarin.Forms" version="2.3.0.28-pre2" />
+            <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
             <package id="Prism.Core" version="6.1.0" />
             <package id="Prism.Forms" version="6.1.0-pre5" />
             <package id="Prism.Ninject.Forms" version="6.2.0-pre5" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.UWP/project.json
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.UWP/project.json
@@ -6,7 +6,7 @@
     "Prism.Forms": "6.1.0-pre5",
     "Prism.Ninject.Forms": "6.2.0-pre5",
     "Portable.Ninject": "3.3.1",
-    "Xamarin.Forms": "2.3.0.38-pre2"
+    "Xamarin.Forms": "2.3.0.46-pre3"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.WinPhone/NinjectApp.WinPhone.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.WinPhone/NinjectApp.WinPhone.vstemplate
@@ -54,7 +54,7 @@
 
     <WizardData>
         <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-            <package id="Xamarin.Forms" version="2.3.0.28-pre2" />
+            <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
             <package id="Prism.Core" version="6.1.0" />
             <package id="Prism.Ninject.Forms" version="6.2.0-pre5" />
             <package id="Prism.Ninject" version="6.2.0-pre3" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Windows/NinjectApp.Windows.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.Windows/NinjectApp.Windows.vstemplate
@@ -53,7 +53,7 @@
 
     <WizardData>
         <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-            <package id="Xamarin.Forms" version="2.3.0.28-pre2" />
+            <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
             <package id="Prism.Core" version="6.1.0" />
             <package id="Prism.Forms" version="6.1.0-pre5" />
             <package id="Prism.Ninject.Forms" version="6.2.0-pre5" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.iOS/NinjectApp.iOS.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp.iOS/NinjectApp.iOS.vstemplate
@@ -62,7 +62,7 @@
     </WizardExtension>
     <WizardData>
         <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-            <package id="Xamarin.Forms" version="2.3.0.28-pre2" />
+            <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
             <package id="Prism.Core" version="6.1.0" />
             <package id="Prism.Forms" version="6.1.0-pre5" />
             <package id="Prism.Ninject.Forms" version="6.2.0-pre5" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp/NinjectApp.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/NinjectApp/NinjectApp.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.3.0.28-pre2" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
       <package id="Prism.Forms" version="6.1.0-pre5" />
       <package id="Prism.Ninject.Forms" version="6.2.0-pre5" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/PrismNinjectApp.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/PrismNinjectApp.csproj
@@ -102,7 +102,7 @@
     <None Include="NinjectApp.Droid\Assets\AboutAssets.txt" />
     <None Include="NinjectApp.Droid\Properties\AndroidManifest.xml" />
     <None Include="NinjectApp.Droid\Resources\AboutResources.txt" />
-    <None Include="NinjectApp.Droid\Resources\Drawable\Icon.png" />
+    <None Include="NinjectApp.Droid\Resources\drawable\icon.png" />
     <None Include="NinjectApp.Droid\Resources\drawable-hdpi\icon.png" />
     <None Include="NinjectApp.Droid\Resources\drawable-xhdpi\icon.png" />
     <None Include="NinjectApp.Droid\Resources\drawable-xxhdpi\icon.png" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/PrismNinjectApp.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/PrismNinjectApp.csproj
@@ -91,6 +91,7 @@
     <None Include="NinjectApp.WinPhone\MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </None>
+    <Compile Include="NinjectApp.Droid\SplashActivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -209,6 +210,8 @@
     <None Include="NinjectApp.iOS\NinjectApp.iOS.vstemplate" />
     <None Include="NinjectApp.iOS\Info.plist" />
     <None Include="NinjectApp.iOS\Entitlements.plist" />
+    <Content Include="NinjectApp.Droid\Resources\layout\splash.xml" />
+    <Content Include="NinjectApp.Droid\Resources\values-v19\styles.xml" />
     <Content Include="NinjectApp.iOS\__TemplateIcon.ico" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/PrismNinjectApp.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismNinjectApp/PrismNinjectApp.csproj
@@ -67,6 +67,7 @@
     <None Include="NinjectApp.Droid\Properties\AssemblyInfo.cs" />
     <None Include="NinjectApp.Droid\Resources\Resource.Designer.cs" />
     <None Include="NinjectApp.Droid\MainActivity.cs" />
+    <None Include="NinjectApp.Droid\SplashActivity.cs" />
     <None Include="NinjectApp.iOS\Properties\AssemblyInfo.cs" />
     <None Include="NinjectApp.iOS\AppDelegate.cs" />
     <None Include="NinjectApp.iOS\Main.cs" />
@@ -91,7 +92,6 @@
     <None Include="NinjectApp.WinPhone\MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </None>
-    <Compile Include="NinjectApp.Droid\SplashActivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/PrismUnityApp.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/PrismUnityApp.csproj
@@ -156,7 +156,7 @@
     <None Include="UnityApp.Droid\Resources\drawable-hdpi\icon.png" />
     <None Include="UnityApp.Droid\Resources\drawable-xhdpi\icon.png" />
     <None Include="UnityApp.Droid\Resources\drawable-xxhdpi\icon.png" />
-    <None Include="UnityApp.Droid\Resources\Drawable\Icon.png" />
+    <None Include="UnityApp.Droid\Resources\drawable\icon.png" />
     <None Include="UnityApp.Droid\Resources\layout\tabs.xml" />
     <None Include="UnityApp.Droid\Resources\layout\toolbar.xml" />
     <None Include="UnityApp.Droid\Resources\values-v21\styles.xml" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/PrismUnityApp.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/PrismUnityApp.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnityApp.Droid\SplashActivity.cs" />
     <None Include="UnityApp.UWP\App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </None>
@@ -183,6 +184,8 @@
     <None Include="UnityApp.Droid\__TemplateIcon.ico" />
     <None Include="UnityApp.iOS\UnityApp.iOS.vstemplate" />
     <None Include="UnityApp.iOS\UnityAppTemplate.iOS.csproj" />
+    <Content Include="UnityApp.Droid\Resources\layout\splash.xml" />
+    <Content Include="UnityApp.Droid\Resources\values-v19\styles.xml" />
     <Content Include="UnityApp.iOS\__TemplateIcon.ico" />
     <None Include="UnityApp.WinPhone\UnityAppTemplate.WinPhone.csproj" />
     <None Include="UnityApp.Windows\Assets\Logo.scale-100.png" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/PrismUnityApp.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/PrismUnityApp.csproj
@@ -74,7 +74,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="UnityApp.Droid\SplashActivity.cs" />
     <None Include="UnityApp.UWP\App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </None>
@@ -114,6 +113,7 @@
       <DependentUpon>App.xaml</DependentUpon>
     </None>
     <None Include="UnityApp.Droid\MainActivity.cs" />
+    <None Include="UnityApp.Droid\SplashActivity.cs" />
     <None Include="UnityApp.Droid\Properties\AssemblyInfo.cs" />
     <None Include="UnityApp.Droid\Resources\Resource.Designer.cs" />
     <None Include="UnityApp.WinPhone\Properties\AssemblyInfo.cs" />
@@ -163,7 +163,9 @@
     <None Include="UnityApp.Droid\Resources\values-v21\styles.xml" />
     <None Include="UnityApp.Droid\Resources\values\colors.xml" />
     <None Include="UnityApp.Droid\Resources\values\styles.xml" />
-    <None Include="UnityApp.Droid\UnityApp.Droid.vstemplate" />
+    <None Include="UnityApp.Droid\UnityApp.Droid.vstemplate">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="UnityApp.iOS\Entitlements.plist" />
     <None Include="UnityApp.iOS\Info.plist" />
     <None Include="UnityApp.iOS\Resources\Default%402x.png" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/MainActivity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using Android.App;
 using Android.Content.PM;
 using Android.Runtime;
@@ -13,16 +12,16 @@ namespace $saferootprojectname$.Droid
     [Activity (Label = "$saferootprojectname$", Icon = "@drawable/icon", ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : FormsAppCompatActivity
     {
-		protected override void OnCreate (Bundle bundle)
-		{
+        protected override void OnCreate( Bundle savedInstanceState )
+        {
             TabLayoutResource = Resource.Layout.tabs;
             ToolbarResource = Resource.Layout.toolbar;
 
-            base.OnCreate (bundle);
+            base.OnCreate( savedInstanceState );
 
-			global::Xamarin.Forms.Forms.Init (this, bundle);
-			LoadApplication (new App ());
-		}
-	}
+            global::Xamarin.Forms.Forms.Init( this, savedInstanceState );
+            LoadApplication( new App () );
+        }
+    }
 }
 

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/MainActivity.cs
@@ -6,11 +6,12 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+using Xamarin.Forms.Platform.Android;
 
 namespace $saferootprojectname$.Droid
 {
-	[Activity (Label = "$saferootprojectname$", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    [Activity (Label = "$saferootprojectname$", Icon = "@drawable/icon", ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    public class MainActivity : FormsAppCompatActivity
     {
 		protected override void OnCreate (Bundle bundle)
 		{

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Properties/AndroidManifest.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
-  <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23" />
-	<application android:label="$safeprojectname$" android:theme="@style/MyTheme"></application>
+  <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="23" />
+    <application android:label="$safeprojectname$" android:theme="@style/MyTheme"></application>
 </manifest>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Properties/AndroidManifest.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
-  <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="23" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.yourcompany.$safeprojectname$" android:installLocation="auto">
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="23" />
     <application android:label="$safeprojectname$" android:theme="@style/MyTheme"></application>
 </manifest>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/layout/splash.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/layout/splash.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:drawable="@color/primaryDark"/>
+  <item>
+    <bitmap android:gravity="center" android:src="@drawable/icon"/>
+  </item>
+</layer-list>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/values-v19/styles.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/values-v19/styles.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+    <style name="SplashTheme" parent="SplashTheme.Base">
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowTranslucentStatus">true</item>
+    </style>
+</resources>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/values-v21/styles.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/values-v21/styles.xml
@@ -1,8 +1,16 @@
 ﻿<resources>
-  <style name="MyTheme" parent="MyTheme.Base">
-    <!--If you are using MasterDetailPage you will want to set these, else you can leave them out-->
-    <!--<item name="android:windowDrawsSystemBarBackgrounds">true</item>
-    <item name="android:statusBarColor">@android:color/transparent</item>-->
-  </style>
+    <!--
+        Base application theme for API 21+. This theme completely replaces
+        MyTheme from BOTH res/values/styles.xml on API 21+ devices.
+    -->
+    <style name="MyTheme" parent="MyTheme.Base">
+        <!--If you are using MasterDetailPage you will want to set these, else you can leave them out-->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+    <style name="SplashTheme" parent="SplashTheme.Base">
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
 </resources>
-

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/values/styles.xml
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/Resources/values/styles.xml
@@ -7,5 +7,18 @@
     <item name="colorAccent">@color/accent</item>
     <item name="android:windowBackground">@color/window_background</item>
   </style>
-</resources>
 
+    <style name="SplashTheme" parent="SplashTheme.Base">
+    <!-- Set theme colors from http://www.google.com/design/spec/style/color.html#color-color-palette-->
+    <!-- colorPrimary is used for the default action bar background -->
+    <item name="colorPrimary">@color/primary</item>
+    <!-- colorPrimaryDark is used for the status bar -->
+    <item name="colorPrimaryDark">@color/primaryDark</item>
+    <!-- colorAccent is used as the default value for colorControlActivated
+         which is used to tint widgets -->
+    <item name="colorAccent">@color/accent</item>
+  </style>
+  <style name="SplashTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowBackground">@layout/splash</item>
+  </style>
+</resources>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/SplashActivity.cs
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/SplashActivity.cs
@@ -1,0 +1,19 @@
+﻿using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Support.V7.App;
+
+namespace $saferootprojectname$.Droid
+{
+    [Activity( Label = "$saferootprojectname$", MainLauncher = true, NoHistory = true, Theme = "@style/SplashTheme",
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation )]
+    public class SplashActivity : AppCompatActivity
+    {
+        protected override void OnCreate( Bundle savedInstanceState )
+        {
+            base.OnCreate( savedInstanceState );
+            var intent = new Intent( this, typeof( MainActivity ) );
+            StartActivity( intent );
+        }
+    }
+}

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityApp.Droid.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityApp.Droid.vstemplate
@@ -71,10 +71,10 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.2.0.4-pre1" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
-      <package id="Prism.Forms" version="6.1.0-pre4" />
-      <package id="Prism.Unity.Forms" version="6.2.0-pre4" />
+      <package id="Prism.Forms" version="6.1.0-pre5" />
+      <package id="Prism.Unity.Forms" version="6.2.0-pre5" />
       <package id="Unity" version="4.0.1" />
       <package id="CommonServiceLocator" version="1.3.0" />
       <package id="Xamarin.Android.Support.v4" version="23.1.1.1" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityApp.Droid.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityApp.Droid.vstemplate
@@ -16,6 +16,7 @@
   <TemplateContent>
     <Project TargetFileName="$safeprojectname$.Droid.csproj" File="UnityAppTemplate.Droid.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="MainActivity.cs">MainActivity.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="SplashActivity.cs">SplashActivity.cs</ProjectItem>
       <Folder Name="Assets" TargetFolderName="Assets">
         <ProjectItem ReplaceParameters="false" TargetFileName="AboutAssets.txt">AboutAssets.txt</ProjectItem>
       </Folder>
@@ -37,11 +38,15 @@
           <ProjectItem ReplaceParameters="false" TargetFileName="icon.png">icon.png</ProjectItem>
         </Folder>
         <Folder Name="layout" TargetFolderName="layout">
-          <ProjectItem ReplaceParameters="false" TargetFileName="tabs.xml">tabs.xml</ProjectItem>
-          <ProjectItem ReplaceParameters="false" TargetFileName="toolbar.xml">toolbar.xml</ProjectItem>
+          <ProjectItem ReplaceParameters="false" TargetFileName="tabs.axml">tabs.xml</ProjectItem>
+          <ProjectItem ReplaceParameters="false" TargetFileName="toolbar.axml">toolbar.xml</ProjectItem>
+          <ProjectItem ReplaceParameters="false" TargetFileName="splash.axml">splash.xml</ProjectItem>
         </Folder>
         <Folder Name="values" TargetFolderName="values">
           <ProjectItem ReplaceParameters="false" TargetFileName="colors.xml">colors.xml</ProjectItem>
+          <ProjectItem ReplaceParameters="false" TargetFileName="styles.xml">styles.xml</ProjectItem>
+        </Folder>
+        <Folder Name="values-v19" TargetFolderName="values-v19">
           <ProjectItem ReplaceParameters="false" TargetFileName="styles.xml">styles.xml</ProjectItem>
         </Folder>
         <Folder Name="values-v21" TargetFolderName="values-v21">

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityAppTemplate.Droid.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityAppTemplate.Droid.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
+    <Compile Include="SplashActivity.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -69,10 +70,12 @@
     <AndroidResource Include="Resources\drawable-xxhdpi\icon.png" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidResource Include="Resources\layout\tabs.xml" />
-    <AndroidResource Include="Resources\layout\toolbar.xml" />
+    <AndroidResource Include="Resources\layout\splash.axml" />
+    <AndroidResource Include="Resources\layout\tabs.axml" />
+    <AndroidResource Include="Resources\layout\toolbar.axml" />
     <AndroidResource Include="Resources\values\colors.xml" />
     <AndroidResource Include="Resources\values\styles.xml" />
+    <AndroidResource Include="Resources\values-v19\styles.xml" />
     <AndroidResource Include="Resources\values-v21\styles.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityAppTemplate.Droid.csproj
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Droid/UnityAppTemplate.Droid.csproj
@@ -17,7 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-	<TargetFrameworkVersion>$androidTargetFrameworkVersion$</TargetFrameworkVersion>
+    <TargetFrameworkVersion>$androidTargetFrameworkVersion$</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.UWP/UnityApp.UWP.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.UWP/UnityApp.UWP.vstemplate
@@ -64,10 +64,10 @@
   
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.2.0.4-pre1" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
-      <package id="Prism.Forms" version="6.1.0-pre4" />
-      <package id="Prism.Unity.Forms" version="6.2.0-pre4" />
+      <package id="Prism.Forms" version="6.1.0-pre5" />
+      <package id="Prism.Unity.Forms" version="6.2.0-pre5" />
       <package id="Unity" version="4.0.1" />
       <package id="CommonServiceLocator" version="1.3.0" />
     </packages>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.UWP/project.json
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.UWP/project.json
@@ -3,10 +3,10 @@
     "CommonServiceLocator": "1.3.0",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
     "Prism.Core": "6.1.0",
-    "Prism.Forms": "6.1.0-pre3",
-    "Prism.Unity.Forms": "6.2.0-pre3",
+    "Prism.Forms": "6.1.0-pre5",
+    "Prism.Unity.Forms": "6.2.0-pre5",
     "Unity": "4.0.1",
-    "Xamarin.Forms": "2.0.0.6490"
+    "Xamarin.Forms": "2.3.0.46-pre3"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.WinPhone/UnityApp.WinPhone.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.WinPhone/UnityApp.WinPhone.vstemplate
@@ -54,10 +54,10 @@
   
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.2.0.4-pre1" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
-      <package id="Prism.Forms" version="6.1.0-pre4" />
-      <package id="Prism.Unity.Forms" version="6.2.0-pre4" />
+      <package id="Prism.Forms" version="6.1.0-pre5" />
+      <package id="Prism.Unity.Forms" version="6.2.0-pre5" />
       <package id="Unity" version="4.0.1" />
       <package id="CommonServiceLocator" version="1.3.0" />
     </packages>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Windows/UnityApp.Windows.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.Windows/UnityApp.Windows.vstemplate
@@ -53,7 +53,7 @@
   
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.2.0.4-pre1" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
       <package id="Prism.Forms" version="6.1.0-pre4" />
       <package id="Prism.Unity.Forms" version="6.2.0-pre4" />

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.iOS/UnityApp.iOS.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp.iOS/UnityApp.iOS.vstemplate
@@ -62,10 +62,10 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.2.0.4-pre1" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
-      <package id="Prism.Forms" version="6.1.0-pre4" />
-      <package id="Prism.Unity.Forms" version="6.2.0-pre4" />
+      <package id="Prism.Forms" version="6.1.0-pre5" />
+      <package id="Prism.Unity.Forms" version="6.2.0-pre5" />
       <package id="Unity" version="4.0.1" />
       <package id="CommonServiceLocator" version="1.3.0" />
     </packages>

--- a/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp/UnityApp.vstemplate
+++ b/Extensibility/TemplatePack/ProjectTemplates/CSharp/Forms/PrismUnityApp/UnityApp/UnityApp.vstemplate
@@ -42,10 +42,10 @@
   </WizardExtension>
   <WizardData>
     <packages repository="extension" repositoryId="Prism.TemplatePack.138e3411-ac97-4c11-8016-c27a831cba2e">
-      <package id="Xamarin.Forms" version="2.2.0.4-pre1" />
+      <package id="Xamarin.Forms" version="2.3.0.46-pre3" />
       <package id="Prism.Core" version="6.1.0" />
-      <package id="Prism.Forms" version="6.1.0-pre4" />
-      <package id="Prism.Unity.Forms" version="6.2.0-pre4" />
+      <package id="Prism.Forms" version="6.1.0-pre5" />
+      <package id="Prism.Unity.Forms" version="6.2.0-pre5" />
       <package id="Unity" version="4.0.1" />
       <package id="CommonServiceLocator" version="1.3.0" />
     </packages>


### PR DESCRIPTION
- Updates Xamarin Studio template to include Material Design for the Android target as we currently have in both the Unity and Ninject templates for Visual Studio
- Updates Xamarin.Forms to 2.3.0.46-pre3
- Updates out of date Prism package references in VS Unity template
- Adds basic Splash Screen for Android across all templates
- Normalizes tabs/spacing
- Switches the minimum android sdk in the VS Unity template from 23 to 19