### PR TITLE
Fix delegation of IConfirmNavigateRequest to also include active views of sub-regions

### DIFF
--- a/Source/Wpf/Prism.Wpf/Regions/IRegion.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/IRegion.cs
@@ -1,6 +1,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
 
@@ -65,6 +66,12 @@ namespace Prism.Regions
         /// <param name="createRegionManagerScope">When <see langword="true"/>, the added view will receive a new instance of <see cref="IRegionManager"/>, otherwise it will use the current region manager for this region.</param>
         /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="DependencyObject"/>.</returns>
         IRegionManager Add(object view, string viewName, bool createRegionManagerScope);
+
+        /// <summary>
+        /// Gets all the active views includes views of scoped <see cref="IRegionManager"/>s
+        /// </summary>
+        /// <returns>A <see cref="IEnumerable{object}"/> of all related views</returns>
+        IEnumerable<object> GetAllActiveViews();
 
         /// <summary>
         /// Removes the specified view from the region.

--- a/Source/Wpf/Prism.Wpf/Regions/Region.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Region.cs
@@ -3,6 +3,7 @@
 using Microsoft.Practices.ServiceLocation;
 using Prism.Properties;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -260,6 +261,32 @@ namespace Prism.Regions
             IRegionManager manager = createRegionManagerScope ? this.RegionManager.CreateRegionManager() : this.RegionManager;
             this.InnerAdd(view, viewName, manager);
             return manager;
+        }
+
+        /// <summary>
+        /// Gets all the active views includes views of scoped <see cref="IRegionManager"/>s
+        /// </summary>
+        /// <returns>A <see cref="IEnumerable{object}"/> of all related views</returns>
+        public virtual IEnumerable<object> GetAllActiveViews()
+        {
+            List<object> views = ActiveViews.ToList();
+            List<object> childViews = new List<object>();
+
+            foreach (object view in views)
+            {
+                DependencyObject dependencyObject = view as DependencyObject;
+                IRegionManager viewRegionManager = dependencyObject?.GetValue(Regions.RegionManager.RegionManagerProperty) as IRegionManager;
+                if (viewRegionManager != null && viewRegionManager != RegionManager)
+                {
+                    foreach (IRegion region in viewRegionManager.Regions)
+                    {
+                        childViews.AddRange(region.GetAllActiveViews());
+                    }
+                }
+            }
+
+            views.AddRange(childViews);
+            return views;
         }
 
         /// <summary>

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
@@ -147,7 +147,7 @@ namespace Prism.Regions
             RequestCanNavigateFromOnCurrentlyActiveView(
                 this.currentNavigationContext,
                 navigationCallback,
-                this.Region.ActiveViews.ToArray(),
+                this.Region.GetAllActiveViews().ToArray(),
                 0);
         }
 


### PR DESCRIPTION
The issue:
A (main) view which creates a scoped regionmanager with (sub)views implementing IConfirmNavigateRequest are not accessed on navigation away from the main-view.

Changes proposed in this pull request:
- Loop through the views to see if they have a scoped regionmanager and also include the active views in the active views list returned to fire all IConfirmNavigateRequest instances