### PR TITLE
Revert "Autoresolve types with Autofac"

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -9,9 +9,11 @@ using Prism.Services;
 using DependencyService = Prism.Services.DependencyService;
 using Prism.Modularity;
 using Autofac;
-using Autofac.Features.ResolveAnything;
 using Prism.Autofac.Forms.Modularity;
+using System;
+using System.Globalization;
 using Prism.Autofac.Navigation;
+using Prism;
 using Prism.Autofac.Forms;
 
 namespace Prism.Autofac
@@ -34,11 +36,9 @@ namespace Prism.Autofac
         /// The method <see cref="IPlatformInitializer.RegisterTypes(IContainer)"/> will be called after <see cref="PrismApplication.RegisterTypes()"/> 
         /// to allow for registering platform specific instances.
         /// </remarks>
-        protected PrismApplication(IPlatformInitializer initializer = null)
-            : base(initializer)
-        {
-        }
-        
+        public PrismApplication(IPlatformInitializer initializer = null) : base(initializer) { }
+
+
         protected override void ConfigureViewModelLocator()
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
@@ -95,9 +95,6 @@ namespace Prism.Autofac
         protected override void ConfigureContainer()
         {
             var builder = new ContainerBuilder();
-
-            // Make sure any not specifically registered concrete type can resolve.
-            builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
 
             builder.RegisterInstance(Logger).As<ILoggerFacade>().SingleInstance();
             builder.RegisterInstance(ModuleCatalog).As<IModuleCatalog>().SingleInstance();


### PR DESCRIPTION
Reverts PrismLibrary/Prism#860.  This PR broke an Autofac test

```
        [Fact]
        public async Task Navigate_Key()
        {
            var app = new PrismApplicationMock();
            var navigationService = ResolveAndSetRootPage(app);
            await navigationService.NavigateAsync("view");
            var rootPage = ((IPageAware)navigationService).Page;
            Assert.True(rootPage.Navigation.ModalStack.Count == 1);
            Assert.IsType(typeof(ViewMock), rootPage.Navigation.ModalStack[0]);
        }
```