### PR TITLE
Handle share activation and init boostraping

### DIFF
--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -219,9 +219,18 @@ namespace Prism.Windows
         {
             return Activator.CreateInstance(type);
         }
-
+        /// <summary> Invoked when the application is .
+        /// OnShareTargetActivated is the entry point for an application when it is activated through sharing.
+        /// Call <see cref="OnActivated"/> to bootstrap the prism application.
+        /// </summary>
+        /// <param name="args">Event data for the event.</param>
+        protected override void OnShareTargetActivated(ShareTargetActivatedEventArgs args)
+        {
+            base.OnShareTargetActivated(args);
+            OnActivated(args);
+        }
         /// <summary>
-        /// OnFileActivated is the entry point for an applicatoin when it is launched and the ActivationKind is File.
+        /// OnFileActivated is the entry point for an application when it is launched and the ActivationKind is File.
         /// Call <see cref="OnActivated"/> to bootstrap the prism application.
         /// </summary>
         /// <param name="args">Event data for the event.</param>

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -219,7 +219,8 @@ namespace Prism.Windows
         {
             return Activator.CreateInstance(type);
         }
-        /// <summary> Invoked when the application is .
+
+        /// <summary> Invoked when the application is activated via ShareTarget.
         /// OnShareTargetActivated is the entry point for an application when it is activated through sharing.
         /// Call <see cref="OnActivated"/> to bootstrap the prism application.
         /// </summary>
@@ -229,6 +230,7 @@ namespace Prism.Windows
             base.OnShareTargetActivated(args);
             OnActivated(args);
         }
+
         /// <summary>
         /// OnFileActivated is the entry point for an application when it is launched and the ActivationKind is File.
         /// Call <see cref="OnActivated"/> to bootstrap the prism application.


### PR DESCRIPTION
Opening a prism uwp app by share target, results in a hanging app (You only see the splash screen, no view will be loaded)
This is behavior is caused by not calling InitializeShell.

Fixes issue # .

Changes proposed in this pull request:
Override OnShareTargetActivated and call OnActivated to initiate the "bootstrapping" process of prism.
This issue and PR is related to #943 