### PR TITLE
Avoid InvalidCastException.

### DIFF
--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -99,8 +99,8 @@ namespace Prism.Commands
         }
 
         protected override bool CanExecute(object parameter)
-        {
-            return parameter is T arg && CanExecute(arg);
+        {        
+            (parameter == null || parameter is T) && CanExecute((T)parameter);
         }
 
         /// <summary>

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -100,7 +100,7 @@ namespace Prism.Commands
 
         protected override bool CanExecute(object parameter)
         {        
-            (parameter == null || parameter is T) && CanExecute((T)parameter);
+            return (parameter == null || parameter is T) && CanExecute((T)parameter);
         }
 
         /// <summary>

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -100,7 +100,7 @@ namespace Prism.Commands
 
         protected override bool CanExecute(object parameter)
         {
-            return CanExecute((T)parameter);
+            return (parameter is null || parameter is T) && CanExecute((T)parameter);            
         }
 
         /// <summary>

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -100,7 +100,7 @@ namespace Prism.Commands
 
         protected override bool CanExecute(object parameter)
         {
-            return (parameter is null || parameter is T) && CanExecute((T)parameter);            
+            return parameter is T arg && CanExecute(arg);
         }
 
         /// <summary>


### PR DESCRIPTION
This change is a simpler working way of avoiding the `InvalidCastException` occuring if the `BindingContext` is not ready yet and returns the parent container.
Please see XF's way of achieving this, [here](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Core/Command.cs#L39).

Please take a moment to fill out the following:

Fixes issue #1002.

Changes proposed in this pull request:
Avoid uncaught `InvalidCastException` in `DelegateCommand<T>`.