### PR TITLE
Raise CanExecuteChanged on PropertyChange empty

### DIFF
--- a/Source/Prism.Tests/Commands/DelegateCommandFixture.cs
+++ b/Source/Prism.Tests/Commands/DelegateCommandFixture.cs
@@ -365,6 +365,33 @@ namespace Prism.Tests.Commands
             });
         }
 
+        [Fact]
+        public void NonGenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName()
+        {
+            bool canExecuteChangedRaised = false;
+
+            var command = new DelegateCommand(() => { }).ObservesProperty(() => IntProperty);
+
+            command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
+
+            OnPropertyChanged(null);
+
+            Assert.True(canExecuteChangedRaised);
+        }
+
+        [Fact]
+        public void NonGenericDelegateCommandNotObservingPropertiesShouldNotRaiseOnEmptyPropertyName()
+        {
+            bool canExecuteChangedRaised = false;
+
+            var command = new DelegateCommand(() => { });
+
+            command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
+
+            OnPropertyChanged(null);
+
+            Assert.False(canExecuteChangedRaised);
+        }
 
         [Fact]
         public void GenericDelegateCommandShouldObserveCanExecute()
@@ -481,6 +508,36 @@ namespace Prism.Tests.Commands
                 DelegateCommand<object> command = new DelegateCommand<object>((o) => { }).ObservesProperty(() => IntProperty).ObservesProperty(() => IntProperty);
             });
         }
+
+        [Fact]
+        public void GenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName()
+        {
+            bool canExecuteChangedRaised = false;
+
+            var command = new DelegateCommand<object>((o) => { }).ObservesProperty(() => IntProperty);
+
+            command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
+
+            OnPropertyChanged(null);
+
+            Assert.True(canExecuteChangedRaised);
+        }
+
+        [Fact]
+        public void GenericDelegateCommandNotObservingPropertiesShouldNotRaiseOnEmptyPropertyName()
+        {
+            bool canExecuteChangedRaised = false;
+
+            var command = new DelegateCommand<object>((o) => { });
+
+            command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
+
+            OnPropertyChanged(null);
+
+            Assert.False(canExecuteChangedRaised);
+        }
+
+
 
         private bool _boolProperty;
         public bool BoolProperty

--- a/Source/Prism/Commands/DelegateCommandBase.cs
+++ b/Source/Prism/Commands/DelegateCommandBase.cs
@@ -116,8 +116,10 @@ namespace Prism.Commands
 
         void Inpc_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (_propertiesToObserve.Contains(e.PropertyName))
+            if (_propertiesToObserve.Contains(e.PropertyName) || (string.IsNullOrEmpty(e.PropertyName) && _propertiesToObserve.Count > 0))
+            {
                 RaiseCanExecuteChanged();
+            }
         }
 
         #region IsActive


### PR DESCRIPTION
Fixes issue #963.
