### PR TITLE
Immutable IoC container for Prism.Autofac.Forms - resolution to issue # 969

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Mocks/PrismApplicationMock.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Mocks/PrismApplicationMock.cs
@@ -5,17 +5,15 @@ using Prism.DI.Forms.Tests.Mocks.Views;
 using Prism.Modularity;
 using Prism.Navigation;
 using Xamarin.Forms;
-using Autofac;
 
 namespace Prism.Autofac.Forms.Tests.Mocks
 {
     public class PrismApplicationMock : PrismApplication
     {
         public PrismApplicationMock()
-        {
-        }
+        { }
 
-        public PrismApplicationMock(Page startPage) : this()
+        public PrismApplicationMock(Page startPage)
         {
             Current.MainPage = startPage;
         }
@@ -41,23 +39,21 @@ namespace Prism.Autofac.Forms.Tests.Mocks
 
         protected override void RegisterTypes()
         {
-            var builder = new ContainerBuilder();
+            FormsDependencyService.Register<IDependencyServiceMock>(new DependencyServiceMock());
 
-            builder.RegisterType<ServiceMock>().As<IServiceMock>();
-            builder.RegisterType<AutowireViewModel>();
-            builder.RegisterType<ViewModelAMock>();
-            builder.Register(ctx => new ViewModelBMock()).Named<ViewModelBMock>(ViewModelBMock.Key);
-            builder.RegisterType<ConstructorArgumentViewModel>();
-            builder.RegisterType<ModuleMock>().SingleInstance();
-
-            builder.Update(Container);
+            Container.RegisterType<ServiceMock>().As<IServiceMock>();
+            Container.RegisterType<AutowireViewModel>();
+            Container.RegisterType<ViewModelAMock>();
+            Container.Register(ctx => new ViewModelBMock()).Named<ViewModelBMock>(ViewModelBMock.Key);
+            Container.RegisterType<ConstructorArgumentViewModel>();
+            Container.RegisterType<ModuleMock>().SingleInstance();
+            Container.Register(ctx => FormsDependencyService.Get<IDependencyServiceMock>())
+                .As<IDependencyServiceMock>();
 
             Container.RegisterTypeForNavigation<ViewMock>("view");
             Container.RegisterTypeForNavigation<ViewAMock, ViewModelAMock>();
             Container.RegisterTypeForNavigation<AutowireView, AutowireViewModel>();
             Container.RegisterTypeForNavigation<ConstructorArgumentView, ConstructorArgumentViewModel>();
-
-            FormsDependencyService.Register<IDependencyServiceMock>(new DependencyServiceMock());
         }
 
         public INavigationService CreateNavigationServiceForPage()

--- a/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
@@ -1,8 +1,6 @@
-﻿using Autofac;
-
-namespace Prism.Autofac.Forms
+﻿namespace Prism.Autofac.Forms
 {
-    public interface IPlatformInitializer : IPlatformInitializer<IContainer>
+    public interface IPlatformInitializer : IPlatformInitializer<IAutofacContainer>
     {
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/Immutable/AutofacContainer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Immutable/AutofacContainer.cs
@@ -1,0 +1,360 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Core.Lifetime;
+using Autofac.Core.Resolving;
+using Autofac.Features.LightweightAdapters;
+using Autofac.Features.OpenGenerics;
+using Autofac.Features.Scanning;
+
+namespace Prism.Autofac.Forms.Immutable
+{
+    public class AutofacContainer : IAutofacContainer
+    {
+        private readonly object _locker = new object();
+
+        private IContainer _container;
+
+        private ContainerBuilder _builder = new ContainerBuilder();
+
+        private IComponentRegistry _runtimeRegistry;
+
+        //TODO: The _registeredTypes field should be eliminated when we can require Autofac 4.4.0 or higher
+        private List<Type> _registeredTypes = new List<Type>();
+
+        public bool IsContainerBuilt => _container != null;
+
+        private void CheckBuilder()
+        {
+            if (IsContainerBuilt)
+            {
+                throw new InvalidOperationException("It is not possible to perform registration operations after the Container has been built.");
+            }
+        }
+
+        //TODO: We will be able to eliminate the TrackRegisteredType() method when we can require Autofac 4.4.0 or higher, and do conditional registration.
+        private void TrackRegisteredType(Type registeredType)
+        {
+            if (registeredType == null) return;
+            lock (_locker)
+            {
+                if (!_registeredTypes.Contains(registeredType))
+                {
+                    _registeredTypes.Add(registeredType);
+                }
+            }
+        }
+
+        //TODO: We will be able to eliminate the IsTypeRegistered() method when we can require Autofac 4.4.0 or higher, and do conditional registration
+        [Obsolete("The IsTypeRegistered() method will be removed in the future; if you are using Autofac 4.4.0 (or higher), use conditional registration instead.")]
+        public bool IsTypeRegistered(Type registeredType)
+        {
+            if (registeredType == null) return false;
+            lock (_locker)
+            {
+                return _registeredTypes.Contains(registeredType);
+            }
+        }
+
+        private void CheckBuildContainer()
+        {
+            if (IsContainerBuilt) return;
+            lock (_locker)
+            {
+                if (_container == null)
+                {
+                    _container = _builder.Build();
+                    _runtimeRegistry = new RuntimeComponentRegistry(_container);
+                }
+            }
+        }
+
+        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        {
+            CheckBuildContainer();
+            return _container.ResolveComponent(registration, parameters);
+        }
+
+        public IComponentRegistry ComponentRegistry
+        {
+            get
+            {
+                CheckBuildContainer();
+                return _runtimeRegistry;
+            }
+        }
+
+        #region Registration operations
+
+        /// <summary>Add a component to the container.</summary>
+        /// <param name="registration">The component to add.</param>
+        public void RegisterComponent(IComponentRegistration registration)
+        {
+            CheckBuilder();
+            //TODO: May need to identify the types being registered, and call TrackRegisteredType() on them
+            _builder.RegisterComponent(registration);
+        }
+
+        /// <summary>Add a registration source to the container.</summary>
+        /// <param name="registrationSource">The registration source to add.</param>
+        public void RegisterSource(IRegistrationSource registrationSource)
+        {
+            CheckBuilder();
+            //TODO: May need to identify the types being registered, and call TrackRegisteredType() on them
+            _builder.RegisterSource(registrationSource);
+        }
+
+        /// <summary>Register an instance as a component.</summary>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <param name="instance">The instance to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        /// <remarks>If no services are explicitly specified for the instance, the
+        /// static type <typeparamref name="T" /> will be used as the default service (i.e. *not* <code>instance.GetType()</code>).</remarks>
+        public IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> RegisterInstance<T>(T instance) where T : class
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(T));
+            return _builder.RegisterInstance(instance);
+        }
+
+        /// <summary>
+        /// Register a component to be created through reflection.
+        /// </summary>
+        /// <typeparam name="TImplementer">The type of the component implementation.</typeparam>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public IRegistrationBuilder<TImplementer, ConcreteReflectionActivatorData, SingleRegistrationStyle> RegisterType<TImplementer>()
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TImplementer));
+            return _builder.RegisterType<TImplementer>();
+        }
+
+        public IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> RegisterType(Type implementationType)
+        {
+            CheckBuilder();
+            TrackRegisteredType(implementationType);
+            return _builder.RegisterType(implementationType);
+        }
+
+        /// <summary>Register a delegate as a component.</summary>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <param name="delegate">The delegate to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> Register<T>(Func<IComponentContext, T> @delegate)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(T));
+            return _builder.Register(@delegate);
+        }
+
+        /// <summary>Register a delegate as a component.</summary>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <param name="delegate">The delegate to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> Register<T>(Func<IComponentContext, IEnumerable<Parameter>, T> @delegate)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(T));
+            return _builder.Register(@delegate);
+        }
+
+        /// <summary>
+        /// Register an un-parameterised generic type, e.g. Repository&lt;&gt;.
+        /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
+        /// </summary>
+        /// <param name="implementer">The open generic implementation type.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> RegisterGeneric(Type implementer)
+        {
+            CheckBuilder();
+            TrackRegisteredType(implementer);
+            return _builder.RegisterGeneric(implementer);
+        }
+
+        /// <summary>Register the types in an assembly.</summary>
+        /// <param name="assemblies">The assemblies from which to register types.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> RegisterAssemblyTypes(params Assembly[] assemblies)
+        {
+            CheckBuilder();
+            //TODO: May need to identify the types being registered, and call TrackRegisteredType() on them
+            return _builder.RegisterAssemblyTypes(assemblies);
+        }
+
+        /// <summary>Register the types in a list.</summary>
+        /// <param name="types">The types to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> RegisterTypes(params Type[] types)
+        {
+            CheckBuilder();
+            foreach (Type type in (types ?? new Type[] {}))
+            {
+                TrackRegisteredType(type);
+            }
+            return _builder.RegisterTypes(types);
+        }
+
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom" />
+        /// to provide <typeparamref name="TTo" /> using the provided <paramref name="adapter" />
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom" />.</typeparam>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom" /> to
+        /// service <typeparamref name="TTo" />, given the context and parameters.</param>
+        public IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle> RegisterAdapter<TFrom, TTo>(Func<IComponentContext, IEnumerable<Parameter>, TFrom, TTo> adapter)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TTo));
+            return _builder.RegisterAdapter(adapter);
+        }
+
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom" />
+        /// to provide <typeparamref name="TTo" /> using the provided <paramref name="adapter" />
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom" />.</typeparam>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom" /> to
+        /// service <typeparamref name="TTo" />, given the context.</param>
+        public IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle> RegisterAdapter<TFrom, TTo>(Func<IComponentContext, TFrom, TTo> adapter)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TTo));
+            return _builder.RegisterAdapter(adapter);
+        }
+
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom" />
+        /// to provide <typeparamref name="TTo" /> using the provided <paramref name="adapter" />
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom" />.</typeparam>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom" /> to
+        /// service <typeparamref name="TTo" />.</param>
+        public IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle> RegisterAdapter<TFrom, TTo>(Func<TFrom, TTo> adapter)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TTo));
+            return _builder.RegisterAdapter(adapter);
+        }
+
+        /// <summary>
+        /// Decorate all components implementing open generic service <paramref name="decoratedServiceType" />.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <param name="decoratedServiceType">Service type being decorated. Must be an open generic type.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        /// <param name="decoratorType">The type of the decorator. Must be an open generic type, and accept a parameter
+        /// of type <paramref name="decoratedServiceType" />, which will be set to the instance being decorated.</param>
+        public IRegistrationBuilder<object, OpenGenericDecoratorActivatorData, DynamicRegistrationStyle> RegisterGenericDecorator(Type decoratorType, Type decoratedServiceType, object fromKey, object toKey = null)
+        {
+            CheckBuilder();
+            TrackRegisteredType(decoratedServiceType);
+            return _builder.RegisterGenericDecorator(decoratorType, decoratedServiceType, fromKey, toKey);
+        }
+
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService" />
+        /// using the provided <paramref name="decorator" /> function.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService" />, given the context and parameters.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        public IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle> RegisterDecorator<TService>(Func<IComponentContext, IEnumerable<Parameter>, TService, TService> decorator, object fromKey, object toKey = null)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TService));
+            return _builder.RegisterDecorator(decorator, fromKey, toKey);
+        }
+
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService" />
+        /// using the provided <paramref name="decorator" /> function.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService" />, given the context.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        public IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle> RegisterDecorator<TService>(Func<IComponentContext, TService, TService> decorator, object fromKey, object toKey = null)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TService));
+            return _builder.RegisterDecorator(decorator, fromKey, toKey);
+        }
+
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService" />
+        /// using the provided <paramref name="decorator" /> function.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService" />.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        public IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle> RegisterDecorator<TService>(Func<TService, TService> decorator, object fromKey, object toKey = null)
+        {
+            CheckBuilder();
+            TrackRegisteredType(typeof(TService));
+            return _builder.RegisterDecorator(decorator, fromKey, toKey);
+        }
+
+        #endregion
+
+        public void Dispose()
+        {
+            _runtimeRegistry?.Dispose();
+            _runtimeRegistry = null;
+            _builder = null;
+            _container?.Dispose();
+            _container = null;
+            _registeredTypes?.Clear();
+            _registeredTypes = null;
+        }
+
+        public ILifetimeScope BeginLifetimeScope()
+        {
+            return _container?.BeginLifetimeScope();
+        }
+
+        public ILifetimeScope BeginLifetimeScope(object tag)
+        {
+            return _container?.BeginLifetimeScope(tag);
+        }
+
+        public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction)
+        {
+            return _container?.BeginLifetimeScope(configurationAction);
+        }
+
+        public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction)
+        {
+            return _container?.BeginLifetimeScope(tag, configurationAction);
+        }
+
+        public IDisposer Disposer => _container?.Disposer;
+
+        public object Tag => _container?.Tag;
+
+        //These events appear to not be used by Prism.Autofac.Forms
+        public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning;
+        public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding;
+        public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning;
+    }
+}

--- a/Source/Xamarin/Prism.Autofac.Forms/Immutable/IAutofacContainer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Immutable/IAutofacContainer.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Autofac;
+using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Features.LightweightAdapters;
+using Autofac.Features.OpenGenerics;
+using Autofac.Features.Scanning;
+
+// ReSharper disable once CheckNamespace
+namespace Prism.Autofac.Forms
+{
+    /// <summary>
+    /// An abstraction of an Autofac ContainerBuilder plus Container - wraps an Autofac IContainer
+    /// instance that can only be built once and cannot be updated (i.e. is immutable).
+    /// </summary>
+    public interface IAutofacContainer : IContainer
+    {
+        /// <summary>
+        /// Identifies if the wrapped Autofac IContainer instance has been built or not.
+        /// (Type/page registrations can no longer be made after it has been built.
+        /// </summary>
+        bool IsContainerBuilt { get; }
+
+        //TODO: We will be able to eliminate the IsTypeRegistered() method when we can require Autofac 4.4.0 or higher, and do conditional registration
+        /// <summary>
+        /// Identifies if a particular Type has already been registered for the wrapped IContainer instance (to be built)
+        /// </summary>
+        /// <param name="registeredType">The Type to check</param>
+        /// <returns>True if the Type is already registered, False if it is not.</returns>
+        [Obsolete("The IsTypeRegistered() method will be removed in the future; if you are using Autofac 4.4.0 (or higher), use conditional registration instead.")]
+        bool IsTypeRegistered(Type registeredType);
+
+        #region Registration operations
+
+        /// <summary>Add a component to the container.</summary>
+        /// <param name="registration">The component to add.</param>
+        void RegisterComponent(IComponentRegistration registration);
+
+        /// <summary>Add a registration source to the container.</summary>
+        /// <param name="registrationSource">The registration source to add.</param>
+        void RegisterSource(IRegistrationSource registrationSource);
+
+        /// <summary>Register an instance as a component.</summary>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <param name="instance">The instance to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        /// <remarks>If no services are explicitly specified for the instance, the
+        /// static type <typeparamref name="T" /> will be used as the default service (i.e. *not* <code>instance.GetType()</code>).</remarks>
+        IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> RegisterInstance<T>(T instance)
+            where T : class;
+
+        /// <summary>
+        /// Register a component to be created through reflection.
+        /// </summary>
+        /// <typeparam name="TImplementer">The type of the component implementation.</typeparam>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        IRegistrationBuilder<TImplementer, ConcreteReflectionActivatorData, SingleRegistrationStyle>
+            RegisterType<TImplementer>();
+
+        IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> RegisterType(
+            Type implementationType);
+
+        /// <summary>Register a delegate as a component.</summary>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <param name="delegate">The delegate to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> Register<T>(
+            Func<IComponentContext, T> @delegate);
+
+        /// <summary>Register a delegate as a component.</summary>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <param name="delegate">The delegate to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> Register<T>(
+            Func<IComponentContext, IEnumerable<Parameter>, T> @delegate);
+
+        /// <summary>
+        /// Register an un-parameterised generic type, e.g. Repository&lt;&gt;.
+        /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
+        /// </summary>
+        /// <param name="implementer">The open generic implementation type.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> RegisterGeneric(
+            Type implementer);
+
+        /// <summary>Register the types in an assembly.</summary>
+        /// <param name="assemblies">The assemblies from which to register types.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> RegisterAssemblyTypes(
+            params Assembly[] assemblies);
+
+        /// <summary>Register the types in a list.</summary>
+        /// <param name="types">The types to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
+            RegisterTypes(params Type[] types);
+
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom" />
+        /// to provide <typeparamref name="TTo" /> using the provided <paramref name="adapter" />
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom" />.</typeparam>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom" /> to
+        /// service <typeparamref name="TTo" />, given the context and parameters.</param>
+        IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle>
+            RegisterAdapter<TFrom, TTo>(Func<IComponentContext, IEnumerable<Parameter>, TFrom, TTo> adapter);
+
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom" />
+        /// to provide <typeparamref name="TTo" /> using the provided <paramref name="adapter" />
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom" />.</typeparam>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom" /> to
+        /// service <typeparamref name="TTo" />, given the context.</param>
+        IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle>
+            RegisterAdapter<TFrom, TTo>(Func<IComponentContext, TFrom, TTo> adapter);
+
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom" />
+        /// to provide <typeparamref name="TTo" /> using the provided <paramref name="adapter" />
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom" />.</typeparam>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom" /> to
+        /// service <typeparamref name="TTo" />.</param>
+        IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle>
+            RegisterAdapter<TFrom, TTo>(Func<TFrom, TTo> adapter);
+
+        /// <summary>
+        /// Decorate all components implementing open generic service <paramref name="decoratedServiceType" />.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <param name="decoratedServiceType">Service type being decorated. Must be an open generic type.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        /// <param name="decoratorType">The type of the decorator. Must be an open generic type, and accept a parameter
+        /// of type <paramref name="decoratedServiceType" />, which will be set to the instance being decorated.</param>
+        IRegistrationBuilder<object, OpenGenericDecoratorActivatorData, DynamicRegistrationStyle>
+            RegisterGenericDecorator(Type decoratorType, Type decoratedServiceType, object fromKey,
+                object toKey = null);
+
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService" />
+        /// using the provided <paramref name="decorator" /> function.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService" />, given the context and parameters.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle>
+            RegisterDecorator<TService>(Func<IComponentContext, IEnumerable<Parameter>, TService, TService> decorator,
+                object fromKey, object toKey = null);
+
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService" />
+        /// using the provided <paramref name="decorator" /> function.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService" />, given the context.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle>
+            RegisterDecorator<TService>(Func<IComponentContext, TService, TService> decorator, object fromKey,
+                object toKey = null);
+
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService" />
+        /// using the provided <paramref name="decorator" /> function.
+        /// The <paramref name="fromKey" /> and <paramref name="toKey" /> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService" />.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle>
+            RegisterDecorator<TService>(Func<TService, TService> decorator, object fromKey, object toKey = null);
+
+        #endregion
+    }
+}

--- a/Source/Xamarin/Prism.Autofac.Forms/Immutable/IPreRegisterTypes.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Immutable/IPreRegisterTypes.cs
@@ -1,0 +1,16 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Prism.Autofac.Forms
+{
+    /// <summary>
+    /// Identifies a class (typically an implementation of IModule) that has Type/Page registration
+    /// requirements that must be handled, prior to building the Prism Autofac container.
+    /// </summary>
+    public interface IPreRegisterTypes
+    {
+        /// <summary>
+        /// Method that is executed during module cataloging to register any Types/Pages that are required by the module.
+        /// </summary>
+        /// <param name="container">The container that registration operations will be performed on</param>
+        void RegisterTypes(IAutofacContainer container);
+    }
+}

--- a/Source/Xamarin/Prism.Autofac.Forms/Immutable/RuntimeComponentRegistry.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Immutable/RuntimeComponentRegistry.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Autofac;
+using Autofac.Core;
+
+namespace Prism.Autofac.Forms.Immutable
+{
+    //Newer versions of Autofac (e.g. 4.5.x) require implementations of IComponentRegistry to
+    //  have a readonly Properties property of type IDictionary<string, object>
+    internal interface IPropertiesDictionary
+    {
+        IDictionary<string, object> Properties { get; }
+    }
+
+    /// <summary>
+    /// Implementation of IComponentRegistry that is provided for querying Type/Page registrations after
+    /// the Prism Autofac container has been built; but does not allow subsequent registrations.
+    /// </summary>
+    public class RuntimeComponentRegistry : IComponentRegistry, IPropertiesDictionary
+    {
+        private IContainer _container;
+
+        public RuntimeComponentRegistry(IContainer container)
+        {
+            _container = container ?? throw new ArgumentNullException(nameof(container));
+        }
+
+        public bool TryGetRegistration(Service service, out IComponentRegistration registration)
+        {
+            return _container.ComponentRegistry.TryGetRegistration(service, out registration);
+        }
+
+        public bool IsRegistered(Service service)
+        {
+            return _container.ComponentRegistry.IsRegistered(service);
+        }
+
+        public void Register(IComponentRegistration registration)
+        {
+            throw new InvalidOperationException("It is not possible to use ContainerBuilder.Update() with an immutable Autofac container; " 
+                                                + " or to perform registration operations after the container has been built.");
+        }
+
+        public void Register(IComponentRegistration registration, bool preserveDefaults)
+        {
+            throw new InvalidOperationException("It is not possible to use ContainerBuilder.Update() with an immutable Autofac container; "
+                                                + " or to perform registration operations after the container has been built.");
+        }
+
+        public void AddRegistrationSource(IRegistrationSource source)
+        {
+            throw new InvalidOperationException("It is not possible to use ContainerBuilder.Update() with an immutable Autofac container; "
+                                                + " or to perform registration operations after the container has been built.");
+        }
+
+        public IEnumerable<IComponentRegistration> RegistrationsFor(Service service)
+        {
+            return _container.ComponentRegistry.RegistrationsFor(service);
+        }
+
+        public IEnumerable<IComponentRegistration> Registrations => _container.ComponentRegistry.Registrations;
+
+        public IEnumerable<IRegistrationSource> Sources => _container.ComponentRegistry.Sources;
+
+        //TODO: The problem here is that IComponentRegistry in Autofac 3.x does NOT have a Properties property
+        //  but Autofac 4.x does.  We don't want to require Autofac 4.x at this time, because that requires .NETStandard
+        //  which requires extra work in Xamarin.Forms and Prism projects. So attempting to retrieve the value
+        //  from the _container.ComponentRegistry if available.
+        //  When we get to the point where we can require Autofac 4.x, it will just be this simple line:
+        //public IDictionary<string, object> Properties => _container.ComponentRegistry.Properties;
+        public IDictionary<string, object> Properties
+        {
+            get
+            {
+                IDictionary<string, object> result = null;
+
+                if (_container?.ComponentRegistry != null)
+                {
+                    try
+                    {
+                        PropertyInfo props = _container.ComponentRegistry.GetType().GetRuntimeProperty("Properties");
+                        if (props != null)
+                        {
+                            result = props.GetValue(_container.ComponentRegistry, null) as IDictionary<string, object>;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        //Could not retrieve Properties property from _container.ComponentRegistry
+                        result = new Dictionary<string, object>();
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public bool HasLocalComponents => _container.ComponentRegistry.HasLocalComponents;
+
+        //These events do not appear to be used by Prism.Autofac.Forms at all.
+        public event EventHandler<ComponentRegisteredEventArgs> Registered;
+        public event EventHandler<RegistrationSourceAddedEventArgs> RegistrationSourceAdded;
+
+        public void Dispose()
+        {
+            _container = null;
+        }        
+    }
+}

--- a/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
@@ -6,32 +6,31 @@ namespace Prism.Autofac.Forms.Modularity
 {
     public class AutofacModuleInitializer : IModuleInitializer
     {
-        readonly IContainer _container;
+        readonly IContainer _context;
 
         /// <summary>
-        /// Create a new instance of <see cref="AutofacModuleInitializer"/> with <paramref name="container"/>
+        /// Create a new instance of <see cref="AutofacModuleInitializer"/> with <paramref name="context"/>
         /// </summary>
-        /// <param name="container"></param>
+        /// <param name="context"></param>
         public AutofacModuleInitializer(IContainer context)
         {
-            _container = context;
+            _context = context;
         }
 
         public void Initialize(ModuleInfo moduleInfo)
         {
-            var module = (IModule)_container.Resolve(moduleInfo.ModuleType);
-            if (module != null)
-                module.Initialize();
+            var module = (IModule)_context.Resolve(moduleInfo.ModuleType);
+            module?.Initialize();
         }
 
         /// <summary>
-        /// Create the <see cref="IModule"/> for <paramref name="moduleType"/> by resolving from <see cref="_container"/>
+        /// Create the <see cref="IModule"/> for <paramref name="moduleType"/> by resolving from <see cref="_context"/>
         /// </summary>
         /// <param name="moduleType">Type of module to create</param>
         /// <returns>An isntance of <see cref="IModule"/> for <paramref name="moduleType"/> if exists; otherwise <see langword="null" /></returns>
         protected virtual IModule CreateModule(Type moduleType)
         {
-            return _container.Resolve(moduleType) as IModule;
+            return _context.Resolve(moduleType) as IModule;
         }
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/Navigation/AutofacPageNavigationService.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Navigation/AutofacPageNavigationService.cs
@@ -5,6 +5,7 @@ using Prism.Logging;
 using Prism.Navigation;
 using Xamarin.Forms;
 
+// ReSharper disable once CheckNamespace
 namespace Prism.Autofac.Navigation
 {
     /// <summary>
@@ -12,7 +13,7 @@ namespace Prism.Autofac.Navigation
     /// </summary>
     public class AutofacPageNavigationService : PageNavigationService
     {
-        readonly IContainer _container;
+        private IContainer _container;
 
         /// <summary>
         /// Create a new instance of <see cref="AutofacPageNavigationService"/> with <paramref name="container"/>
@@ -26,10 +27,15 @@ namespace Prism.Autofac.Navigation
             _container = container;
         }
 
+        internal void SetContainer(IContainer container)
+        {
+            _container = container;
+        }
+
         /// <summary>
-        /// Resolve a <see cref="Page"/> from <see cref="_container"/> for <paramref name="segmentName"/>
+        /// Resolve a <see cref="Page"/> from <see cref="_container"/> for <paramref name="name"/>
         /// </summary>
-        /// <param name="segmentName">Page to resolve</param>
+        /// <param name="name">Page to resolve</param>
         /// <returns>A <see cref="Page"/></returns>
         protected override Page CreatePage(string name)
         {

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -46,6 +46,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AutofacExtensions.cs" />
+    <Compile Include="Immutable\AutofacContainer.cs" />
+    <Compile Include="Immutable\IAutofacContainer.cs" />
+    <Compile Include="Immutable\IPreRegisterTypes.cs" />
+    <Compile Include="Immutable\RuntimeComponentRegistry.cs" />
     <Compile Include="IPlatformInitializer.cs" />
     <Compile Include="Modularity\AutofacModuleInitializer.cs" />
     <Compile Include="Navigation\AutofacPageNavigationService.cs" />


### PR DESCRIPTION
This request proposes to resolve issue #969 where the ability to update a built Autofac IContainer instance via the ContainerBuilder.Update() method is being removed from the Autofac library; and the current version of Prism.Autofac.Forms - 6.3.0 - relies on this soon-to-be-removed functionality.

The need to update the container is eliminated through the use of an instance of AutofacContainer (which implements a new IAutofacContainer interface).  The AutofacContainer type is an abstraction of an Autofac ContainerBuilder plus Container - both of these are wrapped in the AutofacContainer class; with this single type providing all IoC container registration and resolution functions (typically Autofac uses a ContainerBuilder for registration, and a Container for resolution).

`PrismApplication` inherits from `PrismApplicationBase<IAutofacContainer>` instead of `PrismApplicationBase<IContainer>` - with changes in the PrismApplication class to ensure that all type registration operations occur before the Autofac container is built; so that it only needs to be built once, and cannot be updated.

This new approach also resolves some problems that were observed with Prism.Autofac.Forms version 6.3.0 - where (a) the container seemed unable to resolve an instance of IContainer; and (b) navigation to pages in certain IoC-registered-types appeared to fail (e.g. navigation to pages that were declared in IModule instances).

Breaking changes and/or changes that are required in applications that consume the updated Prism.Autofac.Forms library:
- References to IContainer should be changed to IAutofacContainer - so `public void RegisterTypes(IContainer container)` becomes `public void RegisterTypes(IAutofacContainer container)`.  The new AutofacContainer type implements both IContainer and IAutofacContainer, but the type registration features are only available on IAutofacContainer.
- ContainerBuilders are not used to register types in the Autofac container used by Prism - AutofacContainer already creates and maintains its own ContainerBuilder instance.  

So this code:

    var builder = new ContainerBuilder();
    builder.RegisterType<RecipeService>().As<IRecipeService>().SingleInstance();
    builder.Update(Container);

Becomes simply:

    Container.RegisterType<RecipeService>().As<IRecipeService>().SingleInstance();

And type registration code like the example above **MUST** be placed in the overridden `PrismApplication.RegisterTypes()` method, or in a platform-specific `IPlatformInitializer.RegisterTypes()` method.  These are the correct places to do type registration in a Prism.Forms application, and ensure that the type registration occurs before the container is built (since registrations cannot be added post-container-build).
- For instances of IModule that must perform type registration, the IModule implementation should also implement IPreRegisterTypes (a new interface) - and then all type registration code should be placed in the `IModule.RegisterTypes()` method.

Since most functionality in this proposed change replaces existing functionality in Prism.Autofac.Forms, not too many new unit tests were required; but a test was added to make sure that, once built, the Autofac container used by Prism is immutable (type registration operations throw an exception), and that type resolution still works correctly.

Significant testing was performed with this updated Prism.Autofac.Forms code using the Prism application samples available [here](https://github.com/ellisnet/Prism-Samples-Forms/tree/feature/AllAutofacSamples/Autofac_New) - on iOS, Android and UWP devices.
