### PR TITLE
Remove invalid comment

### DIFF
--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -239,8 +239,7 @@ namespace Prism.Interactivity
 
         /// <summary>
         /// Checks if the WindowContent or its DataContext implements <see cref="IInteractionRequestAware"/>.
-        /// If so, it sets the corresponding value.
-        /// Also, if WindowContent does not have a RegionManager attached, it creates a new scoped RegionManager for it.
+        /// If so, it sets the corresponding values.
         /// </summary>
         /// <param name="notification">The notification to be set as a DataContext in the HostWindow.</param>
         /// <param name="wrapperWindow">The HostWindow</param>


### PR DESCRIPTION
In replace of #709 

Prism' PopupWindowAction was created based on Damian Cherubini's [PopupWindowAction: using custom views instead of windows in WPF and Prism](http://southworks.com/blog/2012/05/24/popupwindowaction-using-custom-views-instead-of-windows-in-wpf-and-prism/).

The comment was valid in Cherubini's version, but Prism' version does not have this functionality: it does not set RegionManager.