### PR TITLE
ActionSheetButton Enhancements

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
@@ -25,8 +25,6 @@ namespace Prism.Forms.Tests.Services
             Assert.Equal(typeof(ArgumentException), argumentException.GetType());
         }
 
-        #region Tests using Action
-
         [Fact]
         public async Task DisplayActionSheet_CancelButtonPressed_UsingAction()
         {

--- a/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
@@ -73,6 +73,8 @@ namespace Prism.Forms.Tests.Services
             await DisplayActionSheet_PressButton_UsingGenericAction(null);
         }
 
+        #region Obsolete ActionSheetButton using Commands
+
         [Fact]
         public async Task DisplayActionSheet_CancelButtonPressed_UsingGenericCommand()
         {
@@ -194,6 +196,8 @@ namespace Prism.Forms.Tests.Services
                     break;
             }
         }
+
+        #endregion Obsolete ActionSheetButton using Commands
 
         private async Task DisplayActionSheet_PressButton_UsingAction(string text)
         {

--- a/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
@@ -25,8 +25,82 @@ namespace Prism.Forms.Tests.Services
             Assert.Equal(typeof(ArgumentException), argumentException.GetType());
         }
 
+        #region Tests using Action
+
         [Fact]
-        public async Task DisplayActionSheet_CancelButtonPressed()
+        public async Task DisplayActionSheet_CancelButtonPressed_UsingAction()
+        {
+            await DisplayActionSheet_PressButton_UsingAction("cancel");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_CancelButtonPressed_UsingGenericAction()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericAction("cancel");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_DestroyButtonPressed_UsingAction()
+        {
+            await DisplayActionSheet_PressButton_UsingAction("destroy");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_DestroyButtonPressed_UsingGenericAction()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericAction("destroy");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_OtherButtonPressed_UsingAction()
+        {
+            await DisplayActionSheet_PressButton_UsingAction("other");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_OtherButtonPressed_UsingGenericAction()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericAction("other");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_NoButtonPressed_UsingAction()
+        {
+            await DisplayActionSheet_PressButton_UsingAction(null);
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_NoButtonPressed_UsingGenericAction()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericAction(null);
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_CancelButtonPressed_UsingGenericCommand()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericCommand("cancel");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_DestroyButtonPressed_UsingGenericCommand()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericCommand("destroy");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_OtherButtonPressed_UsingGenericCommand()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericCommand("other");
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_NoButtonPressed_UsingGenericCommand()
+        {
+            await DisplayActionSheet_PressButton_UsingGenericCommand(null);
+        }
+
+        [Fact]
+        public async Task DisplayActionSheet_CancelButtonPressed_UsingCommand()
         {
             var service = new PageDialogServiceMock("cancel", _applicationProvider);
             var cancelButtonPressed = false;
@@ -37,7 +111,7 @@ namespace Prism.Forms.Tests.Services
         }
 
         [Fact]
-        public async Task DisplayActionSheet_DestroyButtonPressed()
+        public async Task DisplayActionSheet_DestroyButtonPressed_UsingCommand()
         {
             var service = new PageDialogServiceMock("destroy", _applicationProvider);
             var destroyButtonPressed = false;
@@ -50,7 +124,7 @@ namespace Prism.Forms.Tests.Services
         }
 
         [Fact]
-        public async Task DisplayActionSheet_NoButtonPressed()
+        public async Task DisplayActionSheet_NoButtonPressed_UsingCommand()
         {
             var service = new PageDialogServiceMock(null, _applicationProvider);
             var buttonPressed = false;
@@ -63,7 +137,7 @@ namespace Prism.Forms.Tests.Services
         }
 
         [Fact]
-        public async Task DisplayActionSheet_OtherButtonPressed()
+        public async Task DisplayActionSheet_OtherButtonPressed_UsingCommand()
         {
             var service = new PageDialogServiceMock("other", _applicationProvider);
             var buttonPressed = false;
@@ -74,7 +148,7 @@ namespace Prism.Forms.Tests.Services
         }
 
         [Fact]
-        public async Task DisplayActionSheet_NullButtonAndOtherButtonPressed()
+        public async Task DisplayActionSheet_NullButtonAndOtherButtonPressed_UsingCommand()
         {
             var service = new PageDialogServiceMock("other", _applicationProvider);
             var buttonPressed = false;
@@ -82,6 +156,131 @@ namespace Prism.Forms.Tests.Services
             var button = ActionSheetButton.CreateButton("other", command);
             await service.DisplayActionSheetAsync(null, button, null);
             Assert.True(buttonPressed);
+        }
+
+        private async Task DisplayActionSheet_PressButton_UsingGenericCommand(string text)
+        {
+            var service = new PageDialogServiceMock(text, _applicationProvider);
+            var cancelButtonModel = new ButtonModel();
+            var destroyButtonModel = new ButtonModel();
+            var otherButtonModel = new ButtonModel();
+            var btns = new IActionSheetButton[]
+            {
+                ActionSheetButton.CreateButton("other", new DelegateCommand<ButtonModel>(OnButtonPressed), otherButtonModel),
+                ActionSheetButton.CreateCancelButton("cancel", new DelegateCommand<ButtonModel>(OnButtonPressed), cancelButtonModel),
+                ActionSheetButton.CreateDestroyButton("destroy", new DelegateCommand<ButtonModel>(OnButtonPressed), destroyButtonModel)
+            };
+            await service.DisplayActionSheetAsync( null, btns );
+
+            switch( text )
+            {
+                case "other":
+                    Assert.False(cancelButtonModel.ButtonPressed);
+                    Assert.False(destroyButtonModel.ButtonPressed);
+                    Assert.True(otherButtonModel.ButtonPressed);
+                    break;
+                case "cancel":
+                    Assert.True(cancelButtonModel.ButtonPressed);
+                    Assert.False(destroyButtonModel.ButtonPressed);
+                    Assert.False(otherButtonModel.ButtonPressed);
+                    break;
+                case "destroy":
+                    Assert.False(cancelButtonModel.ButtonPressed);
+                    Assert.True(destroyButtonModel.ButtonPressed);
+                    Assert.False(otherButtonModel.ButtonPressed);
+                    break;
+                default:
+                    Assert.False(cancelButtonModel.ButtonPressed);
+                    Assert.False(destroyButtonModel.ButtonPressed);
+                    Assert.False(otherButtonModel.ButtonPressed);
+                    break;
+            }
+        }
+
+        private async Task DisplayActionSheet_PressButton_UsingAction(string text)
+        {
+            var service = new PageDialogServiceMock(text, _applicationProvider);
+            bool cancelButtonPressed = false;
+            bool destroyButtonPressed = false;
+            bool otherButtonPressed = false;
+            var btns = new IActionSheetButton[]
+            {
+                ActionSheetButton.CreateButton("other", () => otherButtonPressed = true),
+                ActionSheetButton.CreateCancelButton("cancel", () => cancelButtonPressed = true),
+                ActionSheetButton.CreateDestroyButton("destroy", () => destroyButtonPressed = true)
+            };
+            await service.DisplayActionSheetAsync(null, btns);
+
+            switch(text)
+            {
+                case "other":
+                    Assert.True(otherButtonPressed);
+                    Assert.False(cancelButtonPressed);
+                    Assert.False(destroyButtonPressed);
+                    break;
+                case "cancel":
+                    Assert.False(otherButtonPressed);
+                    Assert.True(cancelButtonPressed);
+                    Assert.False(destroyButtonPressed);
+                    break;
+                case "destroy":
+                    Assert.False(otherButtonPressed);
+                    Assert.False(cancelButtonPressed);
+                    Assert.True(destroyButtonPressed);
+                    break;
+                default:
+                    Assert.False(otherButtonPressed);
+                    Assert.False(cancelButtonPressed);
+                    Assert.False(destroyButtonPressed);
+                    break;
+            }
+        }
+
+        private class ButtonModel
+        {
+            public bool ButtonPressed { get; set; }
+        }
+
+        private void OnButtonPressed(ButtonModel model) => 
+            model.ButtonPressed = true;
+
+        private async Task DisplayActionSheet_PressButton_UsingGenericAction(string text)
+        {
+            var service = new PageDialogServiceMock(text, _applicationProvider);
+            var cancelButtonModel = new ButtonModel();
+            var destroyButtonModel = new ButtonModel();
+            var otherButtonModel = new ButtonModel();
+            var btns = new IActionSheetButton[]
+            {
+                ActionSheetButton.CreateButton("other", OnButtonPressed, otherButtonModel),
+                ActionSheetButton.CreateCancelButton("cancel", OnButtonPressed, cancelButtonModel),
+                ActionSheetButton.CreateDestroyButton("destroy", OnButtonPressed, destroyButtonModel)
+            };
+            await service.DisplayActionSheetAsync(null, btns);
+
+            switch(text)
+            {
+                case "other":
+                    Assert.True(otherButtonModel.ButtonPressed);
+                    Assert.False(cancelButtonModel.ButtonPressed);
+                    Assert.False(destroyButtonModel.ButtonPressed);
+                    break;
+                case "cancel":
+                    Assert.False(otherButtonModel.ButtonPressed);
+                    Assert.True(cancelButtonModel.ButtonPressed);
+                    Assert.False(destroyButtonModel.ButtonPressed);
+                    break;
+                case "destroy":
+                    Assert.False(otherButtonModel.ButtonPressed);
+                    Assert.False(cancelButtonModel.ButtonPressed);
+                    Assert.True(destroyButtonModel.ButtonPressed);
+                    break;
+                default:
+                    Assert.False(otherButtonModel.ButtonPressed);
+                    Assert.False(cancelButtonModel.ButtonPressed);
+                    Assert.False(destroyButtonModel.ButtonPressed);
+                    break;
+            }
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -97,8 +97,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DeviceService.cs" />
     <Compile Include="Services\IDeviceService.cs" />
-    <Compile Include="Services\PageDialogService\ActionSheetButton.cs" />
     <Compile Include="Services\DependencyService.cs" />
+    <Compile Include="Services\PageDialogService\ActionSheetButtonBase.cs" />
+    <Compile Include="Services\PageDialogService\ActionSheetButton.cs" />
+    <Compile Include="Services\PageDialogService\ActionSheetButton{T}.cs" />
     <Compile Include="Services\PageDialogService\IActionSheetButton.cs" />
     <Compile Include="Services\IDependencyService.cs" />
     <Compile Include="Services\PageDialogService\IPageDialogService.cs" />

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButton.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButton.cs
@@ -1,31 +1,34 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 
 namespace Prism.Services
 {
     /// <summary>
     /// Represents a button displayed in <see cref="Prism.Services.IPageDialogService.DisplayActionSheetAsync(string, IActionSheetButton[])"/>
     /// </summary>
-    public class ActionSheetButton : IActionSheetButton
+    public class ActionSheetButton : ActionSheetButtonBase
     {
-        /// <summary>
-        /// The button will be used as destroy
-        /// </summary>
-        public virtual bool IsDestroy { get; protected set; }
+        protected internal ActionSheetButton()
+        {
+            
+        }
 
         /// <summary>
-        /// The button will be used as cancel
+        /// Action to perform when the button is pressed
         /// </summary>
-        public virtual bool IsCancel { get; protected set; }
+        /// <value>The action.</value>
+        public Action Action { get; protected set; }
 
         /// <summary>
-        /// Text to display in the action sheet
+        /// Executes the action to take when the button is pressed
         /// </summary>
-        public virtual string Text { get; protected set; }
+        protected override void OnButtonPressed()
+        {
+            Action?.Invoke();
 
-        /// <summary>
-        /// Command to execute when button is pressed
-        /// </summary>
-        public virtual ICommand Command { get; protected set; }
+            if(Command?.CanExecute(null) ?? false)
+                Command.Execute(null);
+        }
 
         /// <summary>
         /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
@@ -33,9 +36,46 @@ namespace Prism.Services
         /// <param name="text">Button text</param>
         /// <param name="command">Command to execute when button pressed</param>
         /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static ActionSheetButton CreateCancelButton(string text, ICommand command)
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public static IActionSheetButton CreateCancelButton(string text, ICommand command)
         {
-            return CreateButtonInternal(text, command, false, true);
+            return CreateButtonInternal(text, null, isCancel: true, command: command);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="action">Action to execute when button pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateCancelButton(string text, Action action)
+        {
+            return CreateButtonInternal(text, action, isCancel: true);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="command">Command to execute when button pressed</param>
+        /// <param name="parameter">Parameter to pass the command when the button is pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public static IActionSheetButton CreateCancelButton<T>(string text, ICommand command, T parameter)
+        {
+            return CreateButtonInternal(text, null, parameter, isCancel: true, command: command);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="action">Action to execute when button pressed</param>
+        /// <param name="parameter">Parameter to pass the Action when the button is pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateCancelButton<T>(string text, Action<T> action, T parameter)
+        {
+            return CreateButtonInternal(text, action, parameter, isCancel: true);
         }
 
         /// <summary>
@@ -44,9 +84,46 @@ namespace Prism.Services
         /// <param name="text">Button text</param>
         /// <param name="command">Command to execute when button pressed</param>
         /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static ActionSheetButton CreateDestroyButton(string text, ICommand command)
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public static IActionSheetButton CreateDestroyButton(string text, ICommand command)
         {
-            return CreateButtonInternal(text, command, true, false);
+            return CreateButtonInternal(text, null, isDestroy: true, command: command);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="action">Action to execute when button pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateDestroyButton(string text, Action action)
+        {
+            return CreateButtonInternal(text, action, isDestroy: true);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="command">Command to execute when button pressed</param>
+        /// <param name="parameter">Parameter to pass the command when the button is pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public static IActionSheetButton CreateDestroyButton<T>(string text, ICommand command, T parameter)
+        {
+            return CreateButtonInternal(text, null, parameter, isDestroy: true, command: command);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="action">Action to execute when button pressed</param>
+        /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateDestroyButton<T>(string text, Action<T> action, T parameter)
+        {
+            return CreateButtonInternal(text, action, parameter, isDestroy: true);
         }
 
         /// <summary>
@@ -55,19 +132,70 @@ namespace Prism.Services
         /// <param name="text">Button text</param>
         /// <param name="command">Command to execute when button pressed</param>
         /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static ActionSheetButton CreateButton(string text, ICommand command)
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public static IActionSheetButton CreateButton(string text, ICommand command)
         {
-            return CreateButtonInternal(text, command, false, false);
+            return CreateButtonInternal(text, null, command: command);
         }
 
-        static ActionSheetButton CreateButtonInternal(string text, ICommand command, bool isDestroy, bool isCancel)
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="action">Action to execute when button pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateButton(string text, Action action)
         {
-            return new ActionSheetButton
+            return CreateButtonInternal(text, action);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="command">Command to execute when button pressed</param>
+        /// <param name="parameter">The parameter to pass the command when the button is pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public static IActionSheetButton CreateButton<T>(string text, ICommand command, T parameter)
+        {
+            return CreateButtonInternal(text, null, parameter, command: command);
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <param name="action">Action to execute when button pressed</param>
+        /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateButton<T>(string text, Action<T> action, T parameter)
+        {
+            return CreateButtonInternal(text, action, parameter);
+        }
+
+        private static IActionSheetButton CreateButtonInternal(string text, Action action, bool isCancel = false, bool isDestroy = false, ICommand command = null)
+        {
+            return new ActionSheetButton()
             {
                 Text = text,
-                Command = command,
+                Action = action,
+                IsCancel = isCancel,
                 IsDestroy = isDestroy,
-                IsCancel = isCancel
+                Command = command
+            };
+        }
+
+        private static IActionSheetButton CreateButtonInternal<T>(string text, Action<T> action, T parameter, bool isCancel = false, bool isDestroy = false, ICommand command = null)
+        {
+            return new ActionSheetButton<T>()
+            {
+                Text = text,
+                Action = action,
+                Parameter = parameter,
+                IsCancel = isCancel,
+                IsDestroy = isDestroy,
+                Command = command
             };
         }
     }

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButtonBase.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButtonBase.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Prism.Services
+{
+    /// <summary>
+    /// ActionSheetButton Base class
+    /// </summary>
+    public abstract class ActionSheetButtonBase : IActionSheetButton
+    {
+        protected ActionSheetButtonBase()
+        {
+            
+        }
+
+        /// <summary>
+        /// <see cref="ICommand"/> backing <see cref="IActionSheetButton"/>'s Command property
+        /// </summary>
+        /// <value>The command.</value>
+        protected ICommand _command { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="IActionSheetButton"/>
+        /// is cancel.
+        /// </summary>
+        /// <value><c>true</c> if is cancel; otherwise, <c>false</c>.</value>
+        protected bool _isCancel { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="IActionSheetButton"/>
+        /// is destroy.
+        /// </summary>
+        /// <value><c>true</c> if is destroy; otherwise, <c>false</c>.</value>
+        protected bool _isDestroy { get; private set; }
+
+        /// <summary>
+        /// The backing text for <see cref="IActionSheetButton"/>
+        /// </summary>
+        /// <value>The text.</value>
+        protected string _text { get; private set; }
+
+        /// <summary>
+        /// Command to execute when the button is pressed
+        /// </summary>
+        /// <value>The command.</value>
+        [Obsolete("IActionSheetButton is replacing Commands with Action's. Commands will be removed in a future release.")]
+        public ICommand Command
+        {
+            get { return _command; }
+            protected internal set { _command = value; }
+        }
+
+        /// <summary>
+        /// The button will be used as a Cancel Button
+        /// </summary>
+        /// <value><c>true</c> if is cancel; otherwise, <c>false</c>.</value>
+        public bool IsCancel
+        {
+            get { return _isCancel; }
+            protected internal set
+            {
+                if( _isCancel = value )
+                    IsDestroy = false;
+            }
+        }
+
+        /// <summary>
+        /// The button will be used as a Destroy Button
+        /// </summary>
+        /// <value><c>true</c> if is destroy; otherwise, <c>false</c>.</value>
+        public bool IsDestroy
+        {
+            get { return _isDestroy; }
+            protected internal set 
+            {
+                if( _isDestroy = value )
+                    IsCancel = false;
+            }
+        }
+
+        /// <summary>
+        /// Executes the action to take when the button is pressed
+        /// </summary>
+        /// <value>The text.</value>
+        public string Text
+        {
+            get { return _text; }
+            protected internal set { _text = value; }
+        }
+
+        /// <summary>
+        /// Executes the action.
+        /// </summary>
+        protected abstract void OnButtonPressed();
+
+        /// <inheritDoc />
+        bool IActionSheetButton.IsCancel
+        {
+            get { return _isCancel; }
+        }
+
+        /// <inheritDoc />
+        bool IActionSheetButton.IsDestroy
+        {
+            get { return _isDestroy; }
+        }
+
+        /// <inheritDoc />
+        string IActionSheetButton.Text
+        {
+            get { return _text; }
+        }
+
+        /// <inheritDoc />
+        void IActionSheetButton.PressButton() =>
+           OnButtonPressed();
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButton{T}.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButton{T}.cs
@@ -1,0 +1,37 @@
+﻿using System;
+namespace Prism.Services
+{
+    /// <summary>
+    /// Provides a Generic Implementation for IActionSheetButton
+    /// </summary>
+    public class ActionSheetButton<T> : ActionSheetButtonBase
+    {
+        protected internal ActionSheetButton()
+        {
+            
+        }
+
+        /// <summary>
+        /// Generic Action to perform
+        /// </summary>
+        /// <value>The action.</value>
+        public Action<T> Action { get; set; }
+
+        /// <summary>
+        /// Typed Parameter
+        /// </summary>
+        /// <value>The parameter.</value>
+        public T Parameter { get; set; }
+
+        /// <summary>
+        /// Executes the action to take when the button is pressed
+        /// </summary>
+        protected override void OnButtonPressed()
+        {
+            Action?.Invoke(Parameter);
+
+            if(Command?.CanExecute(Parameter) ?? false)
+                Command.Execute( Parameter);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/IActionSheetButton.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/IActionSheetButton.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 
 namespace Prism.Services
 {
@@ -23,8 +24,8 @@ namespace Prism.Services
         string Text { get; }
 
         /// <summary>
-        /// Command to execute when button is pressed
+        /// Presses the button.
         /// </summary>
-        ICommand Command { get; }
+        void PressButton();
     }
 }

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -67,7 +67,7 @@ namespace Prism.Services
         /// </summary>
         /// <para>
         /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
-        /// the <see cref="IActionSheetButton.Command"/> will be executed.
+        /// the <see cref="System.Windows.Input.ICommand"/> or <see cref="Action"/> will be executed.
         /// </para>
         /// <param name="title">Text to display in action sheet</param>
         /// <param name="buttons">Buttons displayed in action sheet</param>
@@ -85,9 +85,7 @@ namespace Prism.Services
 
             foreach (var button in buttons.Where(button => button != null && button.Text.Equals(pressedButton)))
             {
-                if (button.Command.CanExecute(button.Text))
-                    button.Command.Execute(button.Text);
-
+                button.PressButton();
                 return;
             }
         }


### PR DESCRIPTION
Replaces PR #837 for issue #836 

  - Adds support for the use of injecting a generic parameter
  - Deprecates the use of `ICommand`
  - Introduces support for directly using an `Action` or `Action<T>`