### PR TITLE
Update 6-EventToCommandBehavior.md

### DIFF
--- a/docs/Xamarin-Forms/6-EventToCommandBehavior.md
+++ b/docs/Xamarin-Forms/6-EventToCommandBehavior.md
@@ -15,7 +15,7 @@ The `EventToCommandBehavior` expose the following properties
 
 First declare the namespace and assembly in where `EventToCommandBehavior` is declared and declare a XML-namespace.
 
-`x:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms"`
+`xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms"`
 
 ### CommandParameter
 


### PR DESCRIPTION
Fix xmlns typo

change the xmlns in this section : First declare the namespace and assembly in where EventToCommandBehavior is declared and declare a XML-namespace.
x:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms"

to : xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms"

- 