### PR TITLE
Updated XF UnityExtensions to follow Type Registration Conventions

### DIFF
--- a/Source/Wpf/Prism.Unity.Wpf/UnityExtensions.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityExtensions.cs
@@ -11,11 +11,11 @@ namespace Prism.Unity
         /// <typeparam name="T">The Type of the object to register</typeparam>
         /// <param name="container"><see cref="IUnityContainer"/> used to register type for Navigation.</param>
         /// <param name="name">The unique name to register with the object.</param>
-        public static void RegisterTypeForNavigation<T>(this IUnityContainer container, string name = null)
+        public static IUnityContainer RegisterTypeForNavigation<T>(this IUnityContainer container, string name = null)
         {
             Type type = typeof(T);
             string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
-            container.RegisterType(typeof(object), type, viewName);
+            return container.RegisterType(typeof(object), type, viewName);
         }
     }
 }

--- a/Source/Xamarin/Prism.Unity.Forms/UnityExtensions.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityExtensions.cs
@@ -23,13 +23,13 @@ namespace Prism.Unity
         /// <typeparam name="TView">The Type of Page to register</typeparam>
         /// <param name="container"><see cref="IUnityContainer"/> used to register type for Navigation.</param>
         /// <param name="name">The unique name to register with the Page</param>
-        public static void RegisterTypeForNavigation<TView>(this IUnityContainer container, string name) where TView : Page
+        public static IUnityContainer RegisterTypeForNavigation<TView>(this IUnityContainer container, string name) where TView : Page
         {
             Type type = typeof(TView);
 
-            container.RegisterType(typeof(object), type, name);
-
             PageNavigationRegistry.Register(name, type);
+
+            return container.RegisterType(typeof(object), type, name);
         }
 
         /// <summary>
@@ -38,16 +38,16 @@ namespace Prism.Unity
         /// <typeparam name="TView">The Type of Page to register</typeparam>
         /// <typeparam name="TViewModel">The BindableBase ViewModel to use as the unique name for the Page</typeparam>
         /// <param name="container"></param>
-        public static void RegisterTypeForNavigation<TView, TViewModel>(this IUnityContainer container)
+        public static IUnityContainer RegisterTypeForNavigation<TView, TViewModel>(this IUnityContainer container)
             where TView : Page
             where TViewModel : BindableBase
         {
             Type type = typeof(TView);
             string name = typeof(TViewModel).FullName;
 
-            container.RegisterType(typeof(object), type, name);
-
             PageNavigationRegistry.Register(name, type);
+
+            return container.RegisterType(typeof(object), type, name);
         }
     }
 }


### PR DESCRIPTION
The Unity pattern for type registration passes back the container to allow chaining type registration. This update will allow the same type of chaining.

```cs

Container.RegisterTypeForNavigation<ViewA>()
         .RegisterInstance( someInstance )
         .RegisterType<IFoo, Foo>()
         .RegisterTypeForNavigation<ViewB>();


```

This update only targets Unity as Ninject follows a different pattern for type registrations.