### PR TITLE
Enable Custom NavigationService Creation

### DIFF
--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -70,11 +70,11 @@ namespace Prism
 
             ConfigureContainer();
 
-            NavigationService = CreateNavigationService();
-
             RegisterTypes();
 
             _platformInitializer?.RegisterTypes(Container);
+            
+            NavigationService = CreateNavigationService();
 
             InitializeModules();
         }


### PR DESCRIPTION
Ensures that the `PrismApplication.NavigationService` is created after registrations are complete so that any custom implementation of `INavigationService` is resolved and ready for use in `OnInitialized` rather than the default container implementation. 