### PR TITLE
Why hard coded links

### DIFF
--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
@@ -25,6 +25,7 @@ namespace Prism.Navigation
       var name = nameof(T);
 
       //should we allow navigating by page type at all?
+      //name can also be retrieved from the items registered for the navigation.
       if (name.EndsWith(ViewModelSuffix))
         name = name.Replace(ViewModelSuffix, PageSuffix);
       else if (!name.EndsWith(PageSuffix))

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Prism.Navigation
+{
+  public static class PrismNavigationExtensions
+  {
+    public const string ViewModelSuffix = "ViewModel";
+    public const string PageSuffix = "Page";
+
+    public static Task NavigateAsync<T>(this INavigationService navigationService, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
+      where T : class
+    {
+      var name = nameof(T);
+
+      //should we allow navigating by page type at all?
+      if (name.EndsWith(ViewModelSuffix))
+        name = name.Replace(ViewModelSuffix, PageSuffix);
+      else if (!name.EndsWith(PageSuffix))
+        throw new ArgumentOutOfRangeException($"Unable to parse ViewModel '{name}'.");
+
+      return navigationService.NavigateAsync(name, parameters, useModalNavigation, animated);
+    }
+  }
+}

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
@@ -8,6 +8,17 @@ namespace Prism.Navigation
     public const string ViewModelSuffix = "ViewModel";
     public const string PageSuffix = "Page";
 
+    /// <summary>
+    /// Initiates navigation to the target specified by the name.
+    /// </summary>
+    /// <typeparam name="T">The type of the target to navigate to.</typeparam>
+    /// <param name="navigationService">The <see cref="INavigationService"/> object to initiate the navigation request with.</param>
+    /// <param name="parameters">The navigation parameters.</param>
+    /// <param name="useModalNavigation">If true uses PopModalAsync, if false uses PopAsync.</param>
+    /// <param name="animated">If true the transition is animated, if false there is no animation on transition.</param>
+    /// <remarks>
+    /// Name must end with either ViewModel or Page, and must have a matching navigation object available.
+    /// </remarks>
     public static Task NavigateAsync<T>(this INavigationService navigationService, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
       where T : class
     {

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationServiceExtensions
@@ -25,10 +25,9 @@ namespace Prism.Navigation
       var name = nameof(T);
 
       //should we allow navigating by page type at all?
-      //name can also be retrieved from the items registered for the navigation.
-      if (name.EndsWith(ViewModelSuffix))
-        name = name.Replace(ViewModelSuffix, PageSuffix);
-      else if (!name.EndsWith(PageSuffix))
+      if (name.EndsWith(PageSuffix + ViewModelSuffix))
+        name = name.Replace(ViewModelSuffix, string.Empty);
+      else
         throw new ArgumentOutOfRangeException($"Unable to parse ViewModel '{name}'.");
 
       return navigationService.NavigateAsync(name, parameters, useModalNavigation, animated);


### PR DESCRIPTION
We can just infer from VM type name or page name.
I'm not sure if page should be allowed, since we're not supposed to know about it at VM.

Please take a moment to fill out the following:

Fixes issue # .

Changes proposed in this pull request:
- Added a generic type extension method to INavigationService.NavigateAsync, to allow navigation according to naming convention by VM/Page type name.