### PR TITLE
WindowContentType property added

### DIFF
--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -6,6 +6,7 @@ using Prism.Interactivity.InteractionRequest;
 using System;
 using System.Windows;
 using System.Windows.Interactivity;
+using Microsoft.Practices.ServiceLocation;
 
 namespace Prism.Interactivity
 {
@@ -21,6 +22,16 @@ namespace Prism.Interactivity
             DependencyProperty.Register(
                 "WindowContent",
                 typeof(FrameworkElement),
+                typeof(PopupWindowAction),
+                new PropertyMetadata(null));
+
+        /// <summary>
+        /// The type of content of the child window to display as part of the popup.
+        /// </summary>
+        public static readonly DependencyProperty WindowContentTypeProperty =
+            DependencyProperty.Register(
+                "WindowContentType",
+                typeof(Type),
                 typeof(PopupWindowAction),
                 new PropertyMetadata(null));
 
@@ -71,6 +82,15 @@ namespace Prism.Interactivity
         {
             get { return (FrameworkElement)GetValue(WindowContentProperty); }
             set { SetValue(WindowContentProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the type of content of the window.
+        /// </summary>
+        public Type WindowContentType
+        {
+            get { return (Type)GetValue(WindowContentTypeProperty); }
+            set { SetValue(WindowContentTypeProperty, value); }
         }
 
         /// <summary>
@@ -205,7 +225,7 @@ namespace Prism.Interactivity
         {
             Window wrapperWindow;
 
-            if (this.WindowContent != null)
+            if (this.WindowContent != null || this.WindowContentType != null)
             {
                 wrapperWindow = CreateWindow();
 
@@ -245,13 +265,19 @@ namespace Prism.Interactivity
         /// <param name="wrapperWindow">The HostWindow</param>
         protected virtual void PrepareContentForWindow(INotification notification, Window wrapperWindow)
         {
-            if (this.WindowContent == null)
+            if (this.WindowContent != null)
+            {
+                // We set the WindowContent as the content of the window. 
+                wrapperWindow.Content = this.WindowContent;
+            }
+            else if (this.WindowContentType != null)
+            {
+                wrapperWindow.Content = ServiceLocator.Current.GetInstance(this.WindowContentType);
+            }
+            else
             {
                 return;
             }
-
-            // We set the WindowContent as the content of the window. 
-            wrapperWindow.Content = this.WindowContent;
 
             Action<IInteractionRequestAware> setNotificationAndClose = (iira) =>
             {


### PR DESCRIPTION
Fixes issue #432  .

Changes proposed in this pull request:

Instead of 
```xaml
        <prism:InteractionRequestTrigger SourceObject="{Binding CustomPopupRequest}">
            <prism:PopupWindowAction IsModal="True" CenterOverAssociatedObject="True">
                <prism:PopupWindowAction.WindowContent>
                    <views:CustomPopupView />
                </prism:PopupWindowAction.WindowContent>
            </prism:PopupWindowAction>
        </prism:InteractionRequestTrigger>
``` 
you can use
```xaml
        <prism:InteractionRequestTrigger SourceObject="{Binding CustomPopupRequest}">
            <prism:PopupWindowAction IsModal="True" CenterOverAssociatedObject="True" 
                WindowContentType="{x:Type views:CustomPopupView}"/>
        </prism:InteractionRequestTrigger>
```
