### PR TITLE
Add additional add view method which uses a given RegionManager.

### DIFF
--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
@@ -201,6 +201,19 @@ namespace Prism.Wpf.Tests.Regions
         }
 
         [TestMethod]
+        public void AddViewReturnsGivenRegionManager()
+        {
+            var regionManager = new MockRegionManager();
+            IRegion region = new Region();
+            region.RegionManager = regionManager;
+            var myView = new object();
+
+            var returnedRegionManager = region.Add(myView, "MyView", regionManager);
+
+            Assert.AreSame(regionManager, returnedRegionManager);
+        }
+
+        [TestMethod]
         public void AddViewReturnsExistingRegionManager()
         {
             var regionManager = new MockRegionManager();

--- a/Source/Wpf/Prism.Wpf/Regions/IRegion.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/IRegion.cs
@@ -67,6 +67,15 @@ namespace Prism.Regions
         IRegionManager Add(object view, string viewName, bool createRegionManagerScope);
 
         /// <summary>
+        /// Adds a new view to the region with the given region manager.
+        /// </summary>
+        /// <param name="view">The view to add.</param>
+        /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="GetView"/>.</param>
+        /// <param name="regionManager">The <see cref="IRegionManager"/> that is used for this region.</param>
+        /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="DependencyObject"/>.</returns>
+        IRegionManager Add(object view, string viewName, IRegionManager regionManager);
+
+        /// <summary>
         /// Removes the specified view from the region.
         /// </summary>
         /// <param name="view">The view to remove.</param>

--- a/Source/Wpf/Prism.Wpf/Regions/Region.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Region.cs
@@ -261,6 +261,19 @@ namespace Prism.Regions
             this.InnerAdd(view, viewName, manager);
             return manager;
         }
+        /// <summary>
+        /// Adds a new view to the region.
+        /// </summary>
+        /// <param name="view">The view to add.</param>
+        /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="IRegion.GetView"/>.</param>
+        /// <param name="createRegionManagerScope">When <see langword="true"/>, the added view will receive a new instance of <see cref="IRegionManager"/>, otherwise it will use the current region manager for this region.</param>
+        /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="DependencyObject"/>.</returns>
+        public virtual IRegionManager Add(object view, string viewName, IRegionManager regionManager)
+        {
+            IRegionManager manager = regionManager ?? this.RegionManager;
+            this.InnerAdd(view, viewName, manager);
+            return manager;
+        }
 
         /// <summary>
         /// Removes the specified view from the region.


### PR DESCRIPTION
In the use case you want to add views to a region using view injection, it's preferable to have the RegionManager of said region available ahead of time for possible IoC purposes. This minor addition will allow users to create their own RegionManager and inject it into the Region.Add() function.