### PR TITLE
Fix absolute navigation of UWP

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
@@ -171,5 +171,31 @@ namespace Prism.Forms.Tests.Common
             Assert.True(uri.IsAbsoluteUri);
         }
 
+        [Fact]
+        public void ParseArgumentIsNull()
+        {
+            var actual = Assert.Throws<ArgumentNullException>(() => UriParsingHelper.Parse(null));
+            Assert.NotNull(actual);
+            Assert.Equal("uri", actual.ParamName);
+        }
+
+        [Fact]
+        public void ParseRelativeUri()
+        {
+            var uri = UriParsingHelper.Parse(_relativeUri);
+            Assert.NotNull(uri);
+            Assert.Equal(_relativeUri, uri.OriginalString);
+            Assert.False(uri.IsAbsoluteUri);
+        }
+
+        [Fact]
+        public void ParseUriThatStartsWithSlash()
+        {
+            var uri = UriParsingHelper.Parse("/" + _relativeUri);
+            Assert.NotNull(uri);
+            Assert.Equal("http://localhost/" + _relativeUri, uri.OriginalString);
+            Assert.True(uri.IsAbsoluteUri);
+        }
+
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
@@ -8,6 +8,7 @@ namespace Prism.Forms.Tests.Common
     public class UriParsingHelperFixture
     {
         const string _relativeUri = "MainPage?id=3&name=brian";
+        const string _absoluteUriWithOutProtocol = "/MainPage?id=3&name=brian";
         const string _absoluteUri = "htp://www.brianlagunas.com/MainPage?id=3&name=brian";
         const string _deepLinkAbsoluteUri = "android-app://HellowWorld/MainPage?id=1/ViewA?id=2/ViewB?id=3/ViewC?id=4";
         const string _deepLinkRelativeUri = "MainPage?id=1/ViewA?id=2/ViewB?id=3/ViewC?id=4";
@@ -172,7 +173,7 @@ namespace Prism.Forms.Tests.Common
         }
 
         [Fact]
-        public void ParseArgumentIsNull()
+        public void ParseForNull()
         {
             var actual = Assert.Throws<ArgumentNullException>(() => UriParsingHelper.Parse(null));
             Assert.NotNull(actual);
@@ -180,7 +181,7 @@ namespace Prism.Forms.Tests.Common
         }
 
         [Fact]
-        public void ParseRelativeUri()
+        public void ParseForRelativeUri()
         {
             var uri = UriParsingHelper.Parse(_relativeUri);
             Assert.NotNull(uri);
@@ -189,13 +190,12 @@ namespace Prism.Forms.Tests.Common
         }
 
         [Fact]
-        public void ParseUriThatStartsWithSlash()
+        public void ParseForAbsoluteUri()
         {
-            var uri = UriParsingHelper.Parse("/" + _relativeUri);
+            var uri = UriParsingHelper.Parse(_absoluteUri);
             Assert.NotNull(uri);
-            Assert.Equal("http://localhost/" + _relativeUri, uri.OriginalString);
+            Assert.Equal(_absoluteUri, uri.OriginalString);
             Assert.True(uri.IsAbsoluteUri);
         }
-
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
@@ -206,5 +206,23 @@ namespace Prism.Forms.Tests.Common
             Assert.Equal("http://localhost" + _absoluteUriWithOutProtocol, uri.OriginalString);
             Assert.True(uri.IsAbsoluteUri);
         }
+
+        [Fact]
+        public void ParseForDeepLinkAbsoluteUri()
+        {
+            var uri = UriParsingHelper.Parse(_deepLinkAbsoluteUri);
+            Assert.NotNull(uri);
+            Assert.Equal(_deepLinkAbsoluteUri, uri.OriginalString);
+            Assert.True(uri.IsAbsoluteUri);
+        }
+
+        [Fact]
+        public void ParseForDeepLinkRelativeUri()
+        {
+            var uri = UriParsingHelper.Parse(_deepLinkRelativeUri);
+            Assert.NotNull(uri);
+            Assert.Equal(_deepLinkRelativeUri, uri.OriginalString);
+            Assert.False(uri.IsAbsoluteUri);
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Common/UriParsingHelperFixture.cs
@@ -197,5 +197,14 @@ namespace Prism.Forms.Tests.Common
             Assert.Equal(_absoluteUri, uri.OriginalString);
             Assert.True(uri.IsAbsoluteUri);
         }
+
+        [Fact]
+        public void ParseForAbsoluteUriWithOutProtocol()
+        {
+            var uri = UriParsingHelper.Parse(_absoluteUriWithOutProtocol);
+            Assert.NotNull(uri);
+            Assert.Equal("http://localhost" + _absoluteUriWithOutProtocol, uri.OriginalString);
+            Assert.True(uri.IsAbsoluteUri);
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -104,6 +104,32 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
+        public async void Navigate_ToContentPage_ByAbsoluteName()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("/ContentPage");
+
+            Assert.True(rootPage.Navigation.ModalStack.Count == 0);
+            Assert.IsType(typeof(ContentPageMock), _applicationProvider.MainPage);
+        }
+
+        [Fact]
+        public async void Navigate_ToContentPage_ByAbsoluteUri()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
+
+            Assert.True(rootPage.Navigation.ModalStack.Count == 0);
+            Assert.IsType(typeof(ContentPageMock), _applicationProvider.MainPage);
+        }
+
+        [Fact]
         public async void Navigate_ToContentPage_ByName_WithNavigationParameters()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -421,6 +421,38 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
+        public async void DeepNavigate_From_ContentPage_To_NavigationPage_ToContentPage_ByAbsoluteName()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("/NavigationPage/ContentPage");
+
+            Assert.Equal(0, rootPage.Navigation.ModalStack.Count);
+
+            var navPage = _applicationProvider.MainPage;
+            Assert.IsType<NavigationPageMock>(navPage);
+            Assert.True(navPage.Navigation.NavigationStack.Count == 1);
+        }
+
+        [Fact]
+        public async void DeepNavigate_From_ContentPage_To_NavigationPage_ToContentPage_ByAbsoluteUri()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync(new Uri("http://localhost/NavigationPage/ContentPage", UriKind.Absolute));
+
+            Assert.Equal(0, rootPage.Navigation.ModalStack.Count);
+
+            var navPage = _applicationProvider.MainPage;
+            Assert.IsType<NavigationPageMock>(navPage);
+            Assert.True(navPage.Navigation.NavigationStack.Count == 1);
+        }
+
+        [Fact]
         public async void DeepNavigate_From_ContentPage_To_EmptyNavigationPage_ToContentPage()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);

--- a/Source/Xamarin/Prism.Forms/Common/UriParsingHelper.cs
+++ b/Source/Xamarin/Prism.Forms/Common/UriParsingHelper.cs
@@ -89,7 +89,7 @@ namespace Prism.Common
             }
             else
             {
-                return new Uri(uri, UriKind.Relative);
+                return new Uri(uri, UriKind.RelativeOrAbsolute);
             }
         }
     }

--- a/Source/Xamarin/Prism.Forms/Common/UriParsingHelper.cs
+++ b/Source/Xamarin/Prism.Forms/Common/UriParsingHelper.cs
@@ -78,5 +78,19 @@ namespace Prism.Common
             }
             return new Uri("http://localhost" + uri, UriKind.Absolute);
         }
+
+        public static Uri Parse(string uri)
+        {
+            if (uri == null) throw new ArgumentNullException(nameof(uri));
+
+            if (uri.StartsWith("/", StringComparison.Ordinal))
+            {
+                return new Uri("http://localhost" + uri, UriKind.Absolute);
+            }
+            else
+            {
+                return new Uri(uri, UriKind.Relative);
+            }
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -89,7 +89,7 @@ namespace Prism.Navigation
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
         public virtual Task NavigateAsync(string name, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
-            return NavigateAsync(new Uri(name, UriKind.RelativeOrAbsolute), parameters, useModalNavigation, animated);
+            return NavigateAsync(UriParsingHelper.Parse(name), parameters, useModalNavigation, animated);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issue #932 .

Changes proposed in this pull request:
- Add Parse method to UriParsingHelper.
- Update NavigateAsync on PageNavigationService.
- Add unit test for absolute navigations.