### PR TITLE
make it easier to access the container

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -23,6 +23,12 @@ namespace Prism.Autofac
     public abstract class PrismApplication : PrismApplicationBase<IContainer>
     {
         /// <summary>
+        /// Gets the current Prism Application
+        /// </summary>
+        public static new PrismApplication Current => 
+            Application.Current as PrismApplication;
+
+        /// <summary>
         /// Service key used when registering the <see cref="AutofacPageNavigationService"/> with the container
         /// </summary>
         const string _navigationServiceName = "AutofacPageNavigationService";

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -22,6 +22,12 @@ namespace Prism.DryIoc
     public abstract class PrismApplication : PrismApplicationBase<IContainer>
     {
         /// <summary>
+        /// Gets the current Prism Application
+        /// </summary>
+        public static new PrismApplication Current => 
+            Application.Current as PrismApplication;
+
+        /// <summary>
         /// Service key used when registering the <see cref="DryIocPageNavigationService"/> with the container
         /// </summary>
         private const string _navigationServiceKey = "DryIocPageNavigationService";

--- a/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
@@ -19,6 +19,12 @@ namespace Prism.Ninject
 {
     public abstract class PrismApplication : PrismApplicationBase<IKernel>
     {
+        /// <summary>
+        /// Gets the current Prism Application
+        /// </summary>
+        public static new PrismApplication Current => 
+            Application.Current as PrismApplication;
+
         const string _navigationServiceName = "NinjectPageNavigationService";
 
         public PrismApplication(IPlatformInitializer initializer = null) : base(initializer) { }

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -17,6 +17,12 @@ namespace Prism.Unity
 {
     public abstract class PrismApplication : PrismApplicationBase<IUnityContainer>
     {
+        /// <summary>
+        /// Gets the current Prism Application
+        /// </summary>
+        public static new PrismApplication Current => 
+            Application.Current as PrismApplication;
+
         const string _navigationServiceName = "UnityPageNavigationService";
 
         public PrismApplication(IPlatformInitializer initializer = null) : base (initializer) { }


### PR DESCRIPTION
Overrides the Xamarin Forms Current Property to provide the `PrismApplication`. This will make it easier when needing to reference the Container in situations where it might not otherwise be available such as in View Renderer's, Converters, and other View related code which would typically rely on the Xamarin Forms `DependencyService`. 