### PR TITLE
Navigation fixes

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -17,6 +17,8 @@ namespace HelloWorld
         protected override void OnInitialized()
         {
             NavigationService.NavigateAsync("MyMasterDetail/MyNavigationPage/MainPage", animated: false);
+            //44115 
+            //NavigationService.NavigateAsync("MyNavigationPage/MainPage/ViewA/ViewB", animated: false);
         }
 
         protected override void RegisterTypes()

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
@@ -5,15 +5,15 @@
               prism:ViewModelLocator.AutowireViewModel="True"
              x:Class="HelloWorld.Views.MyMasterDetail">
 
-  <MasterDetailPage.Master>
-    <ContentPage Title="Default">
-      <StackLayout>
-        <Button Text="MainPage" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/MainPage" />
-        <Button Text="ViewA" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewA" />
-        <Button Text="ViewB" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewB" />
-        <Button Text="ViewC" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewC" />
-      </StackLayout>
-    </ContentPage>
-  </MasterDetailPage.Master>
-  
+    <MasterDetailPage.Master>
+        <ContentPage Title="Default">
+            <StackLayout>
+                <Button Text="MainPage" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/MainPage" />
+                <Button Text="56593" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewA" />
+                <Button Text="45978" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewA/ViewB/ViewC" />
+                <Button Text="ViewC" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewC" />
+            </StackLayout>
+        </ContentPage>
+    </MasterDetailPage.Master>
+
 </MasterDetailPage>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyNavigationPage.xaml
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyNavigationPage.xaml
@@ -4,8 +4,4 @@
               xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
               prism:ViewModelLocator.AutowireViewModel="True"
              x:Class="HelloWorld.Views.MyNavigationPage">
-  <StackLayout>
-    <Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
-    <Button Command="{Binding NavigateCommand}" Text="Navigate" />
-  </StackLayout>
 </NavigationPage>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -72,7 +72,7 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.NavigateAsync("ViewB");
+            await _navigationService.NavigateAsync("ViewC/ViewB", useModalNavigation: false);
             CanNavigate = true;
         }
 

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ContentPageMock1ViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/ViewModels/ContentPageMock1ViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Forms.Tests.Mocks.ViewModels
+{
+    public class ContentPageMock1ViewModel : ContentPageMockViewModel
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/ContentPageMock1.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/ContentPageMock1.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Forms.Tests.Mocks.Views
+{
+    public class ContentPageMock1 : ContentPageMock
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -571,6 +571,21 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
+        public async void DeepNavigate_To_EmptyNavigationPage_ToContentPage_toContentPage_toContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("NavigationPage-Empty/ContentPage/ContentPage/ContentPage1");
+
+            var navPage = rootPage.Navigation.ModalStack[0];
+            Assert.True(navPage.Navigation.NavigationStack.Count == 3);
+            var lastPage = navPage.Navigation.NavigationStack.LastOrDefault();
+            Assert.True(lastPage.GetType() == typeof(ContentPageMock1));
+        }
+
+        [Fact]
         public async void DeepNavigate_From_ContentPage_To_NavigationPageWithNavigationStack_ToContentPage()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
@@ -584,7 +599,7 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void DeepNavigate_From_ContentPage_To_NavigationPageWithNavigationStack_ToContentPagek_ToContentPage()
+        public async void DeepNavigate_From_ContentPage_To_NavigationPageWithNavigationStack_ToContentPage_ToContentPage()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.ContentPage();

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -24,7 +24,9 @@ namespace Prism.Forms.Tests.Navigation
             _container.Register("PageMock", typeof(PageMock));
 
             _container.Register("ContentPage", typeof(ContentPageMock));
+            _container.Register("ContentPage1", typeof(ContentPageMock1));
             _container.Register(typeof(ContentPageMockViewModel).FullName, typeof(ContentPageMock));
+            _container.Register(typeof(ContentPageMock1ViewModel).FullName, typeof(ContentPageMock1));
 
             _container.Register("NavigationPage", typeof(NavigationPageMock));
             _container.Register("NavigationPage-Empty", typeof(NavigationPageEmptyMock));
@@ -548,6 +550,26 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(navPage.Navigation.NavigationStack.Count == 1);
         }
 
+
+        [Fact]
+        public async void DeepNavigate_From_ContentPage_To_EmptyNavigationPage_ToContentPage_toContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage/NavigationPage-Empty/ContentPage/ContentPage1");
+
+            var navPage = rootPage.Navigation.ModalStack[0].Navigation.ModalStack[0];
+
+            Assert.True(navPage.Navigation.NavigationStack.Count == 2);
+            var lastPage = navPage.Navigation.NavigationStack.LastOrDefault();
+            Assert.True(lastPage.GetType() == typeof(ContentPageMock1));
+            await navPage.Navigation.PopAsync();
+            lastPage = navPage.Navigation.NavigationStack.LastOrDefault();
+            Assert.True(lastPage.GetType() == typeof(ContentPageMock));
+        }
+
         [Fact]
         public async void DeepNavigate_From_ContentPage_To_NavigationPageWithNavigationStack_ToContentPage()
         {
@@ -559,6 +581,24 @@ namespace Prism.Forms.Tests.Navigation
 
             var navPage = rootPage.Navigation.ModalStack[0].Navigation.ModalStack[0];
             Assert.True(navPage.Navigation.NavigationStack.Count == 1);
+        }
+
+        [Fact]
+        public async void DeepNavigate_From_ContentPage_To_NavigationPageWithNavigationStack_ToContentPagek_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("ContentPage/NavigationPageWithStack/ContentPage/ContentPage1");
+
+            var navPage = rootPage.Navigation.ModalStack[0].Navigation.ModalStack[0];
+            Assert.True(navPage.Navigation.NavigationStack.Count == 2);
+            var lastPage = navPage.Navigation.NavigationStack.LastOrDefault();
+            Assert.True(lastPage.GetType() == typeof(ContentPageMock1));
+            await navPage.Navigation.PopAsync();
+            lastPage = navPage.Navigation.NavigationStack.LastOrDefault();
+            Assert.True(lastPage.GetType() == typeof(ContentPageMock));
         }
 
         [Fact]

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -934,6 +934,43 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
+        public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToTabbedPage_ToPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("MasterDetailPage-Empty/NavigationPage/TabbedPage/PageMock");
+
+            var mdpPage = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
+            var navPage = mdpPage.Detail as NavigationPageMock;
+            var tabbedPage = navPage.Navigation.NavigationStack[0] as TabbedPageMock;
+            Assert.NotNull(mdpPage);
+            Assert.NotNull(navPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType(typeof(PageMock), tabbedPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToContentPage_ToTabbedPage_ToPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("MasterDetailPage-Empty/NavigationPage/ContentPage/TabbedPage/PageMock");
+
+            var mdpPage = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
+            var navPage = mdpPage.Detail as NavigationPageMock;
+            var contentPage = navPage.Navigation.NavigationStack[0] as ContentPageMock;
+            var tabbedPage = navPage.Navigation.NavigationStack[1] as TabbedPageMock;
+            Assert.NotNull(mdpPage);
+            Assert.NotNull(navPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType(typeof(PageMock), tabbedPage.CurrentPage);
+        }
+
+        [Fact]
         public async void DeepNavigate_ToCarouselPage_ToContentPage()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);


### PR DESCRIPTION
Opening this PR for comments and to  get Prism to work better with Xamarin.Forms

Fixes issues #765 , #1046 , #1054 

Addressed bugs opened on XF repo:

- https://bugzilla.xamarin.com/show_bug.cgi?id=44115
- https://bugzilla.xamarin.com/show_bug.cgi?id=45978
- https://bugzilla.xamarin.com/show_bug.cgi?id=56593

Changes proposed in this pull request:
-  This PR changes the way the `PageNavigationService `is implemented to fit the Xamarin.Forms navigation more properly, there are some assumptions made in this class about the `NavigationProxy `that XF exposes on all Page types. 

If we have a `NavigationPage ` XF assumes the pages to be pushed are ContentPages, some users may use other type like MDP, this is not recomended, MDP should only be used as root, as to push a tabbed page it Works but we don't recomend, we always recommend navigationpages to only have ContentPages.

MDP, Carousel, and Tabbed should be used as root of the App, and a navigationpage should be a children not the other way around. 