### PR TITLE
Add a GetValue method the NavigationParameters Class

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/NavigationParametersFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/NavigationParametersFixture.cs
@@ -1,9 +1,5 @@
 ﻿using Prism.Navigation;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Prism.Forms.Tests.Navigation
@@ -67,6 +63,45 @@ namespace Prism.Forms.Tests.Navigation
                 var parameters = new NavigationParameters(_uri);
                 parameters.Add("id", 3);
             });            
+        }
+
+        [Fact]
+        public void GetValueSuccessfull()
+        {
+            const string validKey = "ValidKey";
+            const int expectedValue = 100;
+
+            var parameters = new NavigationParameters { { validKey, expectedValue } };
+            var resultValue = parameters.GetValue<int>(validKey);
+
+            Assert.Equal(expectedValue, resultValue);
+        }
+
+        [Fact]
+        public void GetValueThrowsExceptionWhenCastIsInvalid()
+        {
+            const string invalidCastKey = "InvalidCastKey";
+            const string invalidCastValue = "Invalid Cast Value";
+            var expectedType = typeof(int);
+
+            var parameters = new NavigationParameters { { invalidCastKey, "Blah" } };
+
+
+            var ex = Assert.Throws<NavigationParameterInvalidCastException>(() => parameters.GetValue<int>(invalidCastKey));
+
+            Assert.Equal(invalidCastKey, ex.InvalidCaskKey);
+            Assert.Equal(expectedType, ex.ExpectedType);
+            Assert.Equal(invalidCastValue.GetType(), ex.ActualType);
+        }
+
+        [Fact]
+        public void GetValueThrowsExceptionWhenKeyIsMissing()
+        {
+            const string missingKey = "MissingKey";
+            var parameters = new NavigationParameters();
+
+            var ex = Assert.Throws<NavigationParameterNotFoundException>(() => parameters.GetValue<int>(missingKey));
+            Assert.Equal(missingKey, ex.MissingKey);
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationParameterInvalidCastException.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationParameterInvalidCastException.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace Prism.Navigation
+{
+    /// <summary>
+    /// Thrown when the navigation parameter can't be cast.
+    /// </summary>
+    public class NavigationParameterInvalidCastException : InvalidCastException
+    {
+        /// <summary>
+        /// Creates an exception with the missing key and a default message about
+        /// the missing key.
+        /// </summary>
+        /// <param name="invalidCastKey">The missing navigation parameters key.</param>
+        /// <param name="expectedType">The expected type of the navigation parameter.</param>
+        /// <param name="actualType">The actual type of the navigation parameter value.</param>
+        public NavigationParameterInvalidCastException(string invalidCastKey, Type expectedType, Type actualType)
+            : base("The navigation parameter value for key '" + invalidCastKey + "' is of type '" + actualType + "' and can't be cast to '" + expectedType + "'.")
+        {
+            if (invalidCastKey == null) throw new ArgumentNullException(nameof(invalidCastKey));
+            if (expectedType == null) throw new ArgumentNullException(nameof(expectedType));
+            if (actualType == null) throw new ArgumentNullException(nameof(actualType));
+
+            InvalidCaskKey = invalidCastKey;
+            ExpectedType = expectedType;
+            ActualType = actualType;
+        }
+
+        /// <summary>
+        /// The key with the invalid cast.
+        /// </summary>
+        public string InvalidCaskKey { get; }
+
+        /// <summary>
+        /// The expected type of the navigation parameter.
+        /// </summary>
+        public Type ExpectedType { get; }
+
+        /// <summary>
+        /// The actual type of the navigation parameter value.
+        /// </summary>s
+        public Type ActualType { get; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationParameterNotFoundException.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationParameterNotFoundException.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Prism.Navigation
+{
+    /// <summary>
+    /// Thrown when a Prism navigation parameter does not exist.
+    /// </summary>
+    public class NavigationParameterNotFoundException : KeyNotFoundException
+    {
+        /// <summary>
+        /// Creates an exception with the missing key and a default message about
+        /// the missing key.
+        /// </summary>
+        /// <param name="missingKey">The missing navigation parameters key.</param>
+        public NavigationParameterNotFoundException(string missingKey) : base("Missing navigation parameter '" + missingKey + "'.")
+        {
+            MissingKey = missingKey;
+        }
+
+        /// <summary>
+        /// The missing navigation parameters key.
+        /// </summary>
+        public string MissingKey { get; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationParameters.cs
@@ -94,5 +94,33 @@ namespace Prism.Navigation
 
             return queryBuilder.ToString();
         }
+
+        /// <summary>
+        /// Gets and types the values from the <see cref="NavigationParameters"/>.  Throws an exception if the
+        /// parameter is missing or can't be cast.
+        /// </summary>
+        /// <typeparam name="TValueType">What type the parameter value is expected to be.</typeparam>
+        /// <param name="key">The key of the parameter to parse.</param>
+        /// <exception cref="NavigationParameterNotFoundException">Thrown if the key is not found.</exception>
+        /// <exception cref="NavigationParameterInvalidCastException">Thrown if the key can't be cast.</exception>
+        /// <returns>The value of the key from the navigation parameter.</returns>
+        public TValueType GetValue<TValueType>(string key)
+        {
+            // Does the parameter exist.
+            if (!ContainsKey(key))
+            {
+                throw new NavigationParameterNotFoundException(key);
+            }
+
+            // Try to cast it.
+            try
+            {
+                return (TValueType)this[key];
+            }
+            catch (InvalidCastException)
+            {
+                throw new NavigationParameterInvalidCastException(key, typeof(TValueType), this[key].GetType());
+            }
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -54,6 +54,8 @@
   <ItemGroup>
     <Compile Include="IPlatformInitializer.cs" />
     <Compile Include="Navigation\INavigationPageOptions.cs" />
+    <Compile Include="Navigation\NavigationParameterInvalidCastException.cs" />
+    <Compile Include="Navigation\NavigationParameterNotFoundException.cs" />
     <Compile Include="PrismApplicationBase.cs" />
     <Compile Include="Common\ApplicationProvider.cs" />
     <Compile Include="Common\IApplicationProvider.cs" />


### PR DESCRIPTION
I originally wrote the GetValue method as an extension to the NavigationParameters in my Xamarin.  It gets the value from the navigation dictionary casting it correctly.  It throws exceptions if the casting fails or the key does not exist.  Thought others might find the method useful hence the pull request.  I look forward to your feedback and please let me know if you are not interested in this feature.

Please also note this is my first pull request so if I did anything incorrect please let me know.  

Thank you.