### PR TITLE
Ensure PrismApplication.Logger uses registered instance

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -66,6 +66,14 @@ namespace Prism.Autofac
             return new ContainerBuilder().Build();
         }
 
+        protected override ILoggerFacade CreateLogger()
+        {
+            if( Container != null && Container.IsRegistered<ILoggerFacade>() )
+                return Container.Resolve<ILoggerFacade>();
+
+            return base.CreateLogger();
+        }
+
         protected override IModuleManager CreateModuleManager()
         {
             return Container.Resolve<IModuleManager>();

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -6,6 +6,7 @@ using Prism.DryIoc.Extensions;
 using Prism.DryIoc.Modularity;
 using Prism.DryIoc.Navigation;
 using Prism.Events;
+using Prism.Logging;
 using Prism.Modularity;
 using Prism.Mvvm;
 using Prism.Navigation;
@@ -48,6 +49,14 @@ namespace Prism.DryIoc
         {
             var rules = CreateContainerRules();
             return new Container(rules);
+        }
+
+        protected override ILoggerFacade CreateLogger()
+        {
+            if( Container != null && Container.IsRegistered<ILoggerFacade>() )
+                return Container.Resolve<ILoggerFacade>();
+
+            return base.CreateLogger();
         }
 
         protected override IModuleManager CreateModuleManager()

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -74,6 +74,8 @@ namespace Prism
             _platformInitializer?.RegisterTypes(Container);
 
             InitializeModules();
+
+            Logger = CreateLogger();
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
@@ -49,6 +49,14 @@ namespace Prism.Ninject
             return new StandardKernel();
         }
 
+        protected override ILoggerFacade CreateLogger()
+        {
+            if( Container != null && Container.CanResolve<ILoggerFacade>() )
+                return Container.Get<ILoggerFacade>();
+
+            return base.CreateLogger();
+        }
+
         protected override IModuleManager CreateModuleManager()
         {
             return Container.Get<IModuleManager>();

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -47,6 +47,14 @@ namespace Prism.Unity
             return new UnityContainer();
         }
 
+        protected override ILoggerFacade CreateLogger()
+        {
+            if( Container != null && Container.IsRegistered<ILoggerFacade>() )
+                return Container.Resolve<ILoggerFacade>();
+
+            return base.CreateLogger();
+        }
+
         protected override IModuleManager CreateModuleManager()
         {
             return Container.Resolve<IModuleManager>();


### PR DESCRIPTION
Adds second call to CreateLogger at the end of the Initialization so that during initialization so that while we may have a Debug logger during initialization, once the Container and supporting types have been registered we can resolve the ILoggerFacade registered either in shared code or in the PlatformInitializer.
