### PR TITLE
Exposes `Application.Properties` and `Application.SavePropertiesAsync()`

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -13,6 +13,7 @@ using Autofac.Features.ResolveAnything;
 using Prism.Autofac.Forms.Modularity;
 using Prism.Autofac.Navigation;
 using Prism.Autofac.Forms;
+using Prism.AppModel;
 
 namespace Prism.Autofac
 {
@@ -107,6 +108,7 @@ namespace Prism.Autofac
             builder.RegisterInstance(ModuleCatalog).As<IModuleCatalog>().SingleInstance();
 
             builder.Register(ctx => new ApplicationProvider()).As<IApplicationProvider>().SingleInstance();
+            builder.Register(ctx => new ApplicationStore()).As<IApplicationStore>().SingleInstance();
             builder.Register(ctx => new AutofacPageNavigationService(Container, Container.Resolve<IApplicationProvider>(), Container.Resolve<ILoggerFacade>())).Named<INavigationService>(_navigationServiceName);
             builder.Register(ctx => new ModuleManager(Container.Resolve<IModuleInitializer>(), Container.Resolve<IModuleCatalog>())).As<IModuleManager>().SingleInstance();
             builder.Register(ctx => new AutofacModuleInitializer(Container)).As<IModuleInitializer>().SingleInstance();

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using DryIoc;
+using Prism.AppModel;
 using Prism.Common;
 using Prism.DryIoc.Extensions;
 using Prism.DryIoc.Modularity;
@@ -76,6 +77,7 @@ namespace Prism.DryIoc
             Container.RegisterInstance(Container);
             Container.Register<INavigationService, DryIocPageNavigationService>(serviceKey: _navigationServiceKey);
             Container.Register<IApplicationProvider, ApplicationProvider>(Reuse.Singleton);
+            Container.Register<IApplicationStore, ApplicationStore>(Reuse.Singleton);
             Container.Register<IModuleManager, ModuleManager>(Reuse.Singleton);
             Container.Register<IModuleInitializer, DryIocModuleInitializer>(Reuse.Singleton);
             Container.Register<IEventAggregator, EventAggregator>(Reuse.Singleton);

--- a/Source/Xamarin/Prism.Forms/AppModel/ApplicationStore.cs
+++ b/Source/Xamarin/Prism.Forms/AppModel/ApplicationStore.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace Prism.AppModel
+{
+    public class ApplicationStore : IApplicationStore
+    {
+        public IDictionary<string, object> Properties
+        {
+            get { return Application.Current.Properties; }
+        }
+
+        public Task SavePropertiesAsync() =>
+            Application.Current.SavePropertiesAsync();
+    }
+}

--- a/Source/Xamarin/Prism.Forms/AppModel/IApplicationStore.cs
+++ b/Source/Xamarin/Prism.Forms/AppModel/IApplicationStore.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Prism.AppModel
+{
+    public interface IApplicationStore
+    {
+        IDictionary<string, object> Properties { get; }
+
+        Task SavePropertiesAsync();
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -103,6 +103,8 @@
     <Compile Include="Services\IDependencyService.cs" />
     <Compile Include="Services\PageDialogService\IPageDialogService.cs" />
     <Compile Include="Services\PageDialogService\PageDialogService.cs" />
+    <Compile Include="AppModel\IApplicationStore.cs" />
+    <Compile Include="AppModel\ApplicationStore.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Prism\Prism.csproj">

--- a/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
@@ -1,6 +1,7 @@
 ﻿using Ninject;
 using Ninject.Parameters;
 using Ninject.Planning.Bindings.Resolvers;
+using Prism.AppModel;
 using Prism.Common;
 using Prism.Events;
 using Prism.Logging;
@@ -67,6 +68,7 @@ namespace Prism.Ninject
             Container.Bind<IModuleCatalog>().ToConstant(ModuleCatalog).InSingletonScope();
 
             Container.Bind<IApplicationProvider>().To<ApplicationProvider>().InSingletonScope();
+            Container.Bind<IApplicationStore>().To<ApplicationStore>().InSingletonScope();
             Container.Bind<INavigationService>().To<NinjectPageNavigationService>().Named(_navigationServiceName);
             Container.Bind<IModuleManager>().To<ModuleManager>().InSingletonScope();
             Container.Bind<IModuleInitializer>().To<NinjectModuleInitializer>().InSingletonScope();

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Practices.Unity;
+using Prism.AppModel;
 using Prism.Common;
 using Prism.Events;
 using Prism.Logging;
@@ -65,6 +66,7 @@ namespace Prism.Unity
             Container.RegisterInstance<IModuleCatalog>(ModuleCatalog);
 
             Container.RegisterType<IApplicationProvider, ApplicationProvider>(new ContainerControlledLifetimeManager());
+            Container.RegisterType<IApplicationStore, ApplicationStore>(new ContainerControlledLifetimeManager());
             Container.RegisterType<INavigationService, UnityPageNavigationService>(_navigationServiceName);
             Container.RegisterType<IModuleManager, ModuleManager>(new ContainerControlledLifetimeManager());
             Container.RegisterType<IModuleInitializer, UnityModuleInitializer>(new ContainerControlledLifetimeManager());


### PR DESCRIPTION
Adding `IApplicationStore` to expose `Application.Properties` & `Applicaiton.SavePropertiesAsync()` to be consumed in a ViewModel without exposing properties that a ViewModel probably shouldn't have access to like `Application.MainPage`