### PR TITLE
Simplified method GetUriSegments

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
@@ -143,6 +143,14 @@ namespace Prism.Forms.Tests.Common
         }
 
         [Fact]
+        public void ParametersParsedFromUriWithEmptyPathSegments()
+        {
+            var uri = new Uri("app://forms/MainPage//DetailPage");
+            var target = UriParsingHelper.GetUriSegments(uri);
+            Assert.Equal(2, target.Count);
+        }
+
+        [Fact]
         public void EnsureAbsoluteUriForRelativeUri()
         {
             var uri = UriParsingHelper.EnsureAbsolute(new Uri(_relativeUri, UriKind.Relative));

--- a/Source/Xamarin/Prism.Forms/Common/UriParsingHelper.cs
+++ b/Source/Xamarin/Prism.Forms/Common/UriParsingHelper.cs
@@ -9,26 +9,22 @@ namespace Prism.Common
     /// </summary>
     public static class UriParsingHelper
     {
+        private static readonly char[] _pathDelimiter = { '/' };
+
         public static Queue<string> GetUriSegments(Uri uri)
         {
-            Queue<string> segmentStack = new Queue<string>();
-            string[] segments;
+            var segmentStack = new Queue<string>();
 
             if (!uri.IsAbsoluteUri)
-                segments = EnsureAbsolute(uri).PathAndQuery.Split('/');
-            else
-                segments = uri.PathAndQuery.Split('/');
-
-            for (int i = 0; i < segments.Length; i++)
             {
-                var s = segments[i];
-                if (string.IsNullOrEmpty(s))
-                    continue;
-
-                s = Uri.UnescapeDataString(s);
-                segmentStack.Enqueue(s);
+                uri = EnsureAbsolute(uri);
             }
 
+            string[] segments = uri.PathAndQuery.Split(_pathDelimiter, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var segment in segments)
+            {
+                segmentStack.Enqueue(Uri.UnescapeDataString(segment));
+            }
 
             return segmentStack;
         }
@@ -42,12 +38,14 @@ namespace Prism.Common
         {
             string query = string.Empty;
 
-            if (!String.IsNullOrWhiteSpace(segment))
+            if (string.IsNullOrWhiteSpace(segment))
             {
-                var indexOfQuery = segment.IndexOf('?');
-                if (indexOfQuery > 0)
-                    query = segment.Substring(indexOfQuery);
+                return new NavigationParameters(query);
             }
+
+            var indexOfQuery = segment.IndexOf('?');
+            if (indexOfQuery > 0)
+                query = segment.Substring(indexOfQuery);
 
             return new NavigationParameters(query);
         }


### PR DESCRIPTION
Simplified method to utilize StringSplitOptions.RemoveEmptyEntries. Added test to ensure empty entries aren't added to the segments queue.