### PR TITLE
fix Property Injection for navigationService

### DIFF
--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -25,18 +25,27 @@ namespace Prism.Unity
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
             {
-                ParameterOverrides overrides = null;
-
                 var page = view as Page;
-                if (page != null)
+                if (page == null)
                 {
-                    overrides = new ParameterOverrides
-                    {
-                        { "navigationService", CreateNavigationService(page) }
-                    };
+                    return Container.Resolve(type);
                 }
 
-                return Container.Resolve(type, overrides);
+                var navService = CreateNavigationService(page);
+                var overrides = new ParameterOverrides
+                {
+                    { "navigationService", navService }
+                };
+                var dependencyOverride = new DependencyOverrides()
+                {
+                    { typeof(INavigationService), navService }
+                };
+                var propertyOverrides = new PropertyOverrides()
+                {
+                    {"navigationService", navService}
+                };
+
+                return Container.Resolve(type, overrides, dependencyOverride, propertyOverrides);
             });
         }
 


### PR DESCRIPTION
fix Property (Setter) Injection for navigationService

ref:
https://msdn.microsoft.com/en-us/library/ff660920(v=pandp.20).aspx

Please take a moment to fill out the following:

Fixes issue:
Can not inject for navigationService by [Dependency] 

Changes proposed in this pull request:
- add DependencyOverrides, and PropertyOverrides