### PR TITLE
Fixed the behavior when null property was specified in EventArgsParameterPath of EventToCommandBehavior

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Behaviors/EventToCommandBehaviorFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Behaviors/EventToCommandBehaviorFixture.cs
@@ -172,6 +172,31 @@ namespace Prism.Forms.Tests.Behaviors
             Assert.True(executedCommand);
         }
 
+
+        [Fact]
+        public void Command_EventArgsParameterPath_Nested_When_ChildIsNull()
+        {
+            dynamic item = new
+            {
+                AProperty = "Value"
+            };
+            var executedCommand = false;
+            var behavior = new EventToCommandBehaviorMock
+            {
+                EventName = "ItemTapped",
+                EventArgsParameterPath = "Item.AProperty",
+                Command = new DelegateCommand<object>(o =>
+                {
+                    executedCommand = true;
+                    Assert.Null(o);
+                })
+            };
+            var listView = new ListView();
+            listView.Behaviors.Add(behavior);
+            behavior.RaiseEvent(listView, new ItemTappedEventArgs(listView, null));
+            Assert.True(executedCommand);
+        }
+
         [Fact]
         public void Command_CanExecute()
         {

--- a/Source/Xamarin/Prism.Forms.Tests/Behaviors/EventToCommandBehaviorFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Behaviors/EventToCommandBehaviorFixture.cs
@@ -176,10 +176,6 @@ namespace Prism.Forms.Tests.Behaviors
         [Fact]
         public void Command_EventArgsParameterPath_Nested_When_ChildIsNull()
         {
-            dynamic item = new
-            {
-                AProperty = "Value"
-            };
             var executedCommand = false;
             var behavior = new EventToCommandBehaviorMock
             {

--- a/Source/Xamarin/Prism.Forms/Behaviors/EventToCommandBehavior.cs
+++ b/Source/Xamarin/Prism.Forms/Behaviors/EventToCommandBehavior.cs
@@ -185,6 +185,10 @@ namespace Prism.Behaviors
                 {
                     var propInfo = propertyValue.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
                     propertyValue = propInfo.GetValue(propertyValue);
+                    if (propertyValue == null)
+                    {
+                        break;
+                    }
                 }
                 parameter = propertyValue;
             }


### PR DESCRIPTION
Fixes issue # #1085.

Changes proposed in this pull request:
- Fix to terminate the search if null occurs while searching for nested properties