### PR TITLE
Optimize the implementation of DelegateCommand.ObservesProperty

### DIFF
--- a/Source/Prism/Commands/PropertyObserver.cs
+++ b/Source/Prism/Commands/PropertyObserver.cs
@@ -22,10 +22,10 @@ namespace Prism.Commands
         private void SubscribeListeners(Expression propertyExpression)
         {
             var propNameStack = new Stack<string>();
-            while (propertyExpression is MemberExpression temp) // Gets the root of the prop chain.
+            while (propertyExpression is MemberExpression temp) // Gets the root of the property chain.
             {
                 propertyExpression = temp.Expression;
-                propNameStack.Push(temp.Member.Name); // Records the name of each prop.
+                propNameStack.Push(temp.Member.Name); // Records the name of each property.
             }
 
             if (!(propertyExpression is ConstantExpression constantExpression))
@@ -34,7 +34,7 @@ namespace Prism.Commands
 
             var propObserverNodeRoot = new PropertyObserverNode(propNameStack.Pop(), _action);
             PropertyObserverNode previousNode = propObserverNodeRoot;
-            foreach (var propName in propNameStack) 
+            foreach (var propName in propNameStack) // Create a node chain that corresponds to the property chain.
             {
                 var currentNode = new PropertyObserverNode(propName, _action);
                 previousNode.Next = currentNode;
@@ -47,7 +47,7 @@ namespace Prism.Commands
                 throw new InvalidOperationException("Trying to subscribe PropertyChanged listener in object that " +
                                                     $"owns '{propObserverNodeRoot.PropertyName}' property, but the object does not implements INotifyPropertyChanged.");
 
-            propObserverNodeRoot.GenerateNode(inpcObject);
+            propObserverNodeRoot.SubscribeListenerFor(inpcObject);
         }
 
         /// <summary>

--- a/Source/Prism/Commands/PropertyObserver.cs
+++ b/Source/Prism/Commands/PropertyObserver.cs
@@ -11,21 +11,43 @@ namespace Prism.Commands
     /// </summary>
     internal class PropertyObserver
     {
-        private readonly Expression _propertyExpression;
         private readonly Action _action;
-        private HashSet<Tuple<INotifyPropertyChanged, PropertyChangedEventHandler>> _registeredListeners;
 
         private PropertyObserver(Expression propertyExpression, Action action)
         {
-            _propertyExpression = propertyExpression;
             _action = action;
-            _registeredListeners = new HashSet<Tuple<INotifyPropertyChanged, PropertyChangedEventHandler>>();
-            Start();
+            SubscribeListeners(propertyExpression);
         }
 
-        private void Start()
+        private void SubscribeListeners(Expression propertyExpression)
         {
-            PropertyObserverNode.Observes(_propertyExpression, _action, this);
+            var propNameStack = new Stack<string>();
+            while (propertyExpression is MemberExpression temp) // Gets the root of the prop chain.
+            {
+                propertyExpression = temp.Expression;
+                propNameStack.Push(temp.Member.Name); // Records the name of each prop.
+            }
+
+            if (!(propertyExpression is ConstantExpression constantExpression))
+                throw new NotSupportedException("Operation not supported for the given expression type. " +
+                                                "Only MemberExpression and ConstanteExpression are currently supported.");
+
+            var propObserverNodeRoot = new PropertyObserverNode(propNameStack.Pop(), _action);
+            PropertyObserverNode previousNode = propObserverNodeRoot;
+            foreach (var propName in propNameStack) 
+            {
+                var currentNode = new PropertyObserverNode(propName, _action);
+                previousNode.Next = currentNode;
+                previousNode = currentNode;
+            }
+
+            object propOwnerObject = constantExpression.Value;
+
+            if (!(propOwnerObject is INotifyPropertyChanged inpcObject))
+                throw new InvalidOperationException("Trying to subscribe PropertyChanged listener in object that " +
+                                                    $"owns '{propObserverNodeRoot.PropertyName}' property, but the object does not implements INotifyPropertyChanged.");
+
+            propObserverNodeRoot.GenerateNode(inpcObject);
         }
 
         /// <summary>
@@ -37,33 +59,6 @@ namespace Prism.Commands
         internal static PropertyObserver Observes<T>(Expression<Func<T>> propertyExpression, Action action)
         {
             return new PropertyObserver(propertyExpression.Body, action);
-        }          
-
-        internal void RegisterListener(INotifyPropertyChanged inpcObject, PropertyChangedEventHandler onPropertyChanged)
-        {
-            var item = new Tuple<INotifyPropertyChanged, PropertyChangedEventHandler>(inpcObject, onPropertyChanged);
-            _registeredListeners.Add(item);
-            inpcObject.PropertyChanged += onPropertyChanged;
-        }
-
-        internal void Restart()
-        {
-            Stop();
-            Start();
-            _action?.Invoke();
-        }
-
-        /// <summary>
-        /// Stop listen by unsubscribing all INotifyPropertyChanged.PropertyChanged listeners.
-        /// </summary>
-        internal void Stop()
-        {
-            foreach(Tuple<INotifyPropertyChanged, PropertyChangedEventHandler> listener in _registeredListeners)
-            {
-                listener.Item1.PropertyChanged -= listener.Item2;
-            }
-
-            _registeredListeners.Clear();
         }
     }
 }

--- a/Source/Prism/Commands/PropertyObserverNode.cs
+++ b/Source/Prism/Commands/PropertyObserverNode.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Prism.Commands
@@ -12,98 +11,61 @@ namespace Prism.Commands
     internal class PropertyObserverNode
     {
         private readonly Action _action;
-        private string _propertyName;
-        private PropertyObserver _propertyObserver;
+        private INotifyPropertyChanged _inpcObject;
 
-        private PropertyObserverNode(Expression propertyExpression, Action action, PropertyObserver propertyObserver)
+        public string PropertyName { get; }
+        public PropertyObserverNode Next { get; set; }
+
+        public PropertyObserverNode(string propertyName, Action action)
         {
+            PropertyName = propertyName;
             _action = action;
-            _propertyObserver = propertyObserver;
-            SubscribeListeners(propertyExpression as MemberExpression);
         }
 
-        /// <summary>
-        /// Initiate PropertyObserverNode for a given property expression.
-        /// </summary>
-        /// <param name="propertyExpression">Expression representing property to be observed.</param>
-        /// <param name="action">Action to be invoked when PropertyChanged event occours.</param>
-        /// <param name="propertyObserver">PropertyObserver instance which owns registered event handlers.</param>
-        internal static void Observes(Expression propertyExpression, Action action, PropertyObserver propertyObserver)
+        public void GenerateNode(INotifyPropertyChanged inpcObject)
         {
-            new PropertyObserverNode(propertyExpression, action, propertyObserver);
+            _inpcObject = inpcObject;
+            _inpcObject.PropertyChanged += OnPropertyChanged;
+
+            GenerateNextNode();
         }
 
-        private void SubscribeListeners(MemberExpression propertyExpression)
+        private void GenerateNextNode()
         {
-
-            // Represents the object that property in propertyExpression belongs to. 
-            // It may be the ModelView object in case of property in propertyExpression belongs to it.
-            Expression propertyOwnerExpression = propertyExpression.Expression as Expression;
-
-            _propertyName = propertyExpression.Member.Name;
-            object propertyOwnerObject = GetPropertyValue(propertyOwnerExpression);
-
-            if (propertyOwnerObject != null)
-            {
-                INotifyPropertyChanged inpcObject = propertyOwnerObject as INotifyPropertyChanged;
-
-                if (inpcObject == null)
-                {
+            // TODO: To cache, if the step consume significant performance. Note: The type of _inpcObject may become its base type or derived type.
+            var propertyInfo = _inpcObject.GetType().GetRuntimeProperty(PropertyName); 
+            var nextProperty = propertyInfo.GetValue(_inpcObject);
+            if (nextProperty == null) return;
+            if (!(nextProperty is INotifyPropertyChanged nextInpcObject))
+                if (Next != null)
                     throw new InvalidOperationException("Trying to subscribe PropertyChanged listener in object that " +
-                        $"owns '{_propertyName}' property, but the object does not implements INotifyPropertyChanged.");
-                }
+                                                        $"owns '{Next.PropertyName}' property, but the object does not implements INotifyPropertyChanged.");
+                else
+                    return;
 
-                _propertyObserver.RegisterListener(inpcObject, OnPropertyChanged);
-            }
-
-            if (propertyOwnerExpression is MemberExpression)
-            {
-                Observes(propertyOwnerExpression, _propertyObserver.Restart, _propertyObserver);
-            }
+            Next?.GenerateNode(nextInpcObject);
         }
+        private void UnsubscribeListener()
+        {
+            if (_inpcObject != null)
+                _inpcObject.PropertyChanged -= OnPropertyChanged;
 
+            Next?.UnsubscribeListener();
+        }
         private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             // Invoke action when e.PropertyName == null in order to satisfy:
             //  - DelegateCommandFixture.GenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName
             //  - DelegateCommandFixture.NonGenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName
-            if (e?.PropertyName == _propertyName || e?.PropertyName == null)
+            if (e?.PropertyName == PropertyName || e?.PropertyName == null)
             {
                 _action?.Invoke();
-            }
-        }
-
-        private static object GetPropertyValue(Expression expression)
-        {
-            object result;
-
-            if (expression is MemberExpression)
-            {
-                MemberExpression memberExpression = expression as MemberExpression;
-                string propertyName = memberExpression.Member.Name;
-                object propertyOwnerObject = GetPropertyValue(memberExpression.Expression);
-
-                if (propertyOwnerObject == null)
+                if (Next != null)
                 {
-                    result = null;
-                }
-                else
-                {
-                    PropertyInfo propertyInfo = propertyOwnerObject.GetType().GetRuntimeProperty(propertyName);
-                    result = propertyInfo?.GetValue(propertyOwnerObject);
+                    Next.UnsubscribeListener();
+                    GenerateNextNode();
                 }
             }
-            else if (expression is ConstantExpression)
-            {
-                result = (expression as ConstantExpression)?.Value;
-            }
-            else
-            {
-                throw new NotSupportedException("Operation not supported for the given expression type. " +
-                    "Only MemberExpression and ConstanteExpression are currently supported.");
-            }
-
-            return result;
         }
     }
 }


### PR DESCRIPTION
I found that the original implementation of this function has the following two points can be optimized (in `Source/Prism/Commands/PropertyObserverNode.cs` and `Source/Prism/Commands/PropertyObserver.cs`):
1. When registering a listener for each property in the property chain, two operations are REPEATED: **search expression root** and **get the instance of the property by reflection**.  The following recursive method shows this process (in `Source/Prism/Commands/PropertyObserverNode.cs`): 
```csharp
        private static object GetPropertyValue(Expression expression)
        {
            object result;

            if (expression is MemberExpression)
            {
                MemberExpression memberExpression = expression as MemberExpression;
                string propertyName = memberExpression.Member.Name;
                object propertyOwnerObject = GetPropertyValue(memberExpression.Expression);
            ...
                    PropertyInfo propertyInfo = propertyOwnerObject.GetType().GetRuntimeProperty(propertyName);
                    result = propertyInfo?.GetValue(propertyOwnerObject);
            ...
            return result;
        }
``` 

The purpose of this operation is to get the names and instances of all properties, and I think that the operation only needs to be done **once**.

2. When the nested property changes, clear the listener of all the properties on the property chain and re-create all `PropertyObserverNode` instances. I think it just needs to be done in the nested property which was changed and its descendants.

So, I re-implemented this feature for the above two points and passed all the tests in the `DelegateCommandFixture.cs`.
![testspassed](https://user-images.githubusercontent.com/8541016/28496211-52393080-6f98-11e7-9e59-dece9784ebbc.png)

