### PR TITLE
refactoring build props

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -10,7 +10,6 @@
     <PackageTags Condition=" '$(IsUwpProject)' == 'True' ">prism;mvvm;uwp;dependency injection;di</PackageTags>
     <PackageTags Condition=" '$(IsWpfProject)' == 'True' ">prism;mvvm;wpf;dependency injection;di</PackageTags>
     <PackageTags Condition=" '$(IsFormsProject)' == 'True' ">prism;mvvm;uwp;android;ios;xamarin;xamarin.forms;dependency injection;di</PackageTags>
-    <IsPackable>!$(IsTestProject)</IsPackable>
     <Authors>Brian Lagunas;Brian Noyes</Authors>
     <Owners>Brian Lagunas;Brian Noyes</Owners>
     <PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
@@ -26,6 +25,7 @@
     <IsUwpProject>$(MSBuildProjectName.Contains('Windows'))</IsUwpProject>
     <IsWpfProject>$(MSBuildProjectName.Contains('Wpf'))</IsWpfProject>
     <IsFormsProject>$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
+    <IsPackable>!$(IsTestProject)</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,4 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- Workaround for https://github.com/dotnet/sdk/pull/908 -->
   <Target Name="GetPackagingOutputs" />
+
+  <PropertyGroup>
+    <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <NeutralLanguage>en</NeutralLanguage>
+    <PackageTags Condition=" '$(IsCoreProject)' == 'True' ">prism;wpf;xamarin;uwp;uap;xaml</PackageTags>
+    <PackageTags Condition=" '$(IsUwpProject)' == 'True' ">prism;mvvm;uwp;dependency injection;di</PackageTags>
+    <PackageTags Condition=" '$(IsWpfProject)' == 'True' ">prism;mvvm;wpf;dependency injection;di</PackageTags>
+    <PackageTags Condition=" '$(IsFormsProject)' == 'True' ">prism;mvvm;uwp;android;ios;xamarin;xamarin.forms;dependency injection;di</PackageTags>
+    <IsPackable>!$(IsTestProject)</IsPackable>
+    <Authors>Brian Lagunas;Brian Noyes</Authors>
+    <Owners>Brian Lagunas;Brian Noyes</Owners>
+    <PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)/Artifacts</PackageOutputPath>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <IsCoreProject Condition=" '$(IsCoreProject)' == '' ">False</IsCoreProject>
+    <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
+    <IsUwpProject>$(MSBuildProjectName.Contains('Windows'))</IsUwpProject>
+    <IsWpfProject>$(MSBuildProjectName.Contains('Wpf'))</IsWpfProject>
+    <IsFormsProject>$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(DIContainer)' != '' And '$(IsFormsProject)' == 'true' ">
+    <Title>$(DIContainer) for Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>$(DIContainer) extensions for Prism for Xamarin.Forms.</Summary>-->
+    <Description>Use these extensions to build Xamarin.Forms applications with Prism and $(DIContainer).</Description>
+    <PackageTags>prism;xamarin;xamarin.forms;$(DIContainer.ToLower());dependency injection</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsCoreProject)' == 'True' Or '$(IsWpfProject)' == 'True' ">
+    <SignAssembly Condition=" '$(OS)' == 'Windows_NT' ">True</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\prism.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>False</DelaySign>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(IsTestProject)' == 'true' And '$(IsWpfProject)' == 'false' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -32,20 +32,6 @@
     <IsPackable>!$(IsTestProject)</IsPackable>
   </PropertyGroup>
 
-  <!-- AppVeyor -->
-  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
-    <!-- This will create CI builds as 7.0.0.1234-ci -->
-    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-    <VersionSuffix >ci</VersionSuffix>
-  </PropertyGroup>
-
-  <!-- VSTS -->
-  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
-    <!-- This will create CI builds as 7.0.0.1234-ci -->
-    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
-    <VersionSuffix >ci</VersionSuffix>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(DIContainer)' != '' And '$(IsFormsProject)' == 'True' ">
     <Title>$(DIContainer) for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -19,7 +19,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-    <PackageOutputPath>$(MSBuildThisFileDirectory)/Artifacts</PackageOutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <IsCoreProject Condition=" '$(IsCoreProject)' == '' ">False</IsCoreProject>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -18,7 +18,11 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
+    <IncludeSymbols>True</IncludeSymbols>
+    <IncludeSource>True</IncludeSource>
     <PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>
+    <PackageOutputPath Condition=" '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">$(BUILD_ARTIFACTSTAGINGDIRECTORY)</PackageOutputPath>
+    <VersionSuffix Condition=" '$(PREVIEW_NUMBER)' != '' ">pre$(PREVIEW_NUMBER)</VersionSuffix>
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <IsCoreProject Condition=" '$(IsCoreProject)' == '' ">False</IsCoreProject>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
@@ -28,9 +32,17 @@
     <IsPackable>!$(IsTestProject)</IsPackable>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
   <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
     <VersionSuffix >ci</VersionSuffix>
   </PropertyGroup>
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -48,12 +48,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsCoreProject)' == 'True' Or '$(IsWpfProject)' == 'True' ">
+    <!-- Disables Signing on Mac -->
     <SignAssembly Condition=" '$(OS)' == 'Windows_NT' ">True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\prism.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' And '$(IsWpfProject)' == 'false' ">
+  <ItemGroup Condition=" '$(IsTestProject)' == 'True' And '$(IsWpfProject)' == 'False' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -34,7 +34,7 @@
     <VersionSuffix >ci</VersionSuffix>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(DIContainer)' != '' And '$(IsFormsProject)' == 'true' ">
+  <PropertyGroup Condition=" '$(DIContainer)' != '' And '$(IsFormsProject)' == 'True' ">
     <Title>$(DIContainer) for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>$(DIContainer) extensions for Prism for Xamarin.Forms.</Summary>-->
@@ -47,17 +47,12 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsCoreProject)' == 'True' Or '$(IsWpfProject)' == 'True' ">
+  <PropertyGroup Condition=" '$(IsCoreProject)' == 'True' ">
+  <!--<PropertyGroup Condition=" '$(IsCoreProject)' == 'True' Or '$(IsWpfProject)' == 'True' ">-->
     <!-- Disables Signing on Mac -->
     <SignAssembly Condition=" '$(OS)' == 'Windows_NT' ">True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\prism.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(IsTestProject)' == 'True' And '$(IsWpfProject)' == 'False' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
-  </ItemGroup>
 
 </Project>

--- a/Source/Prism.Tests/Prism.Tests.csproj
+++ b/Source/Prism.Tests/Prism.Tests.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Prism\Prism.csproj" />
   </ItemGroup>
 

--- a/Source/Prism.Tests/Prism.Tests.csproj
+++ b/Source/Prism.Tests/Prism.Tests.csproj
@@ -10,6 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -12,6 +12,20 @@
     <IsCoreProject>True</IsCoreProject>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
   </ItemGroup>

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -1,47 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<AssemblyName>Prism</AssemblyName>
-		<PackageId>Prism.Core</PackageId>
-		<NeutralLanguage>en</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
-		<Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.</Description>
-		<PackageTags>prism;wpf;xamarin;mvvm;uwp;uap;xaml</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
-		<!-- This will create CI builds as 7.0.0.1234-ci -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-		<VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-		<SignAssembly>True</SignAssembly>
-		<AssemblyOriginatorKeyFile>..\prism.snk</AssemblyOriginatorKeyFile>
-		<DelaySign>False</DelaySign>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <AssemblyName>Prism</AssemblyName>
+    <PackageId>Prism.Core</PackageId>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
+    <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.</Description>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+    <IsCoreProject>True</IsCoreProject>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
-		<EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
+    <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -4,23 +4,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
-    <RootNamespace>Prism.Autofac.Forms.Tests</RootNamespace>
-    <AssemblyName>Prism.Autofac.Forms.Tests</AssemblyName>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Prism.Autofac.Forms\Prism.Autofac.Forms.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs" />
+    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -8,6 +8,20 @@
     <RootNamespace>Prism.Autofac</RootNamespace>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.0" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -1,43 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.1;</TargetFrameworks>
-		<AssemblyName>Prism.Autofac.Forms</AssemblyName>
-		<PackageId>Prism.Autofac.Forms</PackageId>
-		<Title>Autofac for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Autofac extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and Autofac.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;autofac;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
-		<!-- This will create CI builds as 7.0.0.1234-ci -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-		<VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.1</TargetFramework>
+    <DIContainer>Autofac</DIContainer>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.6.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Autofac" Version="4.6.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -5,6 +5,7 @@
     <DIContainer>Autofac</DIContainer>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+    <RootNamespace>Prism.Autofac</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -4,23 +4,16 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
-    <RootNamespace>Prism.DryIoc.Forms.Tests</RootNamespace>
-    <AssemblyName>Prism.DryIoc.Forms.Tests</AssemblyName>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Prism.DryIoc.Forms\Prism.DryIoc.Forms.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs" />
+    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -1,43 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<AssemblyName>Prism.DryIoc.Forms</AssemblyName>
-		<PackageId>Prism.DryIoc.Forms</PackageId>
-		<Title>DryIoc for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>DryIoc extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and DryIoc.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;dryioc;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
-		<!-- This will create CI builds as 7.0.0.1234-ci -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-		<VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <DIContainer>Autofac</DIContainer>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DryIoc.dll" Version="2.11.4" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="DryIoc.dll" Version="2.10.7" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <DIContainer>Autofac</DIContainer>
+    <RootNamespace>Prism.DryIoc</RootNamespace>
+    <DIContainer>DryIoc</DIContainer>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
   </PropertyGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -8,6 +8,20 @@
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="2.11.4" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -9,6 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -2,14 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -11,6 +11,20 @@
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="2.3.5.256-pre6" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -1,43 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<AssemblyName>Prism.Forms</AssemblyName>
-		<PackageId>Prism.Forms</PackageId>
-		<Title>Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
-		<Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform. Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;mvvm;uwp;ios;android;xaml</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
-		<!-- This will create CI builds as 7.0.0.1234-ci -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-		<VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <RootNamespace>Prism</RootNamespace>
+    <Title>Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
+    <Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a NetStandard Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform. Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Description>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.3.5.256-pre6" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="2.3.5.239-pre3" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\Prism\Prism.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Prism\Prism.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -1,45 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<!-- Targeting netstandard1.3 & netstandard1.5 to match Ninject -->
-		<TargetFrameworks>netstandard1.3;netstandard1.5;</TargetFrameworks>
-		<AssemblyName>Prism.Ninject.Forms</AssemblyName>
-		<PackageId>Prism.Ninject.Forms</PackageId>
-		<Title>Ninject for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Ninject extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and Ninject.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
-		<!-- This will create CI builds as 7.0.0.1234-ci -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-		<VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <!-- Hack to work with Visual Studio for Mac -->
+	<TargetFramework Condition=" '$(OS)' == 'Unix' ">netstandard1.3</TargetFramework>
+    <!-- Targeting netstandard1.3 & netstandard1.5 to match Ninject -->
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.3;netstandard1.5;</TargetFrameworks>
+    <DIContainer>Ninject</DIContainer>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;</TargetFrameworks>
+    <RootNamespace>Prism.Ninject</RootNamespace>
     <DIContainer>Ninject</DIContainer>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -2,10 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Hack to work with Visual Studio for Mac -->
-	<TargetFramework Condition=" '$(OS)' == 'Unix' ">netstandard1.3</TargetFramework>
-    <!-- Targeting netstandard1.3 & netstandard1.5 to match Ninject -->
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.3;netstandard1.5;</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.5;</TargetFrameworks>
     <DIContainer>Ninject</DIContainer>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -9,6 +9,20 @@
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -18,6 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -5,22 +5,16 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
-    <RootNamespace>Prism.Unity.Forms.Tests</RootNamespace>
-    <AssemblyName>Prism.Unity.Forms.Tests</AssemblyName>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Prism.Unity.Forms\Prism.Unity.Forms.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs" />
+    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
+    <RootNamespace>Prism.Unity</RootNamespace>
     <DIContainer>Unity</DIContainer>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -10,6 +10,20 @@
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
   </PropertyGroup>
 
+  <!-- AppVeyor -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- VSTS -->
+  <PropertyGroup Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix>$(VersionPrefix).$(BUILD_BUILDNUMBER)</VersionPrefix>
+    <VersionSuffix >ci</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Unity" Version="4.0.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -1,45 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
-		<AssemblyName>Prism.Unity.Forms</AssemblyName>
-		<PackageId>Prism.Unity.Forms</PackageId>
-		<Title>Unity for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Unity extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and Unity.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
-		<!-- This will create CI builds as 7.0.0.1234-ci -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
-		<VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
+    <DIContainer>Unity</DIContainer>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Unity" Version="4.0.1" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Unity" Version="4.0.1" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/nuspecs/nuget.ps1
+++ b/Source/nuspecs/nuget.ps1
@@ -6,6 +6,8 @@ $nugetFileName = 'nuget.exe'
 
 Write-Host "Packing $env:solution_name"
 
+New-Item -ItemType Directory -Force -Path $nugetOutputDirectory
+
 function Get-FileVersion
 {
     [OutputType([string])]


### PR DESCRIPTION
Refractors build props to centralize a lot of duplicated fields across SDK style projects including NuGet properties, Test dependencies and provides a way to determine if the project is 

- the Core project
- a UWP project
- a WPF project
- a Forms project
- a Test project