### PR TITLE
Fixed typo for IPageNavigationEventRecordable

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/IPageNavigationEventRecordable.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/IPageNavigationEventRecordable.cs
@@ -1,6 +1,6 @@
 ﻿namespace Prism.Forms.Tests.Mocks
 {
-    public interface IPageNavigationEventRecodable
+    public interface IPageNavigationEventRecordable
     {
         PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
     }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
@@ -19,19 +19,11 @@ namespace Prism.Forms.Tests.Mocks
 
         protected override Page CreatePage(string name)
         {
-            var instance = _containerMock.GetInstance(name);
-            var recodable = instance as IPageNavigationEventRecodable;
-            if (recodable != null)
-            {
-                recodable.PageNavigationEventRecorder = _recorder;
-            }
+            var page = _containerMock.GetInstance(name) as Page;
 
-            var page = instance as Page;
-            var viewModelMock = page?.BindingContext as IPageNavigationEventRecodable;
-            if (viewModelMock != null)
-            {
-                viewModelMock.PageNavigationEventRecorder = _recorder;
-            }
+            PageUtilities.InvokeViewAndViewModelAction<IPageNavigationEventRecordable>(
+                page, 
+                x => x.PageNavigationEventRecorder = _recorder);
 
             return page;
         }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
@@ -4,7 +4,7 @@ using Prism.Navigation;
 
 namespace Prism.Forms.Tests.Mocks.ViewModels
 {
-    public class ViewModelBase : BindableBase, INavigationAware, IDestructible, IPageNavigationEventRecodable
+    public class ViewModelBase : BindableBase, INavigationAware, IDestructible, IPageNavigationEventRecordable
     {
         public NavigationParameters NavigatedToParameters { get; private set; }
         public NavigationParameters NavigatedFromParameters { get; private set; }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/CarouselPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/CarouselPageMock.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class CarouselPageMock : CarouselPage, IDestructible, IPageNavigationEventRecodable
+    public class CarouselPageMock : CarouselPage, IDestructible, IPageNavigationEventRecordable
     {
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
 
@@ -21,7 +21,7 @@ namespace Prism.Forms.Tests.Mocks.Views
             Children.Add(new ContentPage() { Title = "Page 3" });
 
             PageNavigationEventRecorder = recorder;
-            ((IPageNavigationEventRecodable) BindingContext).PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable) BindingContext).PageNavigationEventRecorder = recorder;
         }
 
         public void Destroy()

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/ContentPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/ContentPageMock.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class ContentPageMock : ContentPage, INavigationAware, IConfirmNavigationAsync, IDestructible, IPageNavigationEventRecodable
+    public class ContentPageMock : ContentPage, INavigationAware, IConfirmNavigationAsync, IDestructible, IPageNavigationEventRecordable
     {
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
         public bool OnNavigatedToCalled { get; private set; } = false;
@@ -26,7 +26,7 @@ namespace Prism.Forms.Tests.Mocks.Views
             ViewModelLocator.SetAutowireViewModel(this, true);
 
             PageNavigationEventRecorder = recorder;
-            ((IPageNavigationEventRecodable)BindingContext).PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
 
         public void OnNavigatedFrom(NavigationParameters parameters)

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/MasterDetailPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/MasterDetailPageMock.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class MasterDetailPageMock : MasterDetailPage, IMasterDetailPageOptions, IDestructible, IPageNavigationEventRecodable
+    public class MasterDetailPageMock : MasterDetailPage, IMasterDetailPageOptions, IDestructible, IPageNavigationEventRecordable
     {
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
 
@@ -20,7 +20,7 @@ namespace Prism.Forms.Tests.Mocks.Views
             ViewModelLocator.SetAutowireViewModel(this, true);
 
             PageNavigationEventRecorder = recorder;
-            ((IPageNavigationEventRecodable)BindingContext).PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
 
         public bool IsPresentedAfterNavigation { get; set; }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class NavigationPageMock : NavigationPage, IDestructible, IPageNavigationEventRecodable
+    public class NavigationPageMock : NavigationPage, IDestructible, IPageNavigationEventRecordable
     {
         public bool DestroyCalled { get; private set; } = false;
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
@@ -18,7 +18,7 @@ namespace Prism.Forms.Tests.Mocks.Views
             ViewModelLocator.SetAutowireViewModel(this, true);
 
             PageNavigationEventRecorder = recorder;
-            ((IPageNavigationEventRecodable)BindingContext).PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
 
         public void Destroy()

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class TabbedPageMock : TabbedPage, IDestructible, INavigationAware, IPageNavigationEventRecodable
+    public class TabbedPageMock : TabbedPage, IDestructible, INavigationAware, IPageNavigationEventRecordable
     {
         public bool DestroyCalled { get; private set; } = false;
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
@@ -22,7 +22,7 @@ namespace Prism.Forms.Tests.Mocks.Views
             Children.Add(new ContentPageMock(recorder) { Title = "Page 3" });
 
             PageNavigationEventRecorder = recorder;
-            ((IPageNavigationEventRecodable)BindingContext).PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
 
 

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common\PageUtilitiesFixture.cs" />
-    <Compile Include="Mocks\IPageNavigationEventRecodable.cs" />
+    <Compile Include="Mocks\IPageNavigationEventRecordable.cs" />
     <Compile Include="Mocks\PageNavigationEvent.cs" />
     <Compile Include="Mocks\PageNavigationRecord.cs" />
     <Compile Include="Mocks\PageNavigationEventRecorder.cs" />


### PR DESCRIPTION
Fixes issue #862 .

I'm sorry. 
I typed "IPageNavigationEventRecordable" as "IPageNavigationEventRecodable".
In addition, PageNavigationServiceMock#CreatePage has been modified to be smart with Page Utilities#InvokeViewAndViewModelAction.

- Fixed from IPageNavigationEventRecodable to IPageNavigationEventRecordable
- Fixed PageNavigationServiceMock#CreatePage to use PageUtilities

