### PR TITLE
[WIP] Fix call idestructible when using an absolute uri

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ApplicationProviderMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ApplicationProviderMock.cs
@@ -13,6 +13,11 @@ namespace Prism.Forms.Tests.Mocks
             };
         }
 
+        public ApplicationProviderMock(Page page)
+        {
+            MainPage = page;
+        }
+
         public Page MainPage { get; set; }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
@@ -4,7 +4,7 @@ using Prism.Navigation;
 
 namespace Prism.Forms.Tests.Mocks.ViewModels
 {
-    public class ViewModelBase : BindableBase, INavigationAware
+    public class ViewModelBase : BindableBase, INavigationAware, IDestructible
     {
         public NavigationParameters NavigatedToParameters { get; private set; }
         public NavigationParameters NavigatedFromParameters { get; private set; }
@@ -14,6 +14,8 @@ namespace Prism.Forms.Tests.Mocks.ViewModels
         public bool OnNavigatingdToCalled { get; private set; } = false;
 
         public bool OnNavigatedFromCalled { get; private set; } = false;
+
+        public bool DestroyCalled { get; private set; } = false;
 
         public void OnNavigatedFrom(NavigationParameters parameters)
         {
@@ -31,6 +33,11 @@ namespace Prism.Forms.Tests.Mocks.ViewModels
         {
             OnNavigatingdToCalled = true;
             NavigatedToParameters = parameters;
+        }
+
+        public void Destroy()
+        {
+            DestroyCalled = true;
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/ContentPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/ContentPageMock.cs
@@ -6,13 +6,15 @@ using System.Threading.Tasks;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class ContentPageMock : ContentPage, INavigationAware, IConfirmNavigationAsync
+    public class ContentPageMock : ContentPage, INavigationAware, IConfirmNavigationAsync, IDestructible
     {
         public bool OnNavigatedToCalled { get; private set; } = false;
         public bool OnNavigatedFromCalled { get; private set; } = false;
         public bool OnNavigatingToCalled { get; private set; } = false;
 
         public bool OnConfirmNavigationCalled { get; private set; } = false;
+
+        public bool DestroyCalled { get; private set; } = false;
 
         public ContentPageMock()
         {
@@ -45,6 +47,11 @@ namespace Prism.Forms.Tests.Mocks.Views
 
                 return true;
             });
+        }
+
+        public void Destroy()
+        {
+            DestroyCalled = true;
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
@@ -4,11 +4,17 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class NavigationPageMock : NavigationPage
+    public class NavigationPageMock : NavigationPage, IDestructible
     {
+        public bool DestroyCalled { get; private set; } = false;
         public NavigationPageMock() : base (new ContentPageMock())
         {
             ViewModelLocator.SetAutowireViewModel(this, true);
+        }
+
+        public void Destroy()
+        {
+            DestroyCalled = true;
         }
     }
 

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
@@ -1,10 +1,13 @@
 ﻿using Prism.Mvvm;
+using Prism.Navigation;
 using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class TabbedPageMock : TabbedPage
+    public class TabbedPageMock : TabbedPage, IDestructible
     {
+        public bool DestroyCalled { get; private set; } = false;
+
         public TabbedPageMock()
         {
             ViewModelLocator.SetAutowireViewModel(this, true);
@@ -12,6 +15,11 @@ namespace Prism.Forms.Tests.Mocks.Views
             Children.Add(new ContentPageMock() { Title = "Page 1" });
             Children.Add(new PageMock() { Title = "Page 2" });
             Children.Add(new ContentPageMock() { Title = "Page 3" });
+        }
+
+        public void Destroy()
+        {
+            DestroyCalled = true;
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -134,6 +134,63 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
+        public async void Navigate_FromDeepPages_ToContentPage_ByAbsoluteUri()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var pageAware = (IPageAware)navigationService;
+
+            // Set up top page.
+            var contentPageMock = new ContentPageMock();
+            var contentPageMockViewModel = (ViewModelBase)contentPageMock.BindingContext;
+
+            // Navigation Modal
+            pageAware.Page = contentPageMock;
+            await navigationService.NavigateAsync("NavigationPage");
+
+            var navigationPage = (NavigationPageMock)contentPageMock.Navigation.ModalStack[0];
+            var navigationPageViewModel = (ViewModelBase) navigationPage.BindingContext;
+
+            var navigationChild1 = (ContentPageMock)navigationPage.Navigation.NavigationStack[0];
+            var navigationChild1ViewModel = (ViewModelBase)navigationChild1.BindingContext;
+
+            // Navigation UnModal
+            pageAware.Page = navigationChild1;
+            await navigationService.NavigateAsync("ContentPage");
+            var navigationChild2 = (ContentPageMock)navigationPage.Navigation.NavigationStack[1];
+            var navigationChild2ViewModel = (ViewModelBase)navigationChild1.BindingContext;
+
+            // Navigation Modal
+            pageAware.Page = navigationChild2;
+            await navigationService.NavigateAsync("TabbedPage", useModalNavigation:true);
+            var tabbedPage = (TabbedPageMock)navigationPage.Navigation.ModalStack[0];
+            var tabbedPageViewModel = (ViewModelBase)tabbedPage.BindingContext;
+
+
+            // Absolute Navigation
+            pageAware.Page = tabbedPage;
+            await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
+
+            Assert.IsType(typeof(ContentPageMock), _applicationProvider.MainPage);
+            Assert.NotEqual(contentPageMock, _applicationProvider.MainPage);
+
+            Assert.True(contentPageMock.DestroyCalled);
+            Assert.True(contentPageMockViewModel.DestroyCalled);
+
+            Assert.True(navigationPage.DestroyCalled);
+            Assert.True(navigationPageViewModel.DestroyCalled);
+
+            Assert.True(navigationChild1.DestroyCalled);
+            Assert.True(navigationChild1ViewModel.DestroyCalled);
+
+            Assert.True(navigationChild2.DestroyCalled);
+            Assert.True(navigationChild2ViewModel.DestroyCalled);
+
+            Assert.True(tabbedPage.DestroyCalled);
+            Assert.True(tabbedPageViewModel.DestroyCalled);
+        }
+
+
+        [Fact]
         public async void Navigate_ToContentPage_ByName_WithNavigationParameters()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -184,11 +184,17 @@ namespace Prism.Forms.Tests.Navigation
 
             Assert.True(rootPage.Navigation.NavigationStack.Count == 2);
             Assert.IsType(typeof(TabbedPageMock), rootPage.CurrentPage);
-
+            var tabbedPageMock = rootPage.CurrentPage as TabbedPageMock;
+            Assert.NotNull(tabbedPageMock);
+            var viewModel = (ViewModelBase)tabbedPageMock.BindingContext;
+            
             await navigationService.GoBackAsync();
 
             Assert.True(rootPage.Navigation.NavigationStack.Count == 1);
             Assert.IsType(typeof(ContentPageMock), rootPage.CurrentPage);
+            Assert.True(tabbedPageMock.DestroyCalled);
+            Assert.Null(tabbedPageMock.BindingContext);
+            Assert.True(viewModel.DestroyCalled);
         }
 
         [Fact]

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -139,13 +139,14 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_FromDeepPages_ToContentPage_ByAbsoluteUri()
         {
-            // Set up top page.
-            var contentPageMock = new ContentPageMock();
-            var contentPageMockViewModel = (ViewModelBase)contentPageMock.BindingContext;
-            var applicationProvider = new ApplicationProviderMock(contentPageMock);
-
+            var applicationProvider = new ApplicationProviderMock(null);
             var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade);
             var pageAware = (IPageAware)navigationService;
+
+            // Set up top page.
+            await navigationService.NavigateAsync("ContentPage");
+            var contentPageMock = (ContentPageMock)applicationProvider.MainPage;
+            var contentPageMockViewModel = (ViewModelBase)contentPageMock.BindingContext;
 
 
             // Navigation Modal

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -119,29 +119,34 @@ namespace Prism.Forms.Tests.Navigation
         [Fact]
         public async void Navigate_ToContentPage_ByAbsoluteUri()
         {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            // Set up top page.
             var rootPage = new ContentPageMock();
-            var rootPageViewModel = (ViewModelBase) rootPage.BindingContext;
-            ((IPageAware)navigationService).Page = rootPage;
+            var rootPageViewModel = (ViewModelBase)rootPage.BindingContext;
+            var applicationProvider = new ApplicationProviderMock(rootPage);
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade);
 
             await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
 
             Assert.True(rootPage.Navigation.ModalStack.Count == 0);
-            Assert.IsType(typeof(ContentPageMock), _applicationProvider.MainPage);
+            Assert.IsType(typeof(ContentPageMock), applicationProvider.MainPage);
             Assert.NotEqual(rootPage, _applicationProvider.MainPage);
             Assert.True(rootPage.DestroyCalled);
+            Assert.Equal(0, rootPage.Behaviors.Count);
+            Assert.Null(rootPage.BindingContext);
             Assert.True(rootPageViewModel.DestroyCalled);
         }
 
         [Fact]
         public async void Navigate_FromDeepPages_ToContentPage_ByAbsoluteUri()
         {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var pageAware = (IPageAware)navigationService;
-
             // Set up top page.
             var contentPageMock = new ContentPageMock();
             var contentPageMockViewModel = (ViewModelBase)contentPageMock.BindingContext;
+            var applicationProvider = new ApplicationProviderMock(contentPageMock);
+
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade);
+            var pageAware = (IPageAware)navigationService;
+
 
             // Navigation Modal
             pageAware.Page = contentPageMock;
@@ -165,27 +170,36 @@ namespace Prism.Forms.Tests.Navigation
             var tabbedPage = (TabbedPageMock)navigationPage.Navigation.ModalStack[0];
             var tabbedPageViewModel = (ViewModelBase)tabbedPage.BindingContext;
 
-
             // Absolute Navigation
             pageAware.Page = tabbedPage;
             await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
 
-            Assert.IsType(typeof(ContentPageMock), _applicationProvider.MainPage);
-            Assert.NotEqual(contentPageMock, _applicationProvider.MainPage);
+            Assert.IsType(typeof(ContentPageMock), applicationProvider.MainPage);
+            Assert.NotEqual(contentPageMock, applicationProvider.MainPage);
 
             Assert.True(contentPageMock.DestroyCalled);
+            Assert.Equal(0, contentPageMock.Behaviors.Count);
+            Assert.Null(contentPageMock.BindingContext);
             Assert.True(contentPageMockViewModel.DestroyCalled);
 
             Assert.True(navigationPage.DestroyCalled);
+            Assert.Equal(0, navigationPage.Behaviors.Count);
+            Assert.Null(navigationPage.BindingContext);
             Assert.True(navigationPageViewModel.DestroyCalled);
 
             Assert.True(navigationChild1.DestroyCalled);
+            Assert.Equal(0, navigationChild1.Behaviors.Count);
+            Assert.Null(navigationPage.BindingContext);
             Assert.True(navigationChild1ViewModel.DestroyCalled);
 
             Assert.True(navigationChild2.DestroyCalled);
+            Assert.Equal(0, navigationChild2.Behaviors.Count);
+            Assert.Null(navigationPage.BindingContext);
             Assert.True(navigationChild2ViewModel.DestroyCalled);
 
             Assert.True(tabbedPage.DestroyCalled);
+            Assert.Equal(0, tabbedPage.Behaviors.Count);
+            Assert.Null(navigationPage.BindingContext);
             Assert.True(tabbedPageViewModel.DestroyCalled);
         }
 

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -120,13 +120,17 @@ namespace Prism.Forms.Tests.Navigation
         public async void Navigate_ToContentPage_ByAbsoluteUri()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var rootPage = new Xamarin.Forms.ContentPage();
+            var rootPage = new ContentPageMock();
+            var rootPageViewModel = (ViewModelBase) rootPage.BindingContext;
             ((IPageAware)navigationService).Page = rootPage;
 
             await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
 
             Assert.True(rootPage.Navigation.ModalStack.Count == 0);
             Assert.IsType(typeof(ContentPageMock), _applicationProvider.MainPage);
+            Assert.NotEqual(rootPage, _applicationProvider.MainPage);
+            Assert.True(rootPage.DestroyCalled);
+            Assert.True(rootPageViewModel.DestroyCalled);
         }
 
         [Fact]

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -175,7 +175,10 @@ namespace Prism.Navigation
 
             await DoNavigateAction(GetCurrentPage(), nextSegment, nextPage, parameters, async () =>
             {
-                DestroyStackedPages(_applicationProvider.MainPage);
+                if (_applicationProvider.MainPage != null)
+                {
+                    DestroyStackedPages(_applicationProvider.MainPage);
+                }
                 await DoPush(null, nextPage, useModalNavigation, animated);
             });
         }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -175,8 +175,18 @@ namespace Prism.Navigation
 
             await DoNavigateAction(GetCurrentPage(), nextSegment, nextPage, parameters, async () =>
             {
+                DestroyStackedPages(_applicationProvider.MainPage);
                 await DoPush(null, nextPage, useModalNavigation, animated);
             });
+        }
+
+        private void DestroyStackedPages(Page page)
+        {
+            foreach (var childPage in page.Navigation.ModalStack)
+            {
+                DestroyStackedPages(childPage);
+            }
+            PageUtilities.DestroyPage(page);
         }
 
         protected virtual async Task ProcessNavigationForContentPage(Page currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -185,9 +185,9 @@ namespace Prism.Navigation
 
         private void DestroyStackedPages(Page page)
         {
-            foreach (var childPage in page.Navigation.ModalStack)
+            foreach (var childPage in page.Navigation.ModalStack.Reverse())
             {
-                DestroyStackedPages(childPage);
+                PageUtilities.DestroyPage(childPage);
             }
             PageUtilities.DestroyPage(page);
         }


### PR DESCRIPTION
Fixes issue #862 .

Changes proposed in this pull request:
- Call IDestructible when using an absolute URI
Please see NavigationService around line 178.
- Added some test cases for IDestructible
But DeepLink tests are not working right now
For details, please see the following
https://github.com/PrismLibrary/Prism/issues/862#issuecomment-278538523