### PR TITLE
Check for e.Handled inside PrismApplication.OnGoBackRequested

### DIFF
--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -434,14 +434,17 @@ namespace Prism.Windows
         /// <param name="e"></param>
         private void OnGoBackRequested(object sender, DeviceGestureEventArgs e)
         {
-            if (NavigationService.CanGoBack())
+            if (!e.Handled)
             {
-                NavigationService.GoBack();
-                e.Handled = true;
-            }
-            else if (DeviceGestureService.IsHardwareBackButtonPresent && e.IsHardwareButton)
-            {
-                Exit();
+                if (NavigationService.CanGoBack())
+                {
+                    NavigationService.GoBack();
+                    e.Handled = true;
+                }
+                else if (DeviceGestureService.IsHardwareBackButtonPresent && e.IsHardwareButton)
+                {
+                    Exit();
+                }
             }
         }
 


### PR DESCRIPTION
Not a fix for any specific issue. Just an addiction for #867.

Changes proposed in this pull request:
Skip executing if GoBackEvent already  handled