### PR TITLE
#281 Adding an override to provide custom logic for determing when to restore.

### DIFF
--- a/Source/Windows10/Prism.Windows.Tests/Mocks/MockSessionStateService.cs
+++ b/Source/Windows10/Prism.Windows.Tests/Mocks/MockSessionStateService.cs
@@ -51,5 +51,10 @@ namespace Prism.Windows.Tests.Mocks
         {
             return GetSessionStateForFrameDelegate(frame);
         }
+
+        public Task<bool> CanRestoreSessionStateAsync()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Source/Windows10/Prism.Windows/AppModel/ISessionStateService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/ISessionStateService.cs
@@ -40,6 +40,12 @@ namespace Prism.Windows.AppModel
         Task SaveAsync();
 
         /// <summary>
+        /// Determines whether previously saved <see cref="SessionState"/> exists.
+        /// </summary>
+        /// <returns>An asynchronous task that reflects whether or not previously saved <see cref="SessionState"/> exists.</returns>
+        Task<bool> CanRestoreSessionStateAsync();
+
+        /// <summary>
         /// Restores previously saved <see cref="SessionState"/>.
         /// </summary>
         /// <returns>An asynchronous task that reflects when session state has been read. The

--- a/Source/Windows10/Prism.Windows/AppModel/SessionStateService.cs
+++ b/Source/Windows10/Prism.Windows/AppModel/SessionStateService.cs
@@ -92,6 +92,23 @@ namespace Prism.Windows.AppModel
         }
 
         /// <summary>
+        /// Determines whether previously saved <see cref="SessionState"/> exists.
+        /// </summary>
+        /// <returns>An asynchronous task that reflects whether or not previously saved <see cref="SessionState"/> exists.</returns>
+        public async Task<bool> CanRestoreSessionStateAsync()
+        {
+            try
+            {
+                StorageFile file = await ApplicationData.Current.LocalFolder.GetFileAsync(Constants.SessionStateFileName);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Restores previously saved <see cref="SessionState"/>.
         /// </summary>
         /// <returns>An asynchronous task that reflects when session state has been read. The

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -110,7 +110,7 @@ namespace Prism.Windows
         public bool IsSuspending { get; private set; }
 
         /// <summary>
-        /// Override this method with logic that will be performed after the application is initialized. For example, navigating to the application's home page.
+        /// Override this method with logic that will be performed after the application is initialized when it is not resuming. For example, navigating to the application's home page.
         /// Note: This is called whenever the app is launched normally (start menu, taskbar, etc.) but not when resuming.
         /// </summary>
         /// <param name="args">The <see cref="LaunchActivatedEventArgs"/> instance containing the event data.</param>
@@ -259,8 +259,8 @@ namespace Prism.Windows
         }
 
         /// <summary>
-        /// Invoked when the application is launched normally by the end user. Other entry points
-        /// will be used when the application is launched to open a specific file, to display
+        /// Invoked when the application is launched normally by the end user and the application is not resuming.
+        /// Other entry points will be used when the application is launched to open a specific file, to display
         /// search results, and so forth.
         /// </summary>
         /// <param name="args">Details about the launch request and process.</param>
@@ -277,7 +277,7 @@ namespace Prism.Windows
             {
                 await OnLaunchApplicationAsync(args);
             }
-            else if (Window.Current.Content != null & _isRestoringFromTermination)
+            else if (Window.Current.Content != null && _isRestoringFromTermination)
             {
                 await OnResumeApplicationAsync(args);
             }
@@ -325,6 +325,7 @@ namespace Prism.Windows
         /// <summary>
         /// Override this method to provide custom logic that determines whether the app should restore state from a previous session.
         /// By default, the app will only restore state when args.PreviousExecutionState is <see cref="ApplicationExecutionState"/>.Terminated.
+        /// Note: restoring from state will prevent OnLaunchApplicationAsync() from getting called, as that is only called during a fresh launch.
         /// </summary>
         /// <returns>True if the app should restore state. False if the app should perform a fresh launch.</returns>
         protected virtual bool ShouldRestoreState(IActivatedEventArgs args) => args.PreviousExecutionState == ApplicationExecutionState.Terminated;
@@ -371,7 +372,8 @@ namespace Prism.Windows
             ConfigureViewModelLocator();
 
             OnRegisterKnownTypesForSerialization();
-            bool shouldRestore = ShouldRestoreState(args);
+            bool canRestore = await SessionStateService.CanRestoreSessionStateAsync();
+            bool shouldRestore = canRestore && ShouldRestoreState(args);
             if (shouldRestore)
             {
                 await SessionStateService.RestoreSessionStateAsync();

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -323,6 +323,13 @@ namespace Prism.Windows
         protected virtual ISessionStateService OnCreateSessionStateService() => null;
 
         /// <summary>
+        /// Override this method to provide custom logic that determines whether the app should restore state from a previous session.
+        /// By default, the app will only restore state when args.PreviousExecutionState is <see cref="ApplicationExecutionState"/>.Terminated.
+        /// </summary>
+        /// <returns>True if the app should restore state. False if the app should perform a fresh launch.</returns>
+        protected virtual bool ShouldRestoreState(IActivatedEventArgs args) => args.PreviousExecutionState == ApplicationExecutionState.Terminated;
+
+        /// <summary>
         /// Initializes the Frame and its content.
         /// </summary>
         /// <param name="args">The <see cref="IActivatedEventArgs"/> instance containing the event data.</param>
@@ -364,14 +371,15 @@ namespace Prism.Windows
             ConfigureViewModelLocator();
 
             OnRegisterKnownTypesForSerialization();
-            if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
+            bool shouldRestore = ShouldRestoreState(args);
+            if (shouldRestore)
             {
                 await SessionStateService.RestoreSessionStateAsync();
             }
 
             await OnInitializeAsync(args);
 
-            if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
+            if (shouldRestore)
             {
                 // Restore the saved session state and navigate to the last page visited
                 try
@@ -389,7 +397,7 @@ namespace Prism.Windows
 
             return rootFrame;
         }
-
+        
         /// <summary>
         /// Handling the forward navigation request from the <see cref="IDeviceGestureService"/>
         /// </summary>


### PR DESCRIPTION
Picking this back up from #539.

This pull request addresses #281 Prism.Windows should provide a hook for the application to prevent restoring app state.
Adding an override to PrismApplication to allow the app to provide custom logic that determines whether the app should restore state from a previous session.