### PR TITLE
Feature/remove unnecessary string handling in logging

### DIFF
--- a/Source/Prism/Logging/DebugLogger.cs
+++ b/Source/Prism/Logging/DebugLogger.cs
@@ -5,6 +5,7 @@ using Prism.Properties;
 
 namespace Prism.Logging
 {
+#if DEBUG
     /// <summary>
     /// Implementation of <see cref="ILoggerFacade"/> that logs into a message into the Debug.Listeners collection.
     /// </summary>
@@ -24,4 +25,5 @@ namespace Prism.Logging
             Debug.WriteLine(messageToLog);
         }
     }
+#endif
 }

--- a/Source/Prism/Logging/DebugLogger.cs
+++ b/Source/Prism/Logging/DebugLogger.cs
@@ -3,9 +3,11 @@ using System.Diagnostics;
 using System.Globalization;
 using Prism.Properties;
 
+// Define DEBUG symbol to enable Debug.WriteLine to work even when Prism is compiled in Release-mode for Nuget-feed.
+#define DEBUG
+
 namespace Prism.Logging
 {
-#if DEBUG
     /// <summary>
     /// Implementation of <see cref="ILoggerFacade"/> that logs into a message into the Debug.Listeners collection.
     /// </summary>
@@ -25,5 +27,4 @@ namespace Prism.Logging
             Debug.WriteLine(messageToLog);
         }
     }
-#endif
 }

--- a/Source/Windows10/Prism.Windows/PrismApplication.cs
+++ b/Source/Windows10/Prism.Windows/PrismApplication.cs
@@ -142,7 +142,11 @@ namespace Prism.Windows
         /// </remarks>
         protected virtual ILoggerFacade CreateLogger()
         {
+#if DEBUG        
             return new DebugLogger();
+#else
+            return new EmptyLogger();
+#endif            
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -87,7 +87,11 @@ namespace Prism
         /// </remarks>
         protected virtual ILoggerFacade CreateLogger()
         {
+#if DEBUG        
             return new DebugLogger();
+#else
+            return new EmptyLogger();
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes issue #1089.

Changes proposed in this pull request:
- Use EmptyLogger as default in Release mode
- Add #define DEBUG to DebugLogger classto make it work in nuget release