### PR TITLE
Updated nuget.exe URL to be https://.

### DIFF
--- a/Source/nuspecs/nuget.ps1
+++ b/Source/nuspecs/nuget.ps1
@@ -91,7 +91,7 @@ if(Test-Path ./Source)
 if (!(Test-Path $nugetFileName))
 {
     Write-Host 'Downloading Nuget.exe ...'
-    Invoke-WebRequest -Uri "http://nuget.org/nuget.exe" -OutFile $nugetFileName
+    Invoke-WebRequest -Uri "https://nuget.org/nuget.exe" -OutFile $nugetFileName
 }
 
 $projectsJson = Get-Content -Raw -Path projects.json | ConvertFrom-Json


### PR DESCRIPTION
The original URL was http://nuget.org/nuget.exe. This change modifies that to route over a secure transport layer (HTTPS), which is especially important since in the next line, the .exe that's downloaded gets executed.

Please take a moment to fill out the following:

Fixes issue #1077. 

Changes proposed in this pull request:
-  Update the URL to be https://... instead of http://...