### PR TITLE
fixed project type for XS 6.0

### DIFF
--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
@@ -48,7 +48,7 @@
 			</Files>
 		</Project>
 
-		<Project name = "${ProjectName}" directory = "." type = "PortableDotNet" if = "CreatePortableDotNetProject" >
+		<Project name = "${ProjectName}" directory = "." type = "C#PortableLibrary" if = "CreatePortableDotNetProject" >
 			<Options Target = "Library" TargetFrameworkVersion = ".NETPortable,Version=v4.5,Profile=Profile78"/>
 			<Files>
 

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/Properties/AddinInfo.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/Properties/AddinInfo.cs
@@ -2,7 +2,7 @@
 using Mono.Addins;
 using Mono.Addins.Description;
 
-[assembly:Addin ("PrismTemplatePack", Namespace = "Prism.Extensibility", Version = "1.2")]
+[assembly:Addin ("PrismTemplatePack", Namespace = "Prism.Extensibility", Version = "1.3")]
 
 [assembly:AddinName ("Prism Template Pack")]
 [assembly:AddinCategory ("IDE extensions")]


### PR DESCRIPTION
Fixed the project template for Xamarin Studio  6.0.  There was a breaking change with XS 6.0 where the portable project type changed from PortableDotNet to C#PortableLibrary