### PR TITLE
Remove exit() call on hardware back button tap

### DIFF
--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -439,10 +439,6 @@ namespace Prism.Windows
                 NavigationService.GoBack();
                 e.Handled = true;
             }
-            else if (DeviceGestureService.IsHardwareBackButtonPresent && e.IsHardwareButton)
-            {
-                Exit();
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issue #853.

Changes proposed in this pull request:
Removed Exit() call for devices with hardware buttons.

Tested on Win10 mobile with Anniversary update.