### PR TITLE
RequestNavigate Async Extensions

### DIFF
--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Regions\ContentControlRegionAdapter.cs" />
     <Compile Include="Regions\DefaultRegionManagerAccessor.cs" />
     <Compile Include="Regions\IConfirmNavigationRequest.cs" />
+    <Compile Include="Regions\IConfirmNavigationRequestAsync.cs" />
     <Compile Include="Regions\INavigateAsync.cs" />
     <Compile Include="Regions\INavigationAware.cs" />
     <Compile Include="Regions\IRegion.cs" />
@@ -193,6 +194,7 @@
     <Compile Include="Regions\ItemMetadata.cs" />
     <Compile Include="Regions\ItemsControlRegionAdapter.cs" />
     <Compile Include="Regions\IViewsCollection.cs" />
+    <Compile Include="Regions\NavigateAsyncExtensions.cs" />
     <Compile Include="Regions\NavigationAsyncExtensions.cs" />
     <Compile Include="Regions\NavigationContext.cs" />
     <Compile Include="Regions\NavigationParameters.cs" />
@@ -205,6 +207,7 @@
     <Compile Include="Regions\RegionBehaviorFactory.cs" />
     <Compile Include="Regions\RegionContext.cs" />
     <Compile Include="Regions\RegionManager.cs" />
+    <Compile Include="Regions\RegionManagerExtensions.cs" />
     <Compile Include="Regions\RegionMemberLifetimeAttribute.cs" />
     <Compile Include="Regions\RegionNavigationContentLoader.cs" />
     <Compile Include="Regions\RegionNavigationEventArgs.cs" />

--- a/Source/Wpf/Prism.Wpf/Regions/IConfirmNavigationRequestAsync.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/IConfirmNavigationRequestAsync.cs
@@ -1,0 +1,20 @@
+
+
+using System;
+using System.Threading.Tasks;
+
+namespace Prism.Regions
+{
+    /// <summary>
+    /// Provides a way for objects involved in navigation to determine if a navigation request should continue.
+    /// </summary>
+    public interface IConfirmNavigationRequestAsync : INavigationAware
+    {
+        /// <summary>
+        /// Determines whether this instance accepts being navigated away from.
+        /// </summary>
+        /// <param name="navigationContext">The navigation context.</param>
+        /// <returns>True if navigation was allowed</returns>
+        Task<bool> ConfirmNavigationRequestAsync(NavigationContext navigationContext);
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Regions/NavigateAsyncExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/NavigateAsyncExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Prism.Common;
+
+namespace Prism.Regions
+{
+    public static class NavigateAsyncExtensions
+    {
+        /// <summary>
+        /// Initiates navigation to the target specified by the <see cref="Uri" />.
+        /// </summary>
+        /// <param name="target">The navigation target</param>
+        /// <returns>The navigation result.</returns>
+        public static Task<NavigationResult> RequestNavigateAsync(this INavigateAsync navigation, Uri target)
+        {
+            if (navigation == null)
+                throw new ArgumentNullException(nameof(navigation));
+
+            return CallbackHelper.AwaitCallbackResult<NavigationResult>(callback => navigation.RequestNavigate(target, callback));
+        }
+
+        /// <summary>
+        /// Initiates navigation to the target specified by the <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="target">The navigation target</param>
+        /// <param name="navigationParameters">The navigation parameters specific to the navigation request.</param>
+        /// <returns>The navigation result.</returns>
+        public static Task<NavigationResult> RequestNavigateAsync(this INavigateAsync navigation, Uri target, NavigationParameters navigationParameters)
+        {
+            if (navigation == null)
+                throw new ArgumentNullException(nameof(navigation));
+
+            return CallbackHelper.AwaitCallbackResult<NavigationResult>(callback => navigation.RequestNavigate(target, callback, navigationParameters));
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Regions/RegionManagerExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionManagerExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Prism.Common;
+
+namespace Prism.Regions
+{
+    public static class RegionManagerExtensions
+    {
+        /// <summary>
+        /// Navigates the specified region manager.
+        /// </summary>
+        /// <param name="regionName">The name of the region to call Navigate on.</param>
+        /// <param name="source">The URI of the content to display.</param>
+        /// <returns>The navigation result.</returns>
+        public static Task<NavigationResult> RequestNavigateAsync(this IRegionManager regionManager, string regionName, Uri source)
+        {
+            if (regionManager == null)
+                throw new ArgumentNullException(nameof(regionManager));
+
+            return CallbackHelper.AwaitCallbackResult< NavigationResult>(callback => regionManager.RequestNavigate(regionName, source, callback));
+        }
+
+        /// <summary>
+        /// Navigates the specified region manager.
+        /// </summary>
+        /// <param name="regionName">The name of the region to call Navigate on.</param>
+        /// <param name="source">The URI of the content to display.</param>
+        /// <returns>The navigation result.</returns>
+        public static Task<NavigationResult> RequestNavigateAsync(this IRegionManager regionManager, string regionName, string source)
+        {
+            if (regionManager == null)
+                throw new ArgumentNullException(nameof(regionManager));
+
+            return CallbackHelper.AwaitCallbackResult<NavigationResult>(callback => regionManager.RequestNavigate(regionName, source, callback));
+        }
+
+        /// <summary>
+        /// This method allows an IRegionManager to locate a specified region and navigate in it to the specified target Uri, passing a navigation callback and an instance of NavigationParameters, which holds a collection of object parameters.
+        /// </summary>
+        /// <param name="regionName">The name of the region where the navigation will occur.</param>
+        /// <param name="target">A Uri that represents the target where the region will navigate.</param>
+        /// <param name="navigationParameters">An instance of NavigationParameters, which holds a collection of object parameters.</param>
+        /// <returns>The navigation result.</returns>
+        public static Task<NavigationResult> RequestNavigateAsync(this IRegionManager regionManager, string regionName, Uri target, NavigationParameters navigationParameters)
+        {
+            if (regionManager == null)
+                throw new ArgumentNullException(nameof(regionManager));
+
+            return CallbackHelper.AwaitCallbackResult<NavigationResult>(callback => regionManager.RequestNavigate(regionName, target, callback, navigationParameters));
+        }
+
+        /// <summary>
+        /// This method allows an IRegionManager to locate a specified region and navigate in it to the specified target string, passing a navigation callback and an instance of NavigationParameters, which holds a collection of object parameters.
+        /// </summary>
+        /// <param name="regionName">The name of the region where the navigation will occur.</param>
+        /// <param name="target">A string that represents the target where the region will navigate.</param>
+        /// <param name="navigationParameters">An instance of NavigationParameters, which holds a collection of object parameters.</param>
+        /// <returns>The navigation result.</returns>
+        public static Task<NavigationResult> RequestNavigateAsync(this IRegionManager regionManager, string regionName, string target, NavigationParameters navigationParameters)
+        {
+            if (regionManager == null)
+                throw new ArgumentNullException(nameof(regionManager));
+
+            return CallbackHelper.AwaitCallbackResult<NavigationResult>(callback => regionManager.RequestNavigate(regionName, target, callback, navigationParameters));
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace Prism.Regions
@@ -102,38 +103,62 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Initiates navigation to the specified target.
+        /// Initiates navigation to the target specified by the <see cref="Uri"/>.
         /// </summary>
-        /// <param name="target">The target.</param>
-        /// <param name="navigationCallback">A callback to execute when the navigation request is completed.</param>
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is marshalled to callback")]
+        /// <param name="target">The navigation target</param>
+        /// <param name="navigationCallback">The callback executed when the navigation request is completed.</param>
+        /// <remarks>
+        /// Convenience overloads for this method can be found as extension methods on the 
+        /// <see cref="NavigationAsyncExtensions"/> class.
+        /// </remarks>
         public void RequestNavigate(Uri target, Action<NavigationResult> navigationCallback)
         {
             this.RequestNavigate(target, navigationCallback, null);
         }
 
         /// <summary>
-        /// Initiates navigation to the specified target.
+        /// Initiates navigation to the target specified by the <see cref="Uri"/>.
         /// </summary>
-        /// <param name="target">The target.</param>
-        /// <param name="navigationCallback">A callback to execute when the navigation request is completed.</param>
+        /// <param name="target">The navigation target</param>
+        /// <param name="navigationCallback">The callback executed when the navigation request is completed.</param>
         /// <param name="navigationParameters">The navigation parameters specific to the navigation request.</param>
+        /// <remarks>
+        /// Convenience overloads for this method can be found as extension methods on the 
+        /// <see cref="NavigationAsyncExtensions"/> class.
+        /// </remarks>
         public void RequestNavigate(Uri target, Action<NavigationResult> navigationCallback, NavigationParameters navigationParameters)
         {
             if (navigationCallback == null)
                 throw new ArgumentNullException(nameof(navigationCallback));
 
+            RequestNavigateImpl(target, navigationCallback, navigationParameters);
+        }
+
+        private async void RequestNavigateImpl(Uri target, Action<NavigationResult> navigationCallback, NavigationParameters navigationParameters)
+        {
+            NavigationResult result = await this.RequestNavigateAsync(target, navigationParameters);
+            navigationCallback(result);
+        }
+
+        /// <summary>
+        /// Initiates navigation to the specified target.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="navigationParameters">The navigation parameters specific to the navigation request.</param>
+        /// <returns>The navigation result.</returns>
+        private async Task<NavigationResult> RequestNavigateAsync(Uri target, NavigationParameters navigationParameters)
+        {
             try
             {
-                this.DoNavigate(target, navigationCallback, navigationParameters);
+                return await this.DoNavigateAsync(target, navigationParameters);
             }
             catch (Exception e)
             {
-                this.NotifyNavigationFailed(new NavigationContext(this, target), navigationCallback, e);
+                return this.NotifyNavigationFailed(new NavigationContext(this, target), e);
             }
         }
 
-        private void DoNavigate(Uri source, Action<NavigationResult> navigationCallback, NavigationParameters navigationParameters)
+        private async Task<NavigationResult> DoNavigateAsync(Uri source, NavigationParameters navigationParameters)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -143,107 +168,45 @@ namespace Prism.Regions
 
             this.currentNavigationContext = new NavigationContext(this, source, navigationParameters);
 
-            // starts querying the active views
-            RequestCanNavigateFromOnCurrentlyActiveView(
-                this.currentNavigationContext,
-                navigationCallback,
-                this.Region.ActiveViews.ToArray(),
-                0);
-        }
+            NavigationContext navigationContext = this.currentNavigationContext;
 
-        private void RequestCanNavigateFromOnCurrentlyActiveView(
-            NavigationContext navigationContext,
-            Action<NavigationResult> navigationCallback,
-            object[] activeViews,
-            int currentViewIndex)
-        {
-            if (currentViewIndex < activeViews.Length)
+            object[] activeViews = this.Region.ActiveViews.ToArray();
+
+            foreach (object view in activeViews)
             {
-                var vetoingView = activeViews[currentViewIndex] as IConfirmNavigationRequest;
+                var vetoingView = MvvmHelpers.GetImplementerFromViewOrViewModel<IConfirmNavigationRequestAsync>(view);
+
                 if (vetoingView != null)
+                {
+                    // the current active view implements IConfirmNavigationRequestAsync, request confirmation
+                    bool canNavigate = await vetoingView.ConfirmNavigationRequestAsync(navigationContext);
+
+                    if (!(this.currentNavigationContext == navigationContext && canNavigate))
+                    {
+                        return this.NotifyNavigationFailed(navigationContext, null);
+                    }
+                }
+
+                var vetoingViewOld = MvvmHelpers.GetImplementerFromViewOrViewModel<IConfirmNavigationRequest>(view);
+                
+                if (vetoingViewOld != null)
                 {
                     // the current active view implements IConfirmNavigationRequest, request confirmation
                     // providing a callback to resume the navigation request
-                    vetoingView.ConfirmNavigationRequest(
-                        navigationContext,
-                        canNavigate =>
-                        {
-                            if (this.currentNavigationContext == navigationContext && canNavigate)
-                            {
-                                RequestCanNavigateFromOnCurrentlyActiveViewModel(
-                                    navigationContext,
-                                    navigationCallback,
-                                    activeViews,
-                                    currentViewIndex);
-                            }
-                            else
-                            {
-                                this.NotifyNavigationFailed(navigationContext, navigationCallback, null);
-                            }
-                        });
-                }
-                else
-                {
-                    RequestCanNavigateFromOnCurrentlyActiveViewModel(
-                        navigationContext,
-                        navigationCallback,
-                        activeViews,
-                        currentViewIndex);
-                }
-            }
-            else
-            {
-                ExecuteNavigation(navigationContext, activeViews, navigationCallback);
-            }
-        }
+                    bool canNavigate = await CallbackHelper.AwaitCallbackResult<bool>(callback => vetoingViewOld.ConfirmNavigationRequest(navigationContext, callback));
 
-        private void RequestCanNavigateFromOnCurrentlyActiveViewModel(
-            NavigationContext navigationContext,
-            Action<NavigationResult> navigationCallback,
-            object[] activeViews,
-            int currentViewIndex)
-        {
-            var frameworkElement = activeViews[currentViewIndex] as FrameworkElement;
-
-            if (frameworkElement != null)
-            {
-                var vetoingViewModel = frameworkElement.DataContext as IConfirmNavigationRequest;
-
-                if (vetoingViewModel != null)
-                {
-                    // the data model for the current active view implements IConfirmNavigationRequest, request confirmation
-                    // providing a callback to resume the navigation request
-                    vetoingViewModel.ConfirmNavigationRequest(
-                        navigationContext,
-                        canNavigate =>
-                        {
-                            if (this.currentNavigationContext == navigationContext && canNavigate)
-                            {
-                                RequestCanNavigateFromOnCurrentlyActiveView(
-                                    navigationContext,
-                                    navigationCallback,
-                                    activeViews,
-                                    currentViewIndex + 1);
-                            }
-                            else
-                            {
-                                this.NotifyNavigationFailed(navigationContext, navigationCallback, null);
-                            }
-                        });
-
-                    return;
+                    if (!(this.currentNavigationContext == navigationContext && canNavigate))
+                    {
+                        return this.NotifyNavigationFailed(navigationContext, null);
+                    }
                 }
             }
 
-            RequestCanNavigateFromOnCurrentlyActiveView(
-                navigationContext,
-                navigationCallback,
-                activeViews,
-                currentViewIndex + 1);
+            return ExecuteNavigation(navigationContext, activeViews);
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is marshalled to callback")]
-        private void ExecuteNavigation(NavigationContext navigationContext, object[] activeViews, Action<NavigationResult> navigationCallback)
+        private NavigationResult ExecuteNavigation(NavigationContext navigationContext, object[] activeViews)
         {
             try
             {
@@ -266,24 +229,25 @@ namespace Prism.Regions
                 Action<INavigationAware> action = (n) => n.OnNavigatedTo(navigationContext);
                 MvvmHelpers.ViewAndViewModelAction(view, action);
 
-                navigationCallback(new NavigationResult(navigationContext, true));
-
                 // Raise the navigated event when navigation is completed.
                 this.RaiseNavigated(navigationContext);
+
+                return new NavigationResult(navigationContext, true);
             }
             catch (Exception e)
             {
-                this.NotifyNavigationFailed(navigationContext, navigationCallback, e);
+                return this.NotifyNavigationFailed(navigationContext, e);
             }
         }
 
-        private void NotifyNavigationFailed(NavigationContext navigationContext, Action<NavigationResult> navigationCallback, Exception e)
+        private NavigationResult NotifyNavigationFailed(NavigationContext navigationContext, Exception e)
         {
             var navigationResult =
                 e != null ? new NavigationResult(navigationContext, e) : new NavigationResult(navigationContext, false);
 
-            navigationCallback(navigationResult);
             this.RaiseNavigationFailed(navigationContext, e);
+
+            return navigationResult;
         }
 
         private static void NotifyActiveViewsNavigatingFrom(NavigationContext navigationContext, object[] activeViews)


### PR DESCRIPTION
This PR is somewhat similar to from what #118 started.  This one is alternative to and incompatible with #646.

# Changes

In addition to  `IConfirmNavigationRequest`  interface, a new interface  `IConfirmNavigationRequestAsync`  was added:
```csharp
public interface IConfirmNavigationRequestAsync : INavigationAware
{
    Task<bool> ConfirmNavigationRequestAsync(NavigationContext navigationContext);
}
```
Both interfaces are supported. That is, the framework will query the currently active view for implementation of either of these interfaces.

Task-based asynchronous versions of RequestNavigate methods for `INavigateAsync` were added in `NavigateAsyncExtensions`.  These extensions will work for derived interfaces and classes: `IRegion`, `Region`, `IRegionNavigationService`, `RegionNavigationService`.

Task-based asynchronous versions of RequestNavigate methods for `IRegionManager` were added in `RegionManagerExtensions`.  Those will work for derived interfaces and classes, including RegionManager.

Implementation of RegionNavigationService was changed to support `IConfirmNavigationRequestAsync`.  To simplify things, it is implemented using async/await.  Callback-based RequestNavigate that it exposes via IRegionNavigationService is implemented by delegating to private Task-based RequestNavigateAsync method.

Now the implementation of RegionNavigationService.RequestNavigate is clean and lean.


