### PR TITLE
[WIP]Fix navigation service and unit test

### DIFF
--- a/Source/PrismLibrary_XF.sln
+++ b/Source/PrismLibrary_XF.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism", "Prism\Prism.csproj", "{E6C50355-D01E-4CAA-884D-D7929861315C}"
 EndProject
@@ -114,6 +114,7 @@ Global
 		{B6E74918-D92B-4690-BEC9-0BB199A6E933}.Test|x64.ActiveCfg = Test|Any CPU
 		{B6E74918-D92B-4690-BEC9-0BB199A6E933}.Test|x86.ActiveCfg = Test|Any CPU
 		{DD171BA8-7B2D-4722-B5BF-E0A9EBFA1D5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD171BA8-7B2D-4722-B5BF-E0A9EBFA1D5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD171BA8-7B2D-4722-B5BF-E0A9EBFA1D5F}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{DD171BA8-7B2D-4722-B5BF-E0A9EBFA1D5F}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{DD171BA8-7B2D-4722-B5BF-E0A9EBFA1D5F}.Debug|x86.ActiveCfg = Debug|Any CPU

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationEvent.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationEvent.cs
@@ -5,6 +5,7 @@
         OnNavigatingTo,
         OnNavigatedFrom,
         OnNavigatedTo,
+        CanNavigateAsync,
         Destroy
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/NavigationPageEmptyMockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/NavigationPageEmptyMockViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Prism.Forms.Tests.Mocks.ViewModels
+{
+    public class NavigationPageEmptyMockViewModel : ViewModelBase
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/OtherContentPageMockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/OtherContentPageMockViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Forms.Tests.Mocks.ViewModels
+{
+    public class OtherContentPageMockViewModel : ViewModelBase
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/PageMockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/PageMockViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Prism.Forms.Tests.Mocks.ViewModels
 {
-    public class PageMockViewModel
+    public class PageMockViewModel : ViewModelBase
     {
 
     }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ViewModelBase.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Prism.Mvvm;
 using Prism.Navigation;
 
 namespace Prism.Forms.Tests.Mocks.ViewModels
 {
-    public class ViewModelBase : BindableBase, INavigationAware, IDestructible, IPageNavigationEventRecordable
+    public class ViewModelBase : BindableBase, INavigationAware, IDestructible, IPageNavigationEventRecordable, IConfirmNavigation
     {
-        public NavigationParameters NavigatedToParameters { get; private set; }
+        public NavigationParameters NavigatingToParameters { get; private set; }
         public NavigationParameters NavigatedFromParameters { get; private set; }
+        public NavigationParameters NavigatedToParameters { get; private set; }
+        public NavigationParameters CanNavigateParameters { get; private set; }
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
 
         public bool OnNavigatedToCalled { get; private set; } = false;
@@ -35,7 +38,7 @@ namespace Prism.Forms.Tests.Mocks.ViewModels
         public void OnNavigatingTo(NavigationParameters parameters)
         {
             OnNavigatingdToCalled = true;
-            NavigatedToParameters = parameters;
+            NavigatingToParameters = parameters;
             PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatingTo);
         }
 
@@ -43,6 +46,12 @@ namespace Prism.Forms.Tests.Mocks.ViewModels
         {
             DestroyCalled = true;
             PageNavigationEventRecorder?.Record(this, PageNavigationEvent.Destroy);
+        }
+
+        public bool CanNavigate(NavigationParameters parameters)
+        {
+            CanNavigateParameters = parameters;
+            return true;
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/MasterDetailPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/MasterDetailPageMock.cs
@@ -35,6 +35,7 @@ namespace Prism.Forms.Tests.Mocks.Views
         public MasterDetailPageEmptyMock()
         {
             ViewModelLocator.SetAutowireViewModel(this, true);
+            Master = new ContentPageMock {Title = "Master"};
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/MasterDetailPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/MasterDetailPageMock.cs
@@ -15,6 +15,7 @@ namespace Prism.Forms.Tests.Mocks.Views
 
         public MasterDetailPageMock(PageNavigationEventRecorder recorder)
         {
+            Master = new ContentPageMock{ Title = "Master" };
             Detail = new ContentPageMock(recorder);
 
             ViewModelLocator.SetAutowireViewModel(this, true);

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
@@ -5,8 +5,9 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class NavigationPageMock : NavigationPage, INavigationAware, IDestructible, IPageNavigationEventRecordable
+    public class NavigationPageMock : NavigationPage, INavigationAware, IDestructible, IPageNavigationEventRecordable, INavigationPageOptions
     {
+        public bool ClearNavigationStackOnNavigation { get; set; } = true;
         public bool DestroyCalled { get; private set; } = false;
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
 
@@ -52,17 +53,41 @@ namespace Prism.Forms.Tests.Mocks.Views
         }
     }
 
-    public class NavigationPageEmptyMock : NavigationPageMock
+    public class NavigationPageEmptyMock : NavigationPage, INavigationAware, IDestructible, IPageNavigationEventRecordable
     {
-        public NavigationPageEmptyMock()
+        public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
+        public NavigationPageEmptyMock() : this(null)
         {
-            
         }
 
-        public NavigationPageEmptyMock(PageNavigationEventRecorder recorder) : base(recorder)
+        public NavigationPageEmptyMock(PageNavigationEventRecorder recorder)
         {
+            ViewModelLocator.SetAutowireViewModel(this, true);
 
+            PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
+
+        public void Destroy()
+        {
+            PageNavigationEventRecorder.Record(this, PageNavigationEvent.Destroy);
+        }
+
+        public void OnNavigatedFrom(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedFrom);
+        }
+
+        public void OnNavigatedTo(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedTo);
+        }
+
+        public void OnNavigatingTo(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatingTo);
+        }
+
     }
 
     public class NavigationPageWithStackMock : NavigationPage

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
@@ -1,10 +1,11 @@
-﻿using Prism.Mvvm;
+﻿using System.Threading.Tasks;
+using Prism.Mvvm;
 using Prism.Navigation;
 using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class NavigationPageMock : NavigationPage, IDestructible, IPageNavigationEventRecordable
+    public class NavigationPageMock : NavigationPage, INavigationAware, IDestructible, IPageNavigationEventRecordable
     {
         public bool DestroyCalled { get; private set; } = false;
         public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
@@ -21,18 +22,46 @@ namespace Prism.Forms.Tests.Mocks.Views
             ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
 
+        public NavigationPageMock(PageNavigationEventRecorder recorder, Page page) : base(page)
+        {
+            ViewModelLocator.SetAutowireViewModel(this, true);
+
+            PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
+        }
+
         public void Destroy()
         {
             DestroyCalled = true;
             PageNavigationEventRecorder.Record(this, PageNavigationEvent.Destroy);
         }
+
+        public void OnNavigatedFrom(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedFrom);
+        }
+
+        public void OnNavigatedTo(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedTo);
+        }
+
+        public void OnNavigatingTo(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatingTo);
+        }
     }
 
-    public class NavigationPageEmptyMock : NavigationPage
+    public class NavigationPageEmptyMock : NavigationPageMock
     {
-        public NavigationPageEmptyMock() : base()
+        public NavigationPageEmptyMock()
         {
             
+        }
+
+        public NavigationPageEmptyMock(PageNavigationEventRecorder recorder) : base(recorder)
+        {
+
         }
     }
 

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/OtherContentPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/OtherContentPageMock.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Prism.Mvvm;
+
+namespace Prism.Forms.Tests.Mocks.Views
+{
+    public class OtherContentPageMock : ContentPageMock
+    {
+        public OtherContentPageMock() : this(null)
+        {
+        }
+
+        public OtherContentPageMock(PageNavigationEventRecorder recorder) : base(recorder)
+        {
+            ViewModelLocator.SetAutowireViewModel(this, true);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/OtherContentPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/OtherContentPageMock.cs
@@ -4,18 +4,44 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Prism.Mvvm;
+using Prism.Navigation;
+using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class OtherContentPageMock : ContentPageMock
+    public class OtherContentPageMock : ContentPage, INavigationAware, IDestructible, IPageNavigationEventRecordable
     {
         public OtherContentPageMock() : this(null)
         {
         }
 
-        public OtherContentPageMock(PageNavigationEventRecorder recorder) : base(recorder)
+        public OtherContentPageMock(PageNavigationEventRecorder recorder)
         {
             ViewModelLocator.SetAutowireViewModel(this, true);
+            PageNavigationEventRecorder = recorder;
+            ((IPageNavigationEventRecordable)BindingContext).PageNavigationEventRecorder = recorder;
         }
+
+        public void OnNavigatedFrom(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedFrom);
+        }
+
+        public void OnNavigatedTo(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedTo);
+        }
+
+        public void OnNavigatingTo(NavigationParameters parameters)
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatingTo);
+        }
+
+        public void Destroy()
+        {
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.Destroy);
+        }
+
+        public PageNavigationEventRecorder PageNavigationEventRecorder { get; set; }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/PageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/PageMock.cs
@@ -1,9 +1,18 @@
-﻿using Prism.Navigation;
+﻿using Prism.Mvvm;
+using Prism.Navigation;
 using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class PageMock : Page
+    public class PageMock : ContentPageMock
     {
+        public PageMock() : this(null)
+        {
+        }
+
+        public PageMock(PageNavigationEventRecorder recorder) : base(recorder)
+        {
+            ViewModelLocator.SetAutowireViewModel(this, true);
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/PageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/PageMock.cs
@@ -4,15 +4,7 @@ using Xamarin.Forms;
 
 namespace Prism.Forms.Tests.Mocks.Views
 {
-    public class PageMock : ContentPageMock
+    public class PageMock : Page
     {
-        public PageMock() : this(null)
-        {
-        }
-
-        public PageMock(PageNavigationEventRecorder recorder) : base(recorder)
-        {
-            ViewModelLocator.SetAutowireViewModel(this, true);
-        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -157,6 +157,105 @@ namespace Prism.Forms.Tests.Navigation
             Assert.Equal(0, applicationProvider.MainPage.Navigation.NavigationStack.Count);
         }
 
+        [Fact]
+        public async Task NavigateAsync_Replace_RootPage_ByAbsoluteName()
+        {
+            var recorder = new PageNavigationEventRecorder(); ;
+            var rootPage = new ContentPageMock(recorder);
+            var rootPageViewModel = (ViewModelBase)rootPage.BindingContext;
+            var applicationProvider = new ApplicationProviderMock(rootPage);
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade, recorder);
+
+            await navigationService.NavigateAsync("/ContentPage");
+
+            var navigatedPage = applicationProvider.MainPage;
+            Assert.IsType(typeof(ContentPageMock), navigatedPage);
+            Assert.NotEqual(rootPage, navigatedPage);
+
+            var record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage.BindingContext, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPageViewModel, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage.BindingContext, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPageViewModel, record.Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
+
+            Assert.True(recorder.IsEmpty);
+        }
+
+        [Fact]
+        public async Task NavigateAsync_Replace_RootPage_ByAbsoluteUri()
+        {
+            var recorder = new PageNavigationEventRecorder(); ;
+            var rootPage = new ContentPageMock(recorder);
+            var rootPageViewModel = (ViewModelBase)rootPage.BindingContext;
+            var applicationProvider = new ApplicationProviderMock(rootPage);
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade, recorder);
+
+            await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage"));
+
+            var navigatedPage = applicationProvider.MainPage;
+            Assert.IsType(typeof(ContentPageMock), navigatedPage);
+            Assert.NotEqual(rootPage, navigatedPage);
+
+            var record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage.BindingContext, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPageViewModel, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(navigatedPage.BindingContext, record.Sender);
+            Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPage, record.Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
+
+            record = recorder.TakeFirst();
+            Assert.Equal(rootPageViewModel, record.Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
+
+            Assert.True(recorder.IsEmpty);
+        }
 
         /// <summary>
         /// This test case does not depend on the Page of the transition destination. Therefore, the name is OtherPage.
@@ -192,61 +291,6 @@ namespace Prism.Forms.Tests.Navigation
             Assert.Equal(1, rootPage.Navigation.ModalStack.Count);
             Assert.Equal(0, rootPage.Navigation.NavigationStack.Count);
             Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.ModalStack[0]);
-        }
-
-        /// <summary>
-        /// This test case does not depend on the Page of the transition destination. Therefore, the name is OtherPage.
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task NavigateAsync_From_RootPage_ToOtherPagee_ByAbsoluteUri()
-        {
-            // Set up top page.
-            var recorder = new PageNavigationEventRecorder(); ;
-            var rootPage = new ContentPageMock(recorder);
-            var rootPageViewModel = (ViewModelBase)rootPage.BindingContext;
-            var applicationProvider = new ApplicationProviderMock(rootPage);
-            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade, recorder);
-
-            await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
-
-            var navigatedPage = applicationProvider.MainPage;
-            Assert.IsType(typeof(ContentPageMock), navigatedPage);
-            Assert.NotEqual(rootPage, _applicationProvider.MainPage);
-
-            var record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage.BindingContext, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPage, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPageViewModel, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage.BindingContext, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPage, record.Sender);
-            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPageViewModel, record.Sender);
-            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
-
-            Assert.True(recorder.IsEmpty);
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -659,7 +659,48 @@ namespace Prism.Forms.Tests.Navigation
 
             await navigationService.NavigateAsync("MasterDetailPage-Empty/ContentPage");
 
+            Assert.Equal(1, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, rootPage.Navigation.NavigationStack.Count);
+
             var masterDetail = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
+            Assert.NotNull(masterDetail);
+            Assert.NotNull(masterDetail.Detail);
+            Assert.IsType(typeof(ContentPageMock), masterDetail.Detail);
+        }
+
+        [Fact]
+        public async void DeepNavigate_ToEmptyMasterDetailPage_ToContentPage_UseModalNavigation()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("MasterDetailPage-Empty/ContentPage", useModalNavigation: true);
+
+            Assert.Equal(1, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, rootPage.Navigation.NavigationStack.Count);
+            var masterDetail = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
+            Assert.NotNull(masterDetail);
+            Assert.NotNull(masterDetail.Detail);
+            Assert.IsType(typeof(ContentPageMock), masterDetail.Detail);
+        }
+
+        [Fact]
+        public async void DeepNavigate_ToEmptyMasterDetailPage_ToContentPage_NotUseModalNavigation()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPageMock();
+            var navigationPage = new NavigationPage(rootPage);
+            ((IPageAware)navigationService).Page = rootPage;
+
+            Assert.Equal(1, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPageMock>(navigationPage.CurrentPage);
+
+            await navigationService.NavigateAsync("MasterDetailPage-Empty/ContentPage", useModalNavigation: false);
+
+            Assert.Equal(0, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(2, rootPage.Navigation.NavigationStack.Count);
+            var masterDetail = rootPage.Navigation.NavigationStack[1] as MasterDetailPageEmptyMock;
             Assert.NotNull(masterDetail);
             Assert.NotNull(masterDetail.Detail);
             Assert.IsType(typeof(ContentPageMock), masterDetail.Detail);

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -5,6 +5,7 @@ using Prism.Forms.Tests.Mocks.Views;
 using Prism.Logging;
 using Prism.Navigation;
 using System;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 using Xunit;
 
@@ -64,98 +65,141 @@ namespace Prism.Forms.Tests.Navigation
             });
         }
 
+        /// <summary>
+        /// It is a test of navigation to RootPage. The Type of Page does not matter.
+        /// </summary>
+        /// <returns></returns>
         [Fact]
-        public async void Navigate_ToContentPage_ByName()
+        public async Task NavigateAsync_To_RootPage()
         {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var rootPage = new Xamarin.Forms.ContentPage();
-            ((IPageAware)navigationService).Page = rootPage;
+            var applicationProvider = new ApplicationProviderMock(null);
+            var recorder = new PageNavigationEventRecorder();
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade, recorder);
 
             await navigationService.NavigateAsync("ContentPage");
 
-            Assert.True(rootPage.Navigation.ModalStack.Count == 1);
-            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.ModalStack[0]);
-        }
+            var mainPage = applicationProvider.MainPage;
 
-        [Fact]
-        public async void NavigateAsync_ToContentPage_ByName()
-        {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var rootPage = new Xamarin.Forms.NavigationPage();
-            ((IPageAware)navigationService).Page = rootPage;
-
-            await navigationService.NavigateAsync("ContentPage", useModalNavigation: false);
-
-            Assert.True(rootPage.Navigation.NavigationStack.Count == 1);
-            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.NavigationStack[0]);
-        }
-
-        [Fact]
-        public async void Navigate_ToContentPage_ByRelativeUri()
-        {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var rootPage = new Xamarin.Forms.ContentPage();
-            ((IPageAware)navigationService).Page = rootPage;
-
-            await navigationService.NavigateAsync(new Uri("ContentPage", UriKind.Relative));
-
-            Assert.True(rootPage.Navigation.ModalStack.Count == 1);
-            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.ModalStack[0]);
-        }
-
-        [Fact]
-        public async void Navigate_ToContentPage_ByAbsoluteName()
-        {
-            // Set up top page.
-            var recorder = new PageNavigationEventRecorder();
-            var rootPage = new ContentPageMock(recorder);
-            var rootPageViewModel = (ViewModelBase)rootPage.BindingContext;
-            var applicationProvider = new ApplicationProviderMock(rootPage);
-            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade, recorder);
-
-            await navigationService.NavigateAsync("/ContentPage");
-
-            var navigatedPage = applicationProvider.MainPage;
-            Assert.IsType(typeof(ContentPageMock), navigatedPage);
-            Assert.NotEqual(rootPage, _applicationProvider.MainPage);
+            Assert.IsType<ContentPageMock>(mainPage);
+            Assert.Equal(0, mainPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, mainPage.Navigation.NavigationStack.Count);
 
             var record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage, record.Sender);
+            Assert.Equal(mainPage, record.Sender);
             Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
 
             record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage.BindingContext, record.Sender);
+            Assert.Equal(mainPage.BindingContext, record.Sender);
             Assert.Equal(PageNavigationEvent.OnNavigatingTo, record.Event);
 
             record = recorder.TakeFirst();
-            Assert.Equal(rootPage, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPageViewModel, record.Sender);
-            Assert.Equal(PageNavigationEvent.OnNavigatedFrom, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage, record.Sender);
+            Assert.Equal(mainPage, record.Sender);
             Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
 
             record = recorder.TakeFirst();
-            Assert.Equal(navigatedPage.BindingContext, record.Sender);
+            Assert.Equal(mainPage.BindingContext, record.Sender);
             Assert.Equal(PageNavigationEvent.OnNavigatedTo, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPage, record.Sender);
-            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
-
-            record = recorder.TakeFirst();
-            Assert.Equal(rootPageViewModel, record.Sender);
-            Assert.Equal(PageNavigationEvent.Destroy, record.Event);
 
             Assert.True(recorder.IsEmpty);
         }
 
+        /// <summary>
+        /// It is a test of navigation to RootPage. The Type of Page does not matter.
+        /// </summary>
+        /// <returns></returns>
         [Fact]
-        public async void Navigate_ToContentPage_ByAbsoluteUri()
+        public async Task NavigateAsync_To_RootPage_ByAbsoluteName()
+        {
+            var applicationProvider = new ApplicationProviderMock(null);
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade);
+
+            await navigationService.NavigateAsync("/ContentPage");
+
+            var mainPage = applicationProvider.MainPage;
+
+            Assert.IsType<ContentPageMock>(mainPage);
+            Assert.Equal(0, mainPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, mainPage.Navigation.NavigationStack.Count);
+        }
+
+        /// <summary>
+        /// It is a test of navigation to RootPage. The Type of Page does not matter.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task NavigateAsync_To_RootPage_ByRelativeUri()
+        {
+            var applicationProvider = new ApplicationProviderMock(null);
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade);
+
+            await navigationService.NavigateAsync(new Uri("ContentPage", UriKind.Relative));
+
+            var mainPage = applicationProvider.MainPage;
+
+            Assert.IsType<ContentPageMock>(mainPage);
+            Assert.Equal(0, mainPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, mainPage.Navigation.NavigationStack.Count);
+        }
+        /// <summary>
+        /// It is a test of navigation to RootPage. The Type of Page does not matter.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task NavigateAsync_To_RootPage_ByAbsoluteUri()
+        {
+            var applicationProvider = new ApplicationProviderMock(null);
+            var navigationService = new PageNavigationServiceMock(_container, applicationProvider, _loggerFacade);
+
+            await navigationService.NavigateAsync(new Uri("http://localhost/ContentPage", UriKind.Absolute));
+
+            Assert.IsType<ContentPageMock>(applicationProvider.MainPage);
+            Assert.Equal(0, applicationProvider.MainPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, applicationProvider.MainPage.Navigation.NavigationStack.Count);
+        }
+
+
+        /// <summary>
+        /// This test case does not depend on the Page of the transition destination. Therefore, the name is OtherPage.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task NavigateAsync_From_RootPage_ToOtherPage_ByRelativeName()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage");
+
+            Assert.Equal(1, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.ModalStack[0]);
+        }
+
+        /// <summary>
+        /// This test case does not depend on the Page of the transition destination. Therefore, the name is OtherPage.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task NavigateAsync_From_RootPage_ToOtherPage_ByRelativeUri()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync(new Uri("ContentPage", UriKind.Relative));
+
+            Assert.Equal(1, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(0, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.ModalStack[0]);
+        }
+
+        /// <summary>
+        /// This test case does not depend on the Page of the transition destination. Therefore, the name is OtherPage.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task NavigateAsync_From_RootPage_ToOtherPagee_ByAbsoluteUri()
         {
             // Set up top page.
             var recorder = new PageNavigationEventRecorder(); ;
@@ -204,6 +248,58 @@ namespace Prism.Forms.Tests.Navigation
 
             Assert.True(recorder.IsEmpty);
         }
+
+        /// <summary>
+        /// This test case does not depend on the Page of the transition destination. Therefore, the name is OtherPage.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task NavigateAsync_From_NavigationPage_ToOtherPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new NavigationPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage");
+
+            Assert.Equal(0, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(1, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType(typeof(ContentPageMock), rootPage.Navigation.NavigationStack[0]);
+        }
+
+
+        [Fact]
+        public async Task NavigateAsync_From_NavigationPage_ToOtherPage_ByModal()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage();
+            var navigationPage = new NavigationPage(rootPage);
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage", useModalNavigation: true);
+
+            Assert.Equal(1, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(1, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPage>(rootPage.Navigation.NavigationStack[0]);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.ModalStack[0]);
+        }
+
+        [Fact]
+        public async Task NavigateAsync_From_NavigationPage_ToOtherPage_ByNotModal()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage();
+            var navigationPage = new NavigationPage(rootPage);
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage", useModalNavigation: false);
+
+            Assert.Equal(0, rootPage.Navigation.ModalStack.Count);
+            Assert.Equal(2, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPage>(rootPage.Navigation.NavigationStack[0]);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.NavigationStack[1]);
+        }
+
 
         [Fact]
         public async void Navigate_ToContentPage_ByName_WithNavigationParameters()

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -52,6 +52,8 @@
     <Compile Include="Mocks\PageNavigationRecord.cs" />
     <Compile Include="Mocks\PageNavigationEventRecorder.cs" />
     <Compile Include="Mocks\ViewModels\NavigationPageEmptyMockViewModel.cs" />
+    <Compile Include="Mocks\ViewModels\OtherContentPageMockViewModel.cs" />
+    <Compile Include="Mocks\Views\OtherContentPageMock.cs" />
     <Compile Include="Navigation\PageNavigationInfoFixture.cs" />
     <Compile Include="Navigation\PageNavigationRegistryFixture.cs" />
     <Compile Include="Behaviors\EventToCommandBehaviorFixture.cs" />

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Mocks\PageNavigationEvent.cs" />
     <Compile Include="Mocks\PageNavigationRecord.cs" />
     <Compile Include="Mocks\PageNavigationEventRecorder.cs" />
+    <Compile Include="Mocks\ViewModels\NavigationPageEmptyMockViewModel.cs" />
     <Compile Include="Navigation\PageNavigationInfoFixture.cs" />
     <Compile Include="Navigation\PageNavigationRegistryFixture.cs" />
     <Compile Include="Behaviors\EventToCommandBehaviorFixture.cs" />
@@ -125,7 +126,6 @@
       <Name>Prism.Forms</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -26,6 +26,16 @@ namespace Prism.Common
             }
         }
 
+        public static T GetFromViewOrViewModel<T>(object view) where T : class
+        {
+            T viewAsT = view as T;
+            if (viewAsT != null)
+                return viewAsT;
+
+            var element = view as BindableObject;
+            return element?.BindingContext as T;
+        }
+
         public static void DestroyPage(Page page)
         {
             try

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -299,18 +299,6 @@ namespace Prism.Navigation
         {
             bool isPresented = GetMasterDetailPageIsPresented(currentPage);
 
-            if (useModalNavigation.HasValue && useModalNavigation.Value)
-            {
-                var nextPage = CreatePageFromSegment(nextSegment);
-                await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
-                await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
-                {
-                    currentPage.IsPresented = isPresented;
-                    await DoPush(currentPage, nextPage, true, animated);
-                });
-                return;
-            }
-
             var detail = currentPage.Detail;
             if (detail == null)
             {
@@ -320,6 +308,18 @@ namespace Prism.Navigation
                 {
                     currentPage.IsPresented = isPresented;
                     currentPage.Detail = newDetail;
+                });
+                return;
+            }
+
+            if (useModalNavigation.HasValue && useModalNavigation.Value)
+            {
+                var nextPage = CreatePageFromSegment(nextSegment);
+                await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
+                await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
+                {
+                    currentPage.IsPresented = isPresented;
+                    await DoPush(currentPage, nextPage, true, animated);
                 });
                 return;
             }


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes issue #1044 #1045 #1046  .

Changes proposed in this pull request:
- #1044 When Detail of MasterDetailPage is null, the value is set to Detail.
https://github.com/PrismLibrary/Prism/commit/892c6cc6f72c89067004aaf2b5f68fb0d8dc3b86

- #1045 When calling NavigateAsync with NavigationPage, old page's Destroy on the stack is not called
https://github.com/PrismLibrary/Prism/commit/70c5ecd002b2efbd58cf4922ae8cbd1053b8702d

- #1046 When calling DeepLink from Navigation Stack, the second page becomes Modal navigation
not started yet. I will do it.