### PR TITLE
NavigationParameters does now allow to specify a base type as generic parameter T

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/NavigationParametersFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/NavigationParametersFixture.cs
@@ -230,8 +230,48 @@ namespace Prism.Forms.Tests.Navigation
             Assert.IsType<int>(result[1]);
             Assert.IsType<int>(result[2]);
         }
+
+        [Fact]
+        public void GetValueUseParentClassAsTypeParameter()
+        {
+            var parameters = new NavigationParameters();
+            parameters.Add("id", new Child());
+
+            Assert.NotNull(parameters.GetValue<Person>("id"));
+        }
+
+        [Fact]
+        public void TryGetValueUseParentClassAsTypeParameter()
+        {
+            var parameters = new NavigationParameters();
+            parameters.Add("id", new Child());
+
+            Person value;
+            var result = parameters.TryGetValue<Person>("id", out value);
+            Assert.True(result);
+            Assert.IsType<Child>(value);
+        }
+
+        [Fact]
+        public void GetValuesUseParentClassAsTypeParameter()
+        {
+            var parameters = new NavigationParameters();
+            parameters.Add("id", new Child());
+            parameters.Add("id", new Child());
+            parameters.Add("id", new Person());
+
+            var result = parameters.GetValues<Person>("id").ToArray();
+
+            Assert.Equal(3, result.Count());
+            Assert.NotNull(result[0]);
+            Assert.NotNull(result[1]);
+            Assert.NotNull(result[2]);
+        }
     }
 
     public class Person
+    { }
+
+    public class Child : Person
     { }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/NavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/NavigationParameters.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 
 namespace Prism.Navigation
 {
@@ -167,6 +168,8 @@ namespace Prism.Navigation
                         return default(T);
                     else if (kvp.Value.GetType() == typeof(T))
                         return (T)kvp.Value;
+                    else if (typeof(T).GetTypeInfo().IsAssignableFrom(kvp.Value.GetType().GetTypeInfo()))
+                        return (T)kvp.Value;
                     else
                         return (T)Convert.ChangeType(kvp.Value, typeof(T));
                 }
@@ -191,6 +194,8 @@ namespace Prism.Navigation
                     if (kvp.Value == null)
                         value = default(T);
                     else if (kvp.Value.GetType() == typeof(T))
+                        value = (T)kvp.Value;
+                    else if (typeof(T).GetTypeInfo().IsAssignableFrom(kvp.Value.GetType().GetTypeInfo()))
                         value = (T)kvp.Value;
                     else
                         value = (T)Convert.ChangeType(kvp.Value, typeof(T));
@@ -220,6 +225,8 @@ namespace Prism.Navigation
                     if (kvp.Value == null)
                         values.Add(default(T));
                     else if (kvp.Value.GetType() == typeof(T))
+                        values.Add((T)kvp.Value);
+                    else if (typeof(T).GetTypeInfo().IsAssignableFrom(kvp.Value.GetType().GetTypeInfo()))
                         values.Add((T)kvp.Value);
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, typeof(T)));


### PR DESCRIPTION
Problem
===

I want to retrieve values from NavigationParameters that are of a common base type.
This is not possible since there is an error thrown indicating that the type must implement IConvertible.
Since the type I passed inherits the type of the generic parameter T there is no need to implement IConvertible.

What is changed
===

I changed the code so that if the type inherits the generic parameter T then the item is returned.


NavigationParameters does now allow to retrieve values if T is a parent of the item.



    NavigationParameters.GetValue<T>
    NavigationParameters.GetValues<T>
    NavigationParameters.TryGetValue<T>

Please take a moment to fill out the following:

Fixes issue #1008 .

Changes proposed in this pull request:
- 

    public class Test : ICustomInterface{}

    NavigationParameters np = new NavigationParameters ();
    np.Add("Test", new Test());

    np.GetValue<object>(); //this line did not worked previously
    np.GetValue<ICustomInterface>(); //this line did not worked previously