### PR TITLE
AsyncDelegateCommand implementation

### DIFF
--- a/Source/Prism.Tests/Mvvm/DelegateCommandFixture.cs
+++ b/Source/Prism.Tests/Mvvm/DelegateCommandFixture.cs
@@ -607,6 +607,44 @@ namespace Prism.Tests.Mvvm
             });
         }
 
+        [Fact]
+        public void Test_should_fail_because_of_thrown_exception()
+        {
+            Assert.Throws<AggregateException>(() =>
+            {
+                new DelegateCommand(() => { throw new Exception(); }).Execute();
+            });
+        }
+
+        [Fact]
+        public void Test_should_fail_because_of_thrown_exception_generic()
+        {
+            Assert.Throws<AggregateException>(() =>
+            {
+                new DelegateCommand<object>((o) => { throw new Exception(); }).Execute(null);
+            });
+        }
+
+        [Fact]
+        public void Test_should_fail_because_of_thrown_exception_ICommand()
+        {
+            Assert.Throws<AggregateException>(() =>
+            {
+                ICommand command = new DelegateCommand(() => { throw new Exception(); });
+                command.Execute(null);
+            });
+        }
+
+        [Fact]
+        public void Test_should_fail_because_of_thrown_exception_generic_ICommand()
+        {
+            Assert.Throws<AggregateException>(() =>
+            {
+                ICommand command = new DelegateCommand<object>((o) => { throw new Exception(); });
+                command.Execute(null);
+            });
+        }
+
         private bool _boolProperty;
         public bool BoolProperty
         {

--- a/Source/Prism.Tests/Mvvm/DelegateCommandFixture.cs
+++ b/Source/Prism.Tests/Mvvm/DelegateCommandFixture.cs
@@ -610,7 +610,7 @@ namespace Prism.Tests.Mvvm
         [Fact]
         public void Test_should_fail_because_of_thrown_exception()
         {
-            Assert.Throws<AggregateException>(() =>
+            Assert.Throws<Exception>(() =>
             {
                 new DelegateCommand(() => { throw new Exception(); }).Execute();
             });
@@ -619,7 +619,7 @@ namespace Prism.Tests.Mvvm
         [Fact]
         public void Test_should_fail_because_of_thrown_exception_generic()
         {
-            Assert.Throws<AggregateException>(() =>
+            Assert.Throws<Exception>(() =>
             {
                 new DelegateCommand<object>((o) => { throw new Exception(); }).Execute(null);
             });
@@ -628,7 +628,7 @@ namespace Prism.Tests.Mvvm
         [Fact]
         public void Test_should_fail_because_of_thrown_exception_ICommand()
         {
-            Assert.Throws<AggregateException>(() =>
+            Assert.Throws<Exception>(() =>
             {
                 ICommand command = new DelegateCommand(() => { throw new Exception(); });
                 command.Execute(null);
@@ -638,7 +638,7 @@ namespace Prism.Tests.Mvvm
         [Fact]
         public void Test_should_fail_because_of_thrown_exception_generic_ICommand()
         {
-            Assert.Throws<AggregateException>(() =>
+            Assert.Throws<Exception>(() =>
             {
                 ICommand command = new DelegateCommand<object>((o) => { throw new Exception(); });
                 command.Execute(null);

--- a/Source/Prism/Commands/AsyncDelegateCommand.cs
+++ b/Source/Prism/Commands/AsyncDelegateCommand.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Prism.Properties;
+
+namespace Prism.Commands
+{
+    /// <summary>
+    /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute"/> and <see cref="CanExecute"/>.
+    /// </summary>
+    public class AsyncDelegateCommand : DelegateCommand, ICommand
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="AsyncDelegateCommand"/> with awaitable handler method to invoke on execution.
+        /// </summary>
+        /// <param name="executeMethod">The awaitable handler method to invoke when <see cref="ICommand.Execute"/> is called.</param>
+        public AsyncDelegateCommand(Func<Task> executeMethod)
+            : this(executeMethod, () => true)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AsyncDelegateCommand"/> with awaitable handler method to invoke on execution
+        /// and a <see langword="Func" /> to query for determining if the command can execute.
+        /// </summary>
+        /// <param name="executeMethod">The awaitable handler method to invoke when <see cref="ICommand.Execute"/> is called.</param>
+        /// <param name="canExecuteMethod">The <see cref="Func{TResult}"/> to invoke when <see cref="ICommand.CanExecute"/> is called</param>
+        public AsyncDelegateCommand(Func<Task> executeMethod, Func<bool> canExecuteMethod)
+            : base(executeMethod, canExecuteMethod)
+        {
+            if (executeMethod == null || canExecuteMethod == null)
+                throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
+        }
+
+        async void ICommand.Execute(object parameter)
+        {
+            await _executeMethod(parameter);
+        }
+
+        public override Task Execute()
+        {
+            return _executeMethod(null);
+        }
+    }
+}

--- a/Source/Prism/Commands/AsyncDelegateCommand{T}.cs
+++ b/Source/Prism/Commands/AsyncDelegateCommand{T}.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Prism.Properties;
+
+namespace Prism.Commands
+{
+    /// <summary>
+    /// An <see cref="ICommand"/> whose delegates can be attached for <see cref="Execute"/> and <see cref="CanExecute"/>.
+    /// </summary>
+    /// <typeparam name="T">Parameter type.</typeparam>
+    /// <remarks>
+    /// The constructor deliberately prevents the use of value types.
+    /// Because ICommand takes an object, having a value type for T would cause unexpected behavior when CanExecute(null) is called during XAML initialization for command bindings.
+    /// Using default(T) was considered and rejected as a solution because the implementor would not be able to distinguish between a valid and defaulted values.
+    /// <para/>
+    /// Instead, callers should support a value type by using a nullable value type and checking the HasValue property before using the Value property.
+    /// <example>
+    ///     <code>
+    /// public MyClass()
+    /// {
+    ///     this.submitCommand = new DelegateCommand&lt;int?&gt;(this.Submit, this.CanSubmit);
+    /// }
+    /// 
+    /// private bool CanSubmit(int? customerId)
+    /// {
+    ///     return (customerId.HasValue &amp;&amp; customers.Contains(customerId.Value));
+    /// }
+    ///     </code>
+    /// </example>
+    /// </remarks>
+    public class AsyncDelegateCommand<T> : DelegateCommand<T>, ICommand
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="AsyncDelegateCommand{T}"/>.
+        /// </summary>
+        /// <param name="executeMethod">An awaitable handler method to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
+        /// <remarks><see cref="CanExecute"/> will always return true.</remarks>
+        public AsyncDelegateCommand(Func<T, Task> executeMethod)
+            : this(executeMethod, (o) => true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="AsyncDelegateCommand{T}"/>.
+        /// </summary>
+        /// <param name="executeMethod">An awaitable hander method to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
+        /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
+        /// <exception cref="ArgumentNullException">When both <paramref name="executeMethod"/> and <paramref name="canExecuteMethod"/> ar <see langword="null" />.</exception>
+        public AsyncDelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
+            : base((o) => executeMethod((T)o), (o) => canExecuteMethod((T)o))
+        {
+            if (executeMethod == null || canExecuteMethod == null)
+                throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
+        }
+
+        async void ICommand.Execute(object parameter)
+        {
+            await _executeMethod(parameter);
+        }
+
+        public override Task Execute(T parameter)
+        {
+            return _executeMethod(parameter);
+        }
+    }
+}

--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -69,6 +69,7 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command.</param>
         /// <returns>Constructed instance of <see cref="DelegateCommand"/></returns>
+        [Obsolete("Please use AsyncDelegateCommand")]
         public static AsyncDelegateCommand FromAsyncHandler(Func<Task> executeMethod)
         {
             return new AsyncDelegateCommand(executeMethod);
@@ -80,6 +81,7 @@ namespace Prism.Commands
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
         /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
         /// <returns>Constructed instance of <see cref="DelegateCommand"/></returns>
+        [Obsolete("Please use AsyncDelegateCommand")]
         public static AsyncDelegateCommand FromAsyncHandler(Func<Task> executeMethod, Func<bool> canExecuteMethod)
         {
             return new AsyncDelegateCommand(executeMethod, canExecuteMethod);

--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -8,153 +8,11 @@ using Prism.Properties;
 namespace Prism.Commands
 {
     /// <summary>
-    /// An <see cref="ICommand"/> whose delegates can be attached for <see cref="Execute"/> and <see cref="CanExecute"/>.
-    /// </summary>
-    /// <typeparam name="T">Parameter type.</typeparam>
-    /// <remarks>
-    /// The constructor deliberately prevents the use of value types.
-    /// Because ICommand takes an object, having a value type for T would cause unexpected behavior when CanExecute(null) is called during XAML initialization for command bindings.
-    /// Using default(T) was considered and rejected as a solution because the implementor would not be able to distinguish between a valid and defaulted values.
-    /// <para/>
-    /// Instead, callers should support a value type by using a nullable value type and checking the HasValue property before using the Value property.
-    /// <example>
-    ///     <code>
-    /// public MyClass()
-    /// {
-    ///     this.submitCommand = new DelegateCommand&lt;int?&gt;(this.Submit, this.CanSubmit);
-    /// }
-    /// 
-    /// private bool CanSubmit(int? customerId)
-    /// {
-    ///     return (customerId.HasValue &amp;&amp; customers.Contains(customerId.Value));
-    /// }
-    ///     </code>
-    /// </example>
-    /// </remarks>
-    public class DelegateCommand<T> : DelegateCommandBase
-    {
-        /// <summary>
-        /// Initializes a new instance of <see cref="DelegateCommand{T}"/>.
-        /// </summary>
-        /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
-        /// <remarks><see cref="CanExecute"/> will always return true.</remarks>
-        public DelegateCommand(Action<T> executeMethod)
-            : this(executeMethod, (o) => true)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="DelegateCommand{T}"/>.
-        /// </summary>
-        /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
-        /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
-        /// <exception cref="ArgumentNullException">When both <paramref name="executeMethod"/> and <paramref name="canExecuteMethod"/> ar <see langword="null" />.</exception>
-        public DelegateCommand(Action<T> executeMethod, Func<T, bool> canExecuteMethod)
-            : base((o) => executeMethod((T)o), (o) => canExecuteMethod((T)o))
-        {
-            if (executeMethod == null || canExecuteMethod == null)
-                throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
-
-            TypeInfo genericTypeInfo = typeof(T).GetTypeInfo();
-
-            // DelegateCommand allows object or Nullable<>.  
-            // note: Nullable<> is a struct so we cannot use a class constraint.
-            if (genericTypeInfo.IsValueType)
-            {
-                if ((!genericTypeInfo.IsGenericType) || (!typeof(Nullable<>).GetTypeInfo().IsAssignableFrom(genericTypeInfo.GetGenericTypeDefinition().GetTypeInfo())))
-                {
-                    throw new InvalidCastException(Resources.DelegateCommandInvalidGenericPayloadType);
-                }
-            }
-
-        }
-
-        /// <summary>
-        /// Observes a property that implements INotifyPropertyChanged, and automatically calls DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
-        /// </summary>
-        /// <typeparam name="TP">The object type containing the property specified in the expression.</typeparam>
-        /// <param name="propertyExpression">The property expression. Example: ObservesProperty(() => PropertyName).</param>
-        /// <returns>The current instance of DelegateCommand</returns>
-        public DelegateCommand<T> ObservesProperty<TP>(Expression<Func<TP>> propertyExpression)
-        {
-            ObservesPropertyInternal(propertyExpression);
-            return this;
-        }
-
-        /// <summary>
-        /// Observes a property that is used to determine if this command can execute, and if it implements INotifyPropertyChanged it will automatically call DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
-        /// </summary>
-        /// <param name="canExecuteExpression">The property expression. Example: ObservesCanExecute((o) => PropertyName).</param>
-        /// <returns>The current instance of DelegateCommand</returns>
-        public DelegateCommand<T> ObservesCanExecute(Expression<Func<object, bool>> canExecuteExpression)
-        {
-            ObservesCanExecuteInternal(canExecuteExpression);
-            return this;
-        }
-
-        /// <summary>
-        /// Factory method to create a new instance of <see cref="DelegateCommand{T}"/> from an awaitable handler method.
-        /// </summary>
-        /// <param name="executeMethod">Delegate to execute when Execute is called on the command.</param>
-        /// <returns>Constructed instance of <see cref="DelegateCommand{T}"/></returns>
-        public static DelegateCommand<T> FromAsyncHandler(Func<T, Task> executeMethod)
-        {
-            return new DelegateCommand<T>(executeMethod);
-        }
-
-        /// <summary>
-        /// Factory method to create a new instance of <see cref="DelegateCommand{T}"/> from an awaitable handler method.
-        /// </summary>
-        /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
-        /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
-        /// <returns>Constructed instance of <see cref="DelegateCommand{T}"/></returns>
-        public static DelegateCommand<T> FromAsyncHandler(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
-        {
-            return new DelegateCommand<T>(executeMethod, canExecuteMethod);
-        }
-
-        ///<summary>
-        ///Determines if the command can execute by invoked the <see cref="Func{T,Bool}"/> provided during construction.
-        ///</summary>
-        ///<param name="parameter">Data used by the command to determine if it can execute.</param>
-        ///<returns>
-        ///<see langword="true" /> if this command can be executed; otherwise, <see langword="false" />.
-        ///</returns>
-        public virtual bool CanExecute(T parameter)
-        {
-            return base.CanExecute(parameter);
-        }
-
-        ///<summary>
-        ///Executes the command and invokes the <see cref="Action{T}"/> provided during construction.
-        ///</summary>
-        ///<param name="parameter">Data used by the command.</param>
-        public virtual Task Execute(T parameter)
-        {
-            return base.Execute(parameter);
-        }
-
-
-        protected DelegateCommand(Func<T, Task> executeMethod)
-            : this(executeMethod, (o) => true)
-        {
-        }
-
-        protected DelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
-            : base((o) => executeMethod((T)o), (o) => canExecuteMethod((T)o))
-        {
-            if (executeMethod == null || canExecuteMethod == null)
-                throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
-        }
-
-    }
-
-    /// <summary>
     /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute"/> and <see cref="CanExecute"/>.
     /// </summary>
     /// <see cref="DelegateCommandBase"/>
     /// <see cref="DelegateCommand{T}"/>
-    public class DelegateCommand : DelegateCommandBase
+    public class DelegateCommand : DelegateCommandBase, ICommand
     {
         /// <summary>
         /// Creates a new instance of <see cref="DelegateCommand"/> with the <see cref="Action"/> to invoke on execution.
@@ -176,6 +34,11 @@ namespace Prism.Commands
         {
             if (executeMethod == null || canExecuteMethod == null)
                 throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
+        }
+
+        void ICommand.Execute(object parameter)
+        {
+            Execute(parameter).Wait();
         }
 
         /// <summary>
@@ -202,24 +65,24 @@ namespace Prism.Commands
         }
 
         /// <summary>
-        /// Factory method to create a new instance of <see cref="DelegateCommand"/> from an awaitable handler method.
+        /// Factory method to create a new instance of <see cref="AsyncDelegateCommand"/> from an awaitable handler method.
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command.</param>
         /// <returns>Constructed instance of <see cref="DelegateCommand"/></returns>
-        public static DelegateCommand FromAsyncHandler(Func<Task> executeMethod)
+        public static AsyncDelegateCommand FromAsyncHandler(Func<Task> executeMethod)
         {
-            return new DelegateCommand(executeMethod);
+            return new AsyncDelegateCommand(executeMethod);
         }
 
         /// <summary>
-        /// Factory method to create a new instance of <see cref="DelegateCommand"/> from an awaitable handler method.
+        /// Factory method to create a new instance of <see cref="AsyncDelegateCommand"/> from an awaitable handler method.
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
         /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
         /// <returns>Constructed instance of <see cref="DelegateCommand"/></returns>
-        public static DelegateCommand FromAsyncHandler(Func<Task> executeMethod, Func<bool> canExecuteMethod)
+        public static AsyncDelegateCommand FromAsyncHandler(Func<Task> executeMethod, Func<bool> canExecuteMethod)
         {
-            return new DelegateCommand(executeMethod, canExecuteMethod);
+            return new AsyncDelegateCommand(executeMethod, canExecuteMethod);
         }
 
         ///<summary>
@@ -227,7 +90,9 @@ namespace Prism.Commands
         ///</summary>
         public virtual Task Execute()
         {
-            return Execute(null);
+            Execute(null).Wait();
+
+            return Task.Delay(0);
         }
 
         /// <summary>
@@ -239,11 +104,6 @@ namespace Prism.Commands
             return CanExecute(null);
         }
 
-        protected DelegateCommand(Func<Task> executeMethod)
-            : this(executeMethod, () => true)
-        {
-        }
-
         protected DelegateCommand(Func<Task> executeMethod, Func<bool> canExecuteMethod)
             : base((o) => executeMethod(), (o) => canExecuteMethod())
         {
@@ -251,5 +111,4 @@ namespace Prism.Commands
                 throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
         }
     }
-
 }

--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -38,7 +38,7 @@ namespace Prism.Commands
 
         void ICommand.Execute(object parameter)
         {
-            Execute(parameter).Wait();
+            _executeMethod(parameter);
         }
 
         /// <summary>
@@ -90,9 +90,7 @@ namespace Prism.Commands
         ///</summary>
         public virtual Task Execute()
         {
-            Execute(null).Wait();
-
-            return Task.Delay(0);
+            return _executeMethod(null);
         }
 
         /// <summary>

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -70,7 +70,7 @@ namespace Prism.Commands
 
         void ICommand.Execute(object parameter)
         {
-            Execute(parameter).Wait();
+            _executeMethod(parameter);
         }
 
         /// <summary>
@@ -135,9 +135,7 @@ namespace Prism.Commands
         ///<param name="parameter">Data used by the command.</param>
         public virtual Task Execute(T parameter)
         {
-            base.Execute(parameter).Wait();
-
-            return Task.Delay(0);
+            return _executeMethod(parameter);
         }
 
         protected DelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -97,21 +97,23 @@ namespace Prism.Commands
         }
 
         /// <summary>
-        /// Factory method to create a new instance of <see cref="DelegateCommand{T}"/> from an awaitable handler method.
+        /// Factory method to create a new instance of <see cref="AsyncDelegateCommand{T}"/> from an awaitable handler method.
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command.</param>
         /// <returns>Constructed instance of <see cref="DelegateCommand{T}"/></returns>
+        [Obsolete("Please use AsyncDelegateCommand")]
         public static AsyncDelegateCommand<T> FromAsyncHandler(Func<T, Task> executeMethod)
         {
             return new AsyncDelegateCommand<T>(executeMethod);
         }
 
         /// <summary>
-        /// Factory method to create a new instance of <see cref="DelegateCommand{T}"/> from an awaitable handler method.
+        /// Factory method to create a new instance of <see cref="AsyncDelegateCommand{T}"/> from an awaitable handler method.
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
         /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
         /// <returns>Constructed instance of <see cref="DelegateCommand{T}"/></returns>
+        [Obsolete("Please use AsyncDelegateCommand")]
         public static AsyncDelegateCommand<T> FromAsyncHandler(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
         {
             return new AsyncDelegateCommand<T>(executeMethod, canExecuteMethod);

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Prism.Properties;
+
+namespace Prism.Commands
+{
+    /// <summary>
+    /// An <see cref="ICommand"/> whose delegates can be attached for <see cref="Execute"/> and <see cref="CanExecute"/>.
+    /// </summary>
+    /// <typeparam name="T">Parameter type.</typeparam>
+    /// <remarks>
+    /// The constructor deliberately prevents the use of value types.
+    /// Because ICommand takes an object, having a value type for T would cause unexpected behavior when CanExecute(null) is called during XAML initialization for command bindings.
+    /// Using default(T) was considered and rejected as a solution because the implementor would not be able to distinguish between a valid and defaulted values.
+    /// <para/>
+    /// Instead, callers should support a value type by using a nullable value type and checking the HasValue property before using the Value property.
+    /// <example>
+    ///     <code>
+    /// public MyClass()
+    /// {
+    ///     this.submitCommand = new DelegateCommand&lt;int?&gt;(this.Submit, this.CanSubmit);
+    /// }
+    /// 
+    /// private bool CanSubmit(int? customerId)
+    /// {
+    ///     return (customerId.HasValue &amp;&amp; customers.Contains(customerId.Value));
+    /// }
+    ///     </code>
+    /// </example>
+    /// </remarks>
+    public class DelegateCommand<T> : DelegateCommandBase, ICommand
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="DelegateCommand{T}"/>.
+        /// </summary>
+        /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
+        /// <remarks><see cref="CanExecute"/> will always return true.</remarks>
+        public DelegateCommand(Action<T> executeMethod)
+            : this(executeMethod, (o) => true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DelegateCommand{T}"/>.
+        /// </summary>
+        /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
+        /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
+        /// <exception cref="ArgumentNullException">When both <paramref name="executeMethod"/> and <paramref name="canExecuteMethod"/> ar <see langword="null" />.</exception>
+        public DelegateCommand(Action<T> executeMethod, Func<T, bool> canExecuteMethod)
+            : base((o) => executeMethod((T)o), (o) => canExecuteMethod((T)o))
+        {
+            if (executeMethod == null || canExecuteMethod == null)
+                throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
+
+            TypeInfo genericTypeInfo = typeof(T).GetTypeInfo();
+
+            // DelegateCommand allows object or Nullable<>.  
+            // note: Nullable<> is a struct so we cannot use a class constraint.
+            if (genericTypeInfo.IsValueType)
+            {
+                if ((!genericTypeInfo.IsGenericType) || (!typeof(Nullable<>).GetTypeInfo().IsAssignableFrom(genericTypeInfo.GetGenericTypeDefinition().GetTypeInfo())))
+                {
+                    throw new InvalidCastException(Resources.DelegateCommandInvalidGenericPayloadType);
+                }
+            }
+        }
+
+        void ICommand.Execute(object parameter)
+        {
+            Execute(parameter).Wait();
+        }
+
+        /// <summary>
+        /// Observes a property that implements INotifyPropertyChanged, and automatically calls DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
+        /// </summary>
+        /// <typeparam name="TP">The object type containing the property specified in the expression.</typeparam>
+        /// <param name="propertyExpression">The property expression. Example: ObservesProperty(() => PropertyName).</param>
+        /// <returns>The current instance of DelegateCommand</returns>
+        public DelegateCommand<T> ObservesProperty<TP>(Expression<Func<TP>> propertyExpression)
+        {
+            ObservesPropertyInternal(propertyExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Observes a property that is used to determine if this command can execute, and if it implements INotifyPropertyChanged it will automatically call DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
+        /// </summary>
+        /// <param name="canExecuteExpression">The property expression. Example: ObservesCanExecute((o) => PropertyName).</param>
+        /// <returns>The current instance of DelegateCommand</returns>
+        public DelegateCommand<T> ObservesCanExecute(Expression<Func<object, bool>> canExecuteExpression)
+        {
+            ObservesCanExecuteInternal(canExecuteExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Factory method to create a new instance of <see cref="DelegateCommand{T}"/> from an awaitable handler method.
+        /// </summary>
+        /// <param name="executeMethod">Delegate to execute when Execute is called on the command.</param>
+        /// <returns>Constructed instance of <see cref="DelegateCommand{T}"/></returns>
+        public static AsyncDelegateCommand<T> FromAsyncHandler(Func<T, Task> executeMethod)
+        {
+            return new AsyncDelegateCommand<T>(executeMethod);
+        }
+
+        /// <summary>
+        /// Factory method to create a new instance of <see cref="DelegateCommand{T}"/> from an awaitable handler method.
+        /// </summary>
+        /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
+        /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
+        /// <returns>Constructed instance of <see cref="DelegateCommand{T}"/></returns>
+        public static AsyncDelegateCommand<T> FromAsyncHandler(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
+        {
+            return new AsyncDelegateCommand<T>(executeMethod, canExecuteMethod);
+        }
+
+        ///<summary>
+        ///Determines if the command can execute by invoked the <see cref="Func{T,Bool}"/> provided during construction.
+        ///</summary>
+        ///<param name="parameter">Data used by the command to determine if it can execute.</param>
+        ///<returns>
+        ///<see langword="true" /> if this command can be executed; otherwise, <see langword="false" />.
+        ///</returns>
+        public virtual bool CanExecute(T parameter)
+        {
+            return base.CanExecute(parameter);
+        }
+
+        ///<summary>
+        ///Executes the command and invokes the <see cref="Action{T}"/> provided during construction.
+        ///</summary>
+        ///<param name="parameter">Data used by the command.</param>
+        public virtual Task Execute(T parameter)
+        {
+            base.Execute(parameter).Wait();
+
+            return Task.Delay(0);
+        }
+
+        protected DelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
+            : base((o) => executeMethod((T)o), (o) => canExecuteMethod((T)o))
+        {
+            if (executeMethod == null || canExecuteMethod == null)
+                throw new ArgumentNullException(nameof(executeMethod), Resources.DelegateCommandDelegatesCannotBeNull);
+        }
+    }
+}

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -58,9 +58,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\AsyncDelegateCommand.cs" />
+    <Compile Include="Commands\AsyncDelegateCommand{T}.cs" />
     <Compile Include="Commands\CompositeCommand.cs" />
     <Compile Include="Commands\DelegateCommand.cs" />
     <Compile Include="Commands\DelegateCommandBase.cs" />
+    <Compile Include="Commands\DelegateCommand{T}.cs" />
     <Compile Include="Events\BackgroundEventSubscription.cs" />
     <Compile Include="Events\DataEventArgs.cs" />
     <Compile Include="Events\DelegateReference.cs" />


### PR DESCRIPTION
A PR for #724 

Introduces AsyncDelegateCommand.  For backward compatibility, DelegateCommand.FromAsyncHandler is kept but now it returns AsyncDelegateCommand.

Also, for backward compatibility, AsyncDelegateCommand inherits from DelegateCommand which, in general, is not needed.

FromAsyncHandler declared Obsolete.  In the next version, after the users removed FromAsyncHandler from their sources and replace DelegateCommand by AsyncDelegateCommand where needed, FromAsyncHandler may be deleted and the source code simplified.

DelegateCommand and `DelegateCommand<T>` are initialized with synchronous handler in the constructor.
AsyncDelegateCommand and `AsyncDelegateCommand<T>` are initialized with asynchronous handler in the constructor.

In DelegateCommand and `DelegateCommand<T>`, ICommand.Execute() executes the handler synchronously.  The `Task Execute()` method executes the handler synchronously and returns already completed Task which may be safely ignored (no await or Wait() needed).  All exceptions in the handler, if any, are raised in the caller's code before the Execute method returns.

