### PR TITLE
Added missing references in PrismUnityApp Xamarin Studio Project-Temp…

### DIFF
--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
@@ -8,6 +8,9 @@ using Android.Views;
 using Android.Widget;
 using Android.OS;
 
+using Prism.Unity;
+using Microsoft.Practices.Unity;
+
 namespace ${Namespace}
 {
 	[Activity (Label = "${ProjectName}", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]

--- a/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/AppDelegate.cs
+++ b/Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/AppDelegate.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using Foundation;
 using UIKit;
 
+using Prism.Unity;
+using Microsoft.Practices.Unity;
+
 namespace ${Namespace}
 {
 	// The UIApplicationDelegate for the application. This class is responsible for launching the 


### PR DESCRIPTION
`using Prism.Unity;`
`using Microsoft.Practices.Unity;`

were missing in the .Droid- and .iOS-Projects of the Xamarin Studio Project-Template, so I added them.