### PR TITLE
Adding DelegateCommand observes INotifyCollectionChanged

### DIFF
--- a/Source/Prism/Commands/CollectionInfo.cs
+++ b/Source/Prism/Commands/CollectionInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Reflection;
+
+namespace Prism.Commands
+{
+    internal class CollectionInfo
+    {
+        public PropertyInfo Property { get; }
+        public INotifyCollectionChanged Collection { get; }
+
+        public CollectionInfo(PropertyInfo property, INotifyCollectionChanged collection)
+        {
+            this.Property = property;
+            this.Collection = collection;
+        }
+    }
+}

--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -82,6 +82,18 @@ namespace Prism.Commands
         }
 
         /// <summary>
+        /// Observes a collection that implements INotifyCollectionChanged, and automatically calls DelegateCommandBase.RaiseCanExecuteChanged on collection changed notifications.
+        /// </summary>
+        /// <typeparam name="TP">The object type containing the collection property specified in the expression.</typeparam>
+        /// <param name="collectionExpression">The collection expression. Example: ObservesProperty(() => CollectionPropertyName).</param>
+        /// <returns>The current instance of DelegateCommand</returns>
+        public DelegateCommand<T> ObservesCollection<TP>(Expression<Func<TP>> collectionExpression)
+        {
+            ObservesCollectionInternal(collectionExpression);
+            return this;
+        }
+
+        /// <summary>
         /// Observes a property that is used to determine if this command can execute, and if it implements INotifyPropertyChanged it will automatically call DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
         /// </summary>
         /// <param name="canExecuteExpression">The property expression. Example: ObservesCanExecute((o) => PropertyName).</param>
@@ -187,6 +199,18 @@ namespace Prism.Commands
         public DelegateCommand ObservesProperty<T>(Expression<Func<T>> propertyExpression)
         {
             ObservesPropertyInternal(propertyExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Observes a collection that implements INotifyCollectionChanged, and automatically calls DelegateCommandBase.RaiseCanExecuteChanged on collection changed notifications.
+        /// </summary>
+        /// <typeparam name="T">The object type containing the collection property specified in the expression.</typeparam>
+        /// <param name="collectionExpression">The collection expression. Example: ObservesProperty(() => CollectionPropertyName).</param>
+        /// <returns>The current instance of DelegateCommand</returns>
+        public DelegateCommand ObservesCollection<T>(Expression<Func<T>> collectionExpression)
+        {
+            ObservesCollectionInternal(collectionExpression);
             return this;
         }
 

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -58,6 +58,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\CollectionInfo.cs" />
     <Compile Include="Commands\CompositeCommand.cs" />
     <Compile Include="Commands\DelegateCommand.cs" />
     <Compile Include="Commands\DelegateCommandBase.cs" />


### PR DESCRIPTION
Similar to ObservesProperty and ObservesCanExecute, but this works for collections as well. I find that a lot of my commands depend on having one or more objects in a collection and this method simplifies that use case. 