### PR TITLE
Autoset AutowireViewModel

### DIFF
--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -11,16 +11,16 @@ namespace Prism.Mvvm
         /// Instructs Prism whether or not to automatically create an instance of a ViewModel using a convention, and assign the associated View's <see cref="Xamarin.Forms.BindableObject.BindingContext"/> to that instance.
         /// </summary>
         public static readonly BindableProperty AutowireViewModelProperty =
-            BindableProperty.CreateAttached("AutowireViewModel", typeof(bool), typeof(ViewModelLocator), default(bool), propertyChanged: OnAutowireViewModelChanged);
+            BindableProperty.CreateAttached("AutowireViewModel", typeof(bool?), typeof(ViewModelLocator), null, propertyChanged: OnAutowireViewModelChanged);
 
         /// <summary>
         /// Gets the AutowireViewModel property value.
         /// </summary>
         /// <param name="bindable"></param>
         /// <returns></returns>
-        public static bool GetAutowireViewModel(BindableObject bindable)
+        public static bool? GetAutowireViewModel(BindableObject bindable)
         {
-            return (bool)bindable.GetValue(ViewModelLocator.AutowireViewModelProperty);
+            return (bool?)bindable.GetValue(ViewModelLocator.AutowireViewModelProperty);
         }
 
         /// <summary>
@@ -28,14 +28,15 @@ namespace Prism.Mvvm
         /// </summary>
         /// <param name="bindable"></param>
         /// <param name="value"></param>
-        public static void SetAutowireViewModel(BindableObject bindable, bool value)
+        public static void SetAutowireViewModel(BindableObject bindable, bool? value)
         {
             bindable.SetValue(ViewModelLocator.AutowireViewModelProperty, value);
         }
 
         private static void OnAutowireViewModelChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            if ((bool)newValue)
+            bool? bNewValue = (bool?)newValue;
+            if (bNewValue.HasValue && bNewValue.Value)
                 ViewModelLocationProvider.AutoWireViewModelChanged(bindable, Bind);
         }
 

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -364,6 +364,8 @@ namespace Prism.Navigation
                 if (page == null)
                     throw new NullReferenceException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
 
+                SetAutowireViewModelOnPage(page);
+
                 return page;
             }
             catch (Exception e)
@@ -371,6 +373,13 @@ namespace Prism.Navigation
                 _logger.Log(e.ToString(), Category.Exception, Priority.High);
                 throw;
             }
+        }
+
+        void SetAutowireViewModelOnPage(Page page)
+        {
+            var vmlResult = Mvvm.ViewModelLocator.GetAutowireViewModel(page);
+            if (vmlResult == null)
+                Mvvm.ViewModelLocator.SetAutowireViewModel(page, true);
         }
 
         static bool HasNavigationPageParent(Page page)


### PR DESCRIPTION
First attempt at autosetting VML.AutowireViewModel propery to true.  This makes using Prism even easier as you no longer have to worry about doing this manually.  This does make this an opt-out feature.