### PR TITLE
Fix broken links in Documentation/README

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -4,21 +4,21 @@ The documentation for Prism 6 is a work in progress.
 
 ## WPF
 
-- [Introduction to the Prism Library for WPF](WPF/01-Introduction.md)
-- [Initializing Applications Using the Prism Library for WPF](WPF/10-InitializingPrismApplications.md)
-- [Managing Dependencies Between Components Using the Prism Library for WPF](WPF/20-ManagingDependenciesBetweenComponents.md)
-- [Modular Application Development Using Prism Library for WPF](WPF/30-ModularApplicationDevelopment.md)
-- [Implementing the MVVM Pattern Using the Prism Library for WPF](WPF/40-ImplementingtheMVVMPattern.md)
-- [Advanced MVVM Scenarios Using the Prism Library for WPF](WPF/45-AdvancedMVVMScenarios.md)
-- [Composing the User Interface Using the Prism Library for WPF](WPF/50-ComposingtheUserInterface.md)
-- [Navigation Using the Prism Library for WPF](WPF/60-Navigation.md)
-- [Communicating Between Loosely Coupled Components Using the Prism Library for WPF](WPF/70-CommunicatingBetweenLooselyCoupledComponents.md)
-- [Deploying Applications Using the Prism Library for WPF](WPF/90-DeployingPrismApplications.md)
-- [Glossary for the Prism Library for WPF](WPF/AppendixA-Glossary.md)
-- [Patterns in the Prism Library for WPF](WPF/AppendixB-PatternsinthePrismLibrary.md)
-- [Prism Library for WPF](WPF/AppendixC-PrismLibrary.md)
-- [Extending the Prism Library 5.0 for WPF](WPF/AppendixE1-ExtendingPrism.md)
-- [Publishing and Updating Applications Using the Prism Library for WPF Hands-on Lab](WPF/AppendixI-PrismWPFClickOnceDeploymentHOL.md)
+- [Introduction to the Prism Library for WPF](wpf/01-Introduction.md)
+- [Initializing Applications Using the Prism Library for WPF](wpf/10-InitializingPrismApplications.md)
+- [Managing Dependencies Between Components Using the Prism Library for WPF](wpf/20-ManagingDependenciesBetweenComponents.md)
+- [Modular Application Development Using Prism Library for WPF](wpf/30-ModularApplicationDevelopment.md)
+- [Implementing the MVVM Pattern Using the Prism Library for WPF](wpf/40-ImplementingtheMVVMPattern.md)
+- [Advanced MVVM Scenarios Using the Prism Library for WPF](wpf/45-AdvancedMVVMScenarios.md)
+- [Composing the User Interface Using the Prism Library for WPF](wpf/50-ComposingtheUserInterface.md)
+- [Navigation Using the Prism Library for WPF](wpf/60-Navigation.md)
+- [Communicating Between Loosely Coupled Components Using the Prism Library for WPF](wpf/70-CommunicatingBetweenLooselyCoupledComponents.md)
+- [Deploying Applications Using the Prism Library for WPF](wpf/90-DeployingPrismApplications.md)
+- [Glossary for the Prism Library for WPF](wpf/AppendixA-Glossary.md)
+- [Patterns in the Prism Library for WPF](wpf/AppendixB-PatternsinthePrismLibrary.md)
+- [Prism Library for WPF](wpf/AppendixC-PrismLibrary.md)
+- [Extending the Prism Library 5.0 for WPF](wpf/AppendixE1-ExtendingPrism.md)
+- [Publishing and Updating Applications Using the Prism Library for WPF Hands-on Lab](wpf/AppendixI-PrismWPFClickOnceDeploymentHOL.md)
 
 ## Windows 10 UWP
 
@@ -26,11 +26,11 @@ TBD, meanwhile you can use the [Windows 8 documentation](https://msdn.microsoft.
 
 ## Xamarin Forms
 
-- [Getting started with Prism for Xamarin.Forms](Xamarin.Forms/1-GettingStarted.md)
-- [Using the ViewModelLocator](Xamarin.Forms/2-ViewModelLocator.md)
-- [Using the Navigation Service](Xamarin.Forms/3-NavigationService.md)
-- [Using the Page Dialog Service](Xamarin.Forms/4-PageDialogService.md)
-- [Using the DependencyService with Prism](Xamarin.Forms/5-DependencyService.md)
+- [Getting started with Prism for Xamarin.Forms](xamarin.forms/1-GettingStarted.md)
+- [Using the ViewModelLocator](xamarin.forms/2-ViewModelLocator.md)
+- [Using the Navigation Service](xamarin.forms/3-NavigationService.md)
+- [Using the Page Dialog Service](xamarin.forms/4-PageDialogService.md)
+- [Using the DependencyService with Prism](xamarin.forms/5-DependencyService.md)
 
 ### Other
 


### PR DESCRIPTION
Documentation folders have been renamed to lowercase breaking some links in the README file (404s). This PR fixes the links.