### PR TITLE
Improvements PageNavigationService

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
@@ -1,4 +1,6 @@
-﻿using Prism.Common;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Prism.Common;
 using Prism.Logging;
 using Prism.Navigation;
 using Xamarin.Forms;
@@ -15,9 +17,18 @@ namespace Prism.Forms.Tests.Mocks
             _containerMock = containerMock;
         }
 
+        public bool HasProcessedCustomNavigation { get; private set; }
+
         protected override Page CreatePage(string name)
         {
             return _containerMock.GetInstance(name) as Page;
+        }
+
+        protected override Task ProcessNavigationForPage(Page currentPage, string nextSegment, Queue<string> segments,
+            NavigationParameters navigationParameters, bool? useModalNavigation, bool animated)
+        {
+            HasProcessedCustomNavigation = true;
+            return Task.FromResult(0);
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/CustomTabbedPageMockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/CustomTabbedPageMockViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Forms.Tests.Mocks.ViewModels
+{
+    public class CustomTabbedPageMockViewModel : ViewModelBase
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/CustomTabbedPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/CustomTabbedPageMock.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Mvvm;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Mocks.Views
+{
+    public class CustomTabbedPageMock : MultiPage<Page>
+    {
+        public CustomTabbedPageMock()
+        {
+            ViewModelLocator.SetAutowireViewModel(this, true);
+        }
+
+        protected override Page CreateDefault(object item)
+        {
+            return new ContentPageMock();
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -37,6 +37,8 @@ namespace Prism.Forms.Tests.Navigation
             _container.Register("TabbedPage", typeof(TabbedPageMock));
             _container.Register("CarouselPage", typeof(CarouselPageMock));
 
+            _container.Register("CustomTabbedPageMock", typeof(CustomTabbedPageMock));
+
             _applicationProvider = new ApplicationProviderMock();
             _loggerFacade = new EmptyLogger();
         }
@@ -648,7 +650,7 @@ namespace Prism.Forms.Tests.Navigation
             ((MasterDetailPageEmptyMockViewModel)rootPage.BindingContext).IsPresentedAfterNavigation = false;
 
             Assert.Null(rootPage.Detail);
-            Assert.False(rootPage.IsPresented);            
+            Assert.False(rootPage.IsPresented);
 
             await navigationService.NavigateAsync("TabbedPage");
             Assert.IsType(typeof(TabbedPageMock), rootPage.Detail);
@@ -684,6 +686,18 @@ namespace Prism.Forms.Tests.Navigation
             Assert.NotNull(tabbedPage);
             Assert.NotNull(tabbedPage.CurrentPage);
             Assert.IsType(typeof(ContentPageMock), tabbedPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void Navigate_ToCustomTabbedPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new CustomTabbedPageMock();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage");
+
+            Assert.True(navigationService.HasProcessedCustomNavigation);
         }
 
         public void Dispose()

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -64,12 +64,14 @@
     <Compile Include="Mocks\PageDialogServiceMock.cs" />
     <Compile Include="Mocks\ViewModels\CarouselPageMockViewModel.cs" />
     <Compile Include="Mocks\ViewModels\ContentPageMockViewModel.cs" />
+    <Compile Include="Mocks\ViewModels\CustomTabbedPageMockViewModel.cs" />
     <Compile Include="Mocks\ViewModels\MasterDetailPageMockViewModel.cs" />
     <Compile Include="Mocks\ViewModels\NavigationPageMockViewModel.cs" />
     <Compile Include="Mocks\ViewModels\TabbedPageMockViewModel.cs" />
     <Compile Include="Mocks\ViewModels\ViewModelBase.cs" />
     <Compile Include="Mocks\Views\CarouselPageMock.cs" />
     <Compile Include="Mocks\Views\ContentPageMock.cs" />
+    <Compile Include="Mocks\Views\CustomTabbedPageMock.cs" />
     <Compile Include="Mocks\Views\MasterDetailPageMock.cs" />
     <Compile Include="Mocks\Views\NavigationPageMock.cs" />
     <Compile Include="Mocks\Views\PageMock.cs" />

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -15,16 +15,21 @@ namespace Prism.Navigation
     /// </summary>
     public abstract class PageNavigationService : INavigationService, IPageAware
     {
-        protected IApplicationProvider _applicationProvider;
-        protected ILoggerFacade _logger;
+        protected readonly IApplicationProvider _applicationProvider;
+        protected readonly ILoggerFacade _logger;
 
-        private Page _page;
+        Page _page;
         Page IPageAware.Page
         {
             get { return _page; }
             set { _page = value; }
         }
 
+        /// <summary>
+        /// Create a new instance of <see cref="PageNavigationService"/> with <paramref name="applicationProvider"/> and <paramref name="logger"/>
+        /// </summary>
+        /// <param name="applicationProvider">Instance of <see cref="IApplicationProvider"/></param>
+        /// <param name="logger">Instance of <paramref name="logger"/> for Prism logging</param>
         protected PageNavigationService(IApplicationProvider applicationProvider, ILoggerFacade logger)
         {
             _applicationProvider = applicationProvider;
@@ -104,7 +109,7 @@ namespace Prism.Navigation
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
         /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
         /// <example>
-        /// Navigate(new Uri("MainPage?id=3&name=brian", UriKind.RelativeSource), parameters);
+        /// Navigate(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
         /// </example>
         public virtual Task NavigateAsync(Uri uri, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
@@ -135,7 +140,7 @@ namespace Prism.Navigation
             }
             else if (currentPage is NavigationPage)
             {
-                await ProcessNavigationForNavigationPage((NavigationPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                await ProcessNavigationForNavigationPage((NavigationPage)currentPage, nextSegment, segments, parameters, animated);
             }
             else if (currentPage is MultiPage<Page>)
             {
@@ -180,7 +185,7 @@ namespace Prism.Navigation
             });
         }
 
-        async Task ProcessNavigationForNavigationPage(NavigationPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        async Task ProcessNavigationForNavigationPage(NavigationPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool animated)
         {
             if (currentPage.Navigation.NavigationStack.Count == 0)
             {
@@ -502,12 +507,9 @@ namespace Prism.Navigation
                 return confirmNavigationItem.CanNavigateAsync(parameters);
 
             var bindableObject = page as BindableObject;
-            if (bindableObject != null)
-            {
-                var confirmNavigationBindingContext = bindableObject.BindingContext as IConfirmNavigationAsync;
-                if (confirmNavigationBindingContext != null)
-                    return confirmNavigationBindingContext.CanNavigateAsync(parameters);
-            }
+            var confirmNavigationBindingContext = bindableObject?.BindingContext as IConfirmNavigationAsync;
+            if (confirmNavigationBindingContext != null)
+                return confirmNavigationBindingContext.CanNavigateAsync(parameters);
 
             return Task.FromResult(CanNavigate(page, parameters));
         }
@@ -519,12 +521,9 @@ namespace Prism.Navigation
                 return confirmNavigationItem.CanNavigate(parameters);
 
             var bindableObject = page as BindableObject;
-            if (bindableObject != null)
-            {
-                var confirmNavigationBindingContext = bindableObject.BindingContext as IConfirmNavigation;
-                if (confirmNavigationBindingContext != null)
-                    return confirmNavigationBindingContext.CanNavigate(parameters);
-            }
+            var confirmNavigationBindingContext = bindableObject?.BindingContext as IConfirmNavigation;
+            if (confirmNavigationBindingContext != null)
+                return confirmNavigationBindingContext.CanNavigate(parameters);
 
             return true;
         }
@@ -548,12 +547,9 @@ namespace Prism.Navigation
                 invocation(navigationAwareItem);
 
             var bindableObject = item as BindableObject;
-            if (bindableObject != null)
-            {
-                var navigationAwareDataContext = bindableObject.BindingContext as INavigationAware;
-                if (navigationAwareDataContext != null)
-                    invocation(navigationAwareDataContext);
-            }
+            var navigationAwareDataContext = bindableObject?.BindingContext as INavigationAware;
+            if (navigationAwareDataContext != null)
+                invocation(navigationAwareDataContext);
         }
 
         static NavigationParameters GetSegmentParameters(string uriSegment, NavigationParameters parameters)

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -116,9 +116,10 @@ namespace Prism.Navigation
             var navigationSegments = UriParsingHelper.GetUriSegments(uri);
 
             if (uri.IsAbsoluteUri)
+            {
                 return ProcessNavigationForAbsoulteUri(navigationSegments, parameters, useModalNavigation, animated);
-            else
-                return ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
+            }
+            return ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
         }
 
         async Task ProcessNavigation(Page currentPage, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
@@ -142,18 +143,50 @@ namespace Prism.Navigation
             {
                 await ProcessNavigationForNavigationPage((NavigationPage)currentPage, nextSegment, segments, parameters, animated);
             }
-            else if (currentPage is MultiPage<Page>)
+            else if (currentPage is TabbedPage)
             {
-                await ProcessNavigationForTabbedPage((MultiPage<Page>)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                await ProcessNavigationForTabbedPage((TabbedPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
             }
-            else if (currentPage is MultiPage<ContentPage>)
+            else if (currentPage is CarouselPage)
             {
-                await ProcessNavigationForCarouselPage((MultiPage<ContentPage>)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                await ProcessNavigationForCarouselPage((CarouselPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
             }
             else if (currentPage is MasterDetailPage)
             {
-                await ProcessNavigationForMasterDetailPage((MasterDetailPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                await
+                    ProcessNavigationForMasterDetailPage((MasterDetailPage)currentPage, nextSegment, segments,
+                        parameters, useModalNavigation, animated);
             }
+            else
+            {
+                // Could not determine type for currentPage
+                await
+                    ProcessNavigationForPage(currentPage, nextSegment, segments, parameters, useModalNavigation,
+                        animated);
+            }
+        }
+
+        /// <summary>
+        /// Process navigation for <paramref name="currentPage"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Override this method to process navigation for any custom implementation of <see cref="Page"/> that does not inherit from 
+        /// <see cref="ContentPage"/>, <see cref="NavigationPage"/>, <see cref="TabbedPage"/>, <see cref="CarouselPage"/> or <see cref="MasterDetailPage"/>
+        /// </para>
+        /// </remarks>
+        /// <param name="currentPage">Page to navigate to</param>
+        /// <param name="nextSegment">Next navigation segment</param>
+        /// <param name="segments">Remaining navigation segments</param>
+        /// <param name="navigationParameters">The navigation parameters</param>
+        /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
+        /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition</param>
+        /// <returns></returns>
+        protected virtual Task ProcessNavigationForPage(Page currentPage, string nextSegment, Queue<string> segments,
+            NavigationParameters navigationParameters, bool? useModalNavigation, bool animated)
+        {
+            _logger.Log($"Processing vavigation for custom page '{currentPage.GetType()}'. Please implement an override to ProcessNavigationForPage to navigate to this page.", Category.Warn, Priority.Medium);
+            return Task.FromResult(0);
         }
 
         async Task ProcessNavigationForAbsoulteUri(Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
@@ -223,7 +256,7 @@ namespace Prism.Navigation
             }
         }
 
-        async Task ProcessNavigationForTabbedPage(MultiPage<Page> currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        async Task ProcessNavigationForTabbedPage(TabbedPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
             var nextSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
             foreach (var child in currentPage.Children)
@@ -244,7 +277,7 @@ namespace Prism.Navigation
             });
         }
 
-        async Task ProcessNavigationForCarouselPage(MultiPage<ContentPage> currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        async Task ProcessNavigationForCarouselPage(CarouselPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
             var nextSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
             foreach (var child in currentPage.Children)

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -185,7 +185,7 @@ namespace Prism.Navigation
         protected virtual Task ProcessNavigationForPage(Page currentPage, string nextSegment, Queue<string> segments,
             NavigationParameters navigationParameters, bool? useModalNavigation, bool animated)
         {
-            _logger.Log($"Processing vavigation for custom page '{currentPage.GetType()}'. Please implement an override to ProcessNavigationForPage to navigate to this page.", Category.Warn, Priority.Medium);
+            _logger.Log($"Processing navigation for custom page '{currentPage.GetType()}'. Please implement an override to ProcessNavigationForPage to navigate to this page.", Category.Warn, Priority.Medium);
             return Task.FromResult(0);
         }
 

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -137,13 +137,13 @@ namespace Prism.Navigation
             {
                 await ProcessNavigationForNavigationPage((NavigationPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
             }
-            else if (currentPage is TabbedPage)
+            else if (currentPage is MultiPage<Page>)
             {
-                await ProcessNavigationForTabbedPage((TabbedPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                await ProcessNavigationForTabbedPage((MultiPage<Page>)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
             }
-            else if (currentPage is CarouselPage)
+            else if (currentPage is MultiPage<ContentPage>)
             {
-                await ProcessNavigationForCarouselPage((CarouselPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                await ProcessNavigationForCarouselPage((MultiPage<ContentPage>)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
             }
             else if (currentPage is MasterDetailPage)
             {
@@ -218,7 +218,7 @@ namespace Prism.Navigation
             }
         }
 
-        async Task ProcessNavigationForTabbedPage(TabbedPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        async Task ProcessNavigationForTabbedPage(MultiPage<Page> currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
             var nextSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
             foreach (var child in currentPage.Children)
@@ -239,7 +239,7 @@ namespace Prism.Navigation
             });
         }
 
-        async Task ProcessNavigationForCarouselPage(CarouselPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        async Task ProcessNavigationForCarouselPage(MultiPage<ContentPage> currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
             var nextSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
             foreach (var child in currentPage.Children)


### PR DESCRIPTION
Renaming `ProcessNavigationForTabbedPage` to `ProcessNavigationForMultiPagePage` and `ProcessNavigationForCarouselPage` to `ProcessNavigationForMultiPageContentPage` more closely reflects the intention but the names feel funky :)

Thoughts?