### PR TITLE
Added method to clear all errors on ErrorsContainer

### DIFF
--- a/Source/Prism/Mvvm/ErrorsContainer.cs
+++ b/Source/Prism/Mvvm/ErrorsContainer.cs
@@ -66,6 +66,17 @@ namespace Prism.Mvvm
         }
 
         /// <summary>
+        /// Clears all errors.
+        /// </summary>
+        public void ClearErrors()
+        {
+            foreach (var key in this.validationResults.Keys.ToArray())
+            {
+                ClearErrors(key);
+            }
+        }
+
+        /// <summary>
         /// Clears the errors for the property indicated by the property expression.
         /// </summary>
         /// <typeparam name="TProperty">The property type.</typeparam>


### PR DESCRIPTION
Fixes issue #: n/a

Changes proposed in this pull request:
- Adds a method to clear all errors on ErrorsContainer. This is useful for resetting a form to default state. Without this change, the developer is forced to create a derived class to access the protected member containing the keys.