### PR TITLE
Autofac updates

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Mocks/PrismApplicationMock.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Mocks/PrismApplicationMock.cs
@@ -41,21 +41,17 @@ namespace Prism.Autofac.Forms.Tests.Mocks
 
         protected override void RegisterTypes()
         {
-            var builder = new ContainerBuilder();
+            Builder.RegisterType<ServiceMock>().As<IServiceMock>();
+            Builder.RegisterType<AutowireViewModel>();
+            Builder.RegisterType<ViewModelAMock>();
+            Builder.RegisterType<ViewModelBMock>().Named<ViewModelBMock>(ViewModelBMock.Key);
+            Builder.RegisterType<ConstructorArgumentViewModel>();
+            Builder.RegisterType<ModuleMock>().SingleInstance();
 
-            builder.RegisterType<ServiceMock>().As<IServiceMock>();
-            builder.RegisterType<AutowireViewModel>();
-            builder.RegisterType<ViewModelAMock>();
-            builder.Register(ctx => new ViewModelBMock()).Named<ViewModelBMock>(ViewModelBMock.Key);
-            builder.RegisterType<ConstructorArgumentViewModel>();
-            builder.RegisterType<ModuleMock>().SingleInstance();
-
-            builder.Update(Container);
-
-            Container.RegisterTypeForNavigation<ViewMock>("view");
-            Container.RegisterTypeForNavigation<ViewAMock, ViewModelAMock>();
-            Container.RegisterTypeForNavigation<AutowireView, AutowireViewModel>();
-            Container.RegisterTypeForNavigation<ConstructorArgumentView, ConstructorArgumentViewModel>();
+            Builder.RegisterTypeForNavigation<ViewMock>("view");
+            Builder.RegisterTypeForNavigation<ViewAMock, ViewModelAMock>();
+            Builder.RegisterTypeForNavigation<AutowireView, AutowireViewModel>();
+            Builder.RegisterTypeForNavigation<ConstructorArgumentView, ConstructorArgumentViewModel>();
 
             DependencyService.Register<IDependencyServiceMock, DependencyServiceMock>();
         }

--- a/Source/Xamarin/Prism.Autofac.Forms/AutofacExtensions.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/AutofacExtensions.cs
@@ -4,7 +4,7 @@ using Prism.Mvvm;
 using Xamarin.Forms;
 using Prism.Navigation;
 
-namespace Prism.Autofac.Forms
+namespace Prism.Autofac
 {
     public static class AutofacExtensions
     {

--- a/Source/Xamarin/Prism.Autofac.Forms/AutofacExtensions.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/AutofacExtensions.cs
@@ -6,15 +6,18 @@ using Prism.Navigation;
 
 namespace Prism.Autofac
 {
+    /// <summary>
+    /// Autofac View Registration Extensions
+    /// </summary>
     public static class AutofacExtensions
     {
         /// <summary>
         /// Registers a Page for navigation.
         /// </summary>
         /// <typeparam name="TView">The Type of Page to register</typeparam>
-        /// <param name="container"><see cref="IContainer"/> used to register type for Navigation.</param>
+        /// <param name="builder"><see cref="ContainerBuilder"/> used to register type for Navigation.</param>
         /// <param name="name">The unique name to register with the Page</param>
-        public static IContainer RegisterTypeForNavigation<TView>(this IContainer container, string name = null) where TView : Page
+        public static ContainerBuilder RegisterTypeForNavigation<TView>(this ContainerBuilder builder, string name = null) where TView : Page
         {
             Type viewType = typeof(TView);
 
@@ -22,21 +25,21 @@ namespace Prism.Autofac
                 name = viewType.Name;
 
             
-            return container.RegisterTypeForNavigation(viewType, name);
+            return builder.RegisterTypeForNavigation(viewType, name);
         }
 
         /// <summary>
         /// Registers a Page for navigation
         /// </summary>
-        /// <param name="container"><see cref="IContainer"/> used to register type for Navigation.</param>
+        /// <param name="builder"><see cref="ContainerBuilder"/> used to register type for Navigation.</param>
         /// <param name="viewType">The type of Page to register</param>
         /// <param name="name">The unique name to register with the Page</param>
-        /// <returns><see cref="IContainer"/></returns>
-        public static IContainer RegisterTypeForNavigation(this IContainer container, Type viewType, string name)
+        /// <returns><see cref="ContainerBuilder"/></returns>
+        public static ContainerBuilder RegisterTypeForNavigation(this ContainerBuilder builder, Type viewType, string name)
         {
             PageNavigationRegistry.Register(name, viewType);
-            RegisterTypeIfMissing(container, viewType, name);
-            return container;
+            RegisterTypeIfMissing(builder, viewType, name);
+            return builder;
         }
 
         /// <summary>
@@ -45,29 +48,29 @@ namespace Prism.Autofac
         /// <typeparam name="TView">The Type of Page to register</typeparam>
         /// <typeparam name="TViewModel">The ViewModel to use as the BindingContext for the Page</typeparam>
         /// <param name="name">The unique name to register with the Page</param>
-        /// <param name="container"></param>
-        public static IContainer RegisterTypeForNavigation<TView, TViewModel>(this IContainer container, string name = null)
+        /// <param name="builder"></param>
+        public static ContainerBuilder RegisterTypeForNavigation<TView, TViewModel>(this ContainerBuilder builder, string name = null)
             where TView : Page
             where TViewModel : class
         {
-            return container.RegisterTypeForNavigationWithViewModel<TViewModel>(typeof(TView), name);
+            return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(typeof(TView), name);
         }
 
-		/// <summary>
-		/// Registers a Page for navigation based on the current Device OS using a shared ViewModel
-		/// </summary>
-		/// <typeparam name="TView">Default View Type to be shared across multiple Device Operating Systems if they are not specified directly.</typeparam>
-		/// <typeparam name="TViewModel">Shared ViewModel Type</typeparam>
-		/// <param name="container"><see cref="IContainer"/> used to register type for Navigation.</param>
-		/// <param name="name">The unique name to register with the Page. If left empty or null will default to the ViewModel root name. i.e. MyPageViewModel => MyPage</param>
-		/// <param name="androidView">Android Specific View Type</param>
-		/// <param name="iOSView">iOS Specific View Type</param>
-		/// <param name="otherView">Other Platform Specific View Type</param>
-		/// <param name="windowsView">Windows Specific View Type</param>
-		/// <param name="winPhoneView">Windows Phone Specific View Type</param>
-		/// <returns><see cref="IUnityContainer"/></returns>
-		[Obsolete("This signature of the RegisterTypeForNavigationOnPlatform method is obsolete due to Device.OnPlatform being deprecated. Use the new IPlatform[] overload instead.")]
-		public static IContainer RegisterTypeForNavigationOnPlatform<TView, TViewModel>(this IContainer container, string name = null, Type androidView = null, Type iOSView = null, Type otherView = null, Type windowsView = null, Type winPhoneView = null)
+        /// <summary>
+        /// Registers a Page for navigation based on the current Device OS using a shared ViewModel
+        /// </summary>
+        /// <typeparam name="TView">Default View Type to be shared across multiple Device Operating Systems if they are not specified directly.</typeparam>
+        /// <typeparam name="TViewModel">Shared ViewModel Type</typeparam>
+        /// <param name="builder"><see cref="ContainerBuilder"/> used to register type for Navigation.</param>
+        /// <param name="name">The unique name to register with the Page. If left empty or null will default to the ViewModel root name. i.e. MyPageViewModel => MyPage</param>
+        /// <param name="androidView">Android Specific View Type</param>
+        /// <param name="iOSView">iOS Specific View Type</param>
+        /// <param name="otherView">Other Platform Specific View Type</param>
+        /// <param name="windowsView">Windows Specific View Type</param>
+        /// <param name="winPhoneView">Windows Phone Specific View Type</param>
+        /// <returns><see cref="ContainerBuilder"/></returns>
+        [Obsolete("This signature of the RegisterTypeForNavigationOnPlatform method is obsolete due to Device.OnPlatform being deprecated. Use the new IPlatform[] overload instead.")]
+        public static ContainerBuilder RegisterTypeForNavigationOnPlatform<TView, TViewModel>(this ContainerBuilder builder, string name = null, Type androidView = null, Type iOSView = null, Type otherView = null, Type windowsView = null, Type winPhoneView = null)
             where TView : Page
             where TViewModel : class
         {
@@ -76,84 +79,84 @@ namespace Prism.Autofac
 
             if (Device.OS == TargetPlatform.Android && androidView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(androidView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(androidView, name);
             }
             else if (Device.OS == TargetPlatform.iOS && iOSView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(iOSView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(iOSView, name);
             }
             else if (Device.OS == TargetPlatform.Other && otherView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(otherView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(otherView, name);
             }
             else if (Device.OS == TargetPlatform.Windows && windowsView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(windowsView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(windowsView, name);
             }
             else if (Device.OS == TargetPlatform.WinPhone && winPhoneView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(winPhoneView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(winPhoneView, name);
             }
             else
             {
-                return container.RegisterTypeForNavigation<TView, TViewModel>(name);
+                return builder.RegisterTypeForNavigation<TView, TViewModel>(name);
             }
         }
 
-		/// <summary>
-		/// Registers a Page for navigation based on the current Device OS using a shared ViewModel
-		/// </summary>
-		/// <typeparam name="TView">Default View Type to be shared across multiple Device Operating Systems if they are not specified directly.</typeparam>
-		/// <typeparam name="TViewModel">Shared ViewModel Type</typeparam>
-		/// <param name="container"><see cref="IContainer"/> used to register type for Navigation.</param>
-		/// <param name="platforms"></param>
-		public static void RegisterTypeForNavigationOnPlatform<TView, TViewModel>(this IContainer container, params IPlatform[] platforms)
-			where TView : Page
-			where TViewModel : class
-		{
-			var name = typeof(TView).Name;
-			RegisterTypeForNavigationOnPlatform<TView, TViewModel>(container, name, platforms);
-		}
+        /// <summary>
+        /// Registers a Page for navigation based on the current Device OS using a shared ViewModel
+        /// </summary>
+        /// <typeparam name="TView">Default View Type to be shared across multiple Device Operating Systems if they are not specified directly.</typeparam>
+        /// <typeparam name="TViewModel">Shared ViewModel Type</typeparam>
+        /// <param name="builder"><see cref="ContainerBuilder"/> used to register type for Navigation.</param>
+        /// <param name="platforms"></param>
+        public static void RegisterTypeForNavigationOnPlatform<TView, TViewModel>(this ContainerBuilder builder, params IPlatform[] platforms)
+            where TView : Page
+            where TViewModel : class
+        {
+            var name = typeof(TView).Name;
+            RegisterTypeForNavigationOnPlatform<TView, TViewModel>(builder, name, platforms);
+        }
 
-		/// <summary>
-		/// Registers a Page for navigation based on the current Device OS using a shared ViewModel
-		/// </summary>
-		/// <typeparam name="TView">Default View Type to be shared across multiple Device Operating Systems if they are not specified directly.</typeparam>
-		/// <typeparam name="TViewModel">Shared ViewModel Type</typeparam>
-		/// <param name="container"><see cref="IContainer"/> used to register type for Navigation.</param>
-		/// <param name="name">The unique name to register with the Page. If left empty or null will default to the View name.</param>
-		/// <param name="platforms"></param>
-		public static void RegisterTypeForNavigationOnPlatform<TView, TViewModel>(this IContainer container, string name, params IPlatform[] platforms)
-			where TView : Page
-			where TViewModel : class
-		{
-			if (string.IsNullOrWhiteSpace(name))
-				name = typeof(TView).Name;
+        /// <summary>
+        /// Registers a Page for navigation based on the current Device OS using a shared ViewModel
+        /// </summary>
+        /// <typeparam name="TView">Default View Type to be shared across multiple Device Operating Systems if they are not specified directly.</typeparam>
+        /// <typeparam name="TViewModel">Shared ViewModel Type</typeparam>
+        /// <param name="builder"><see cref="ContainerBuilder"/> used to register type for Navigation.</param>
+        /// <param name="name">The unique name to register with the Page. If left empty or null will default to the View name.</param>
+        /// <param name="platforms"></param>
+        public static void RegisterTypeForNavigationOnPlatform<TView, TViewModel>(this ContainerBuilder builder, string name, params IPlatform[] platforms)
+            where TView : Page
+            where TViewModel : class
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = typeof(TView).Name;
 
-			foreach (var platform in platforms)
-			{
-				if (Device.RuntimePlatform == platform.RuntimePlatform.ToString())
-				{
-					container.RegisterTypeForNavigationWithViewModel<TViewModel>(platform.ViewType, name);
-					return;
-				}
-			}
+            foreach (var platform in platforms)
+            {
+                if (Device.RuntimePlatform == platform.RuntimePlatform.ToString())
+                {
+                    builder.RegisterTypeForNavigationWithViewModel<TViewModel>(platform.ViewType, name);
+                    return;
+                }
+            }
 
-			container.RegisterTypeForNavigation<TView, TViewModel>(name);
-		}
+            builder.RegisterTypeForNavigation<TView, TViewModel>(name);
+        }
 
-		/// <summary>
-		/// Registers a Page for navigation based on the Device Idiom using a shared ViewModel
-		/// </summary>
-		/// <typeparam name="TView">Default View Type to be used across multiple Idioms if they are not specified directly.</typeparam>
-		/// <typeparam name="TViewModel">The shared ViewModel</typeparam>
-		/// <param name="container"><see cref="IContainer"/> used to register type for Navigation.</param>
-		/// <param name="name">The common name used for Navigation. If left empty or null will default to the ViewModel root name. i.e. MyPageViewModel => MyPage</param>
-		/// <param name="desktopView">Desktop Specific View Type</param>
-		/// <param name="tabletView">Tablet Specific View Type</param>
-		/// <param name="phoneView">Phone Specific View Type</param>
-		/// <returns><see cref="IUnityContainer"/></returns>
-		public static IContainer RegisterTypeForNavigationOnIdiom<TView, TViewModel>(this IContainer container, string name = null, Type desktopView = null, Type tabletView = null, Type phoneView = null)
+        /// <summary>
+        /// Registers a Page for navigation based on the Device Idiom using a shared ViewModel
+        /// </summary>
+        /// <typeparam name="TView">Default View Type to be used across multiple Idioms if they are not specified directly.</typeparam>
+        /// <typeparam name="TViewModel">The shared ViewModel</typeparam>
+        /// <param name="builder"><see cref="ContainerBuilder"/> used to register type for Navigation.</param>
+        /// <param name="name">The common name used for Navigation. If left empty or null will default to the ViewModel root name. i.e. MyPageViewModel => MyPage</param>
+        /// <param name="desktopView">Desktop Specific View Type</param>
+        /// <param name="tabletView">Tablet Specific View Type</param>
+        /// <param name="phoneView">Phone Specific View Type</param>
+        /// <returns><see cref="ContainerBuilder"/></returns>
+        public static ContainerBuilder RegisterTypeForNavigationOnIdiom<TView, TViewModel>(this ContainerBuilder builder, string name = null, Type desktopView = null, Type tabletView = null, Type phoneView = null)
             where TView : Page
             where TViewModel : class
         {
@@ -162,23 +165,23 @@ namespace Prism.Autofac
 
             if (Device.Idiom == TargetIdiom.Desktop && desktopView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(desktopView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(desktopView, name);
             }
             else if (Device.Idiom == TargetIdiom.Phone && phoneView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(phoneView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(phoneView, name);
             }
             else if (Device.Idiom == TargetIdiom.Tablet && tabletView != null)
             {
-                return container.RegisterTypeForNavigationWithViewModel<TViewModel>(tabletView, name);
+                return builder.RegisterTypeForNavigationWithViewModel<TViewModel>(tabletView, name);
             }
             else
             {
-                return container.RegisterTypeForNavigation<TView, TViewModel>(name);
+                return builder.RegisterTypeForNavigation<TView, TViewModel>(name);
             }
         }
 
-        private static IContainer RegisterTypeForNavigationWithViewModel<TViewModel>(this IContainer container, Type viewType, string name)
+        private static ContainerBuilder RegisterTypeForNavigationWithViewModel<TViewModel>(this ContainerBuilder builder, Type viewType, string name)
             where TViewModel : class
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -186,18 +189,18 @@ namespace Prism.Autofac
 
             ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
 
-            return container.RegisterTypeForNavigation(viewType, name);
+            return builder.RegisterTypeForNavigation(viewType, name);
         }
 
         /// <summary>
-        /// Registers a type in the container only if that type was not already registered,
-        /// after the container is already created.
-        /// Uses a new ContainerBuilder instance to update the Container.
+        /// Registers a type in the builder only if that type was not already registered,
+        /// after the builder is already created.
+        /// Uses a new ContainerBuilder instance to update the builder.
         /// </summary>
+        /// <param name="builder">The Container Builder.</param>
         /// <param name="type">The type to register.</param>
         /// <param name="name">The name you will use to resolve the component in future.</param>
-        /// <param name="registerAsSingleton">Registers the type as a singleton.</param>
-        private static void RegisterTypeIfMissing(IContainer container, Type type, string name, bool registerAsSingleton = false)
+        private static void RegisterTypeIfMissing(ContainerBuilder builder, Type type, string name)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
@@ -205,17 +208,7 @@ namespace Prism.Autofac
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
 
-            if (!container.IsRegistered(type))
-            {
-                var containerUpdater = new ContainerBuilder();
-
-                if (registerAsSingleton)
-                    containerUpdater.RegisterType(type).Named<Page>(name).SingleInstance();
-                else
-                    containerUpdater.RegisterType(type).Named<Page>(name);
-
-                containerUpdater.Update(container);
-            }
+            builder.RegisterType(type).Named<Page>(name);
         }
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
@@ -2,8 +2,7 @@
 
 namespace Prism.Autofac
 {
-    public interface IPlatformInitializer : IPlatformInitializer<IContainer>
+    public interface IPlatformInitializer : IPlatformInitializer<ContainerBuilder>
     {
-        void RegisterTypes(ContainerBuilder builder);
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
@@ -1,6 +1,6 @@
 ﻿using Autofac;
 
-namespace Prism.Autofac.Forms
+namespace Prism.Autofac
 {
     public interface IPlatformInitializer : IPlatformInitializer<IContainer>
     {

--- a/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/IPlatformInitializer.cs
@@ -4,5 +4,6 @@ namespace Prism.Autofac.Forms
 {
     public interface IPlatformInitializer : IPlatformInitializer<IContainer>
     {
+        void RegisterTypes(ContainerBuilder builder);
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
@@ -6,32 +6,32 @@ namespace Prism.Autofac.Modularity
 {
     public class AutofacModuleInitializer : IModuleInitializer
     {
-        readonly IContainer _container;
+        readonly IComponentContext _context;
 
         /// <summary>
         /// Create a new instance of <see cref="AutofacModuleInitializer"/> with <paramref name="container"/>
         /// </summary>
-        /// <param name="container"></param>
-        public AutofacModuleInitializer(IContainer context)
+        /// <param name="context"></param>
+        public AutofacModuleInitializer(IComponentContext context)
         {
-            _container = context;
+            _context = context;
         }
 
         public void Initialize(ModuleInfo moduleInfo)
         {
-            var module = (IModule)_container.Resolve(moduleInfo.ModuleType);
+            var module = (IModule)_context.Resolve(moduleInfo.ModuleType);
             if (module != null)
                 module.Initialize();
         }
 
         /// <summary>
-        /// Create the <see cref="IModule"/> for <paramref name="moduleType"/> by resolving from <see cref="_container"/>
+        /// Create the <see cref="IModule"/> for <paramref name="moduleType"/> by resolving from <see cref="_context"/>
         /// </summary>
         /// <param name="moduleType">Type of module to create</param>
         /// <returns>An isntance of <see cref="IModule"/> for <paramref name="moduleType"/> if exists; otherwise <see langword="null" /></returns>
         protected virtual IModule CreateModule(Type moduleType)
         {
-            return _container.Resolve(moduleType) as IModule;
+            return _context.Resolve(moduleType) as IModule;
         }
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
@@ -2,7 +2,7 @@
 using Prism.Modularity;
 using Autofac;
 
-namespace Prism.Autofac.Forms.Modularity
+namespace Prism.Autofac.Modularity
 {
     public class AutofacModuleInitializer : IModuleInitializer
     {

--- a/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Modularity/AutofacModuleInitializer.cs
@@ -9,7 +9,7 @@ namespace Prism.Autofac.Modularity
         readonly IComponentContext _context;
 
         /// <summary>
-        /// Create a new instance of <see cref="AutofacModuleInitializer"/> with <paramref name="container"/>
+        /// Create a new instance of <see cref="AutofacModuleInitializer"/> with <paramref name="context"/>
         /// </summary>
         /// <param name="context"></param>
         public AutofacModuleInitializer(IComponentContext context)

--- a/Source/Xamarin/Prism.Autofac.Forms/Navigation/AutofacPageNavigationService.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/Navigation/AutofacPageNavigationService.cs
@@ -12,31 +12,31 @@ namespace Prism.Autofac.Navigation
     /// </summary>
     public class AutofacPageNavigationService : PageNavigationService
     {
-        readonly IContainer _container;
+        readonly IComponentContext _context;
 
         /// <summary>
-        /// Create a new instance of <see cref="AutofacPageNavigationService"/> with <paramref name="container"/>
+        /// Create a new instance of <see cref="AutofacPageNavigationService"/> with <paramref name="context"/>
         /// </summary>
         /// <param name="applicationProvider">An instance of <see cref="IApplicationProvider"/></param>
-        /// <param name="container">An instance of <see cref="IContainer"/></param>
+        /// <param name="context">An instance of <see cref="IComponentContext"/></param>
         /// <param name="logger">An instance of <see cref="ILoggerFacade"/></param>
-        public AutofacPageNavigationService(IContainer container, IApplicationProvider applicationProvider, ILoggerFacade logger)
+        public AutofacPageNavigationService(IComponentContext context, IApplicationProvider applicationProvider, ILoggerFacade logger)
             : base(applicationProvider, logger)
         {
-            _container = container;
+            _context = context;
         }
 
         /// <summary>
-        /// Resolve a <see cref="Page"/> from <see cref="_container"/> for <paramref name="segmentName"/>
+        /// Resolve a <see cref="Page"/> from <see cref="_context"/> for <paramref name="segmentName"/>
         /// </summary>
         /// <param name="segmentName">Page to resolve</param>
         /// <returns>A <see cref="Page"/></returns>
-        protected override Page CreatePage(string name)
+        protected override Page CreatePage(string segmentName)
         {
-            if (!_container.IsRegisteredWithName<Page>(name))
-                throw new NullReferenceException($"The requested page '{name}' has not been registered.");
+            if (!_context.IsRegisteredWithName<Page>(segmentName))
+                throw new NullReferenceException($"The requested page '{segmentName}' has not been registered.");
 
-            return _container.ResolveNamed<Page>(name);
+            return _context.ResolveNamed<Page>(segmentName);
         }
     }
 }

--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -118,10 +118,8 @@ namespace Prism.Autofac
         /// Creates the <see cref="IModuleManager"/> from the container.
         /// </summary>
         /// <returns></returns>
-        protected override IModuleManager CreateModuleManager()
-        {
-            return Container.Resolve<IModuleManager>();
-        }
+        protected override IModuleManager CreateModuleManager() =>
+            Container.Resolve<IModuleManager>();
 
         /// <summary>
         /// Create instance of <see cref="INavigationService"/>
@@ -133,18 +131,6 @@ namespace Prism.Autofac
         protected override INavigationService CreateNavigationService()
         {
             return Container.ResolveNamed<INavigationService>(_navigationServiceName);
-        }
-
-        /// <summary>
-        /// Initializes any Modules found in the Module Catalog
-        /// </summary>
-        protected override void InitializeModules()
-        {
-            if (ModuleCatalog.Modules.Any())
-            {
-                var manager = Container.Resolve<IModuleManager>();
-                manager.Run();
-            }
         }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -155,7 +155,7 @@ namespace Prism.Autofac
             Builder.RegisterInstance(Logger).As<ILoggerFacade>().SingleInstance();
             Builder.RegisterInstance(ModuleCatalog).As<IModuleCatalog>().SingleInstance();
 
-            //Builder.RegisterType<ApplicationProvider>().As<IApplicationProvider>().SingleInstance();
+            Builder.RegisterType<ApplicationProvider>().As<IApplicationProvider>().SingleInstance();
             Builder.RegisterType<ApplicationStore>().As<IApplicationStore>().SingleInstance();
             Builder.RegisterType<AutofacPageNavigationService>().Named<INavigationService>(_navigationServiceName);
             Builder.RegisterType<ModuleManager>().As<IModuleManager>().SingleInstance();

--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -1,19 +1,18 @@
 ﻿using System.Linq;
-using Prism.Navigation;
-using Prism.Mvvm;
-using Prism.Common;
-using Xamarin.Forms;
-using Prism.Logging;
-using Prism.Events;
-using Prism.Services;
-using DependencyService = Prism.Services.DependencyService;
-using Prism.Modularity;
 using Autofac;
 using Autofac.Features.ResolveAnything;
-using Prism.Autofac.Forms.Modularity;
-using Prism.Autofac.Navigation;
-using Prism.Autofac.Forms;
 using Prism.AppModel;
+using Prism.Autofac.Modularity;
+using Prism.Autofac.Navigation;
+using Prism.Common;
+using Prism.Events;
+using Prism.Logging;
+using Prism.Modularity;
+using Prism.Mvvm;
+using Prism.Navigation;
+using Prism.Services;
+using Xamarin.Forms;
+using DependencyService = Prism.Services.DependencyService;
 
 namespace Prism.Autofac
 {

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -9,7 +9,6 @@ namespace Prism
 {
     public abstract class PrismApplicationBase<T> : Application
     {
-        IPlatformInitializer<T> _platformInitializer = null;
         Page _previousPage = null;
 
         /// <summary>
@@ -30,6 +29,11 @@ namespace Prism
         protected IModuleCatalog ModuleCatalog { get; set; }
 
         /// <summary>
+        /// Get the Platform Initializer
+        /// </summary>
+        protected IPlatformInitializer<T> PlatformInitializer { get; }
+
+        /// <summary>
         /// Gets the <see cref="INavigationService"/> for the application.
         /// </summary>
         protected INavigationService NavigationService { get; set; }
@@ -39,12 +43,12 @@ namespace Prism
             base.ModalPopping += PrismApplicationBase_ModalPopping;
             base.ModalPopped += PrismApplicationBase_ModalPopped;
 
-            _platformInitializer = initializer;
+            PlatformInitializer = initializer;
             InitializeInternal();
         }
 
         /// <summary>
-        /// Run the intialization process.
+        /// Run the initialization process.
         /// </summary>
         void InitializeInternal()
         {
@@ -69,7 +73,7 @@ namespace Prism
 
             RegisterTypes();
 
-            _platformInitializer?.RegisterTypes(Container);
+            PlatformInitializer?.RegisterTypes(Container);
             
             NavigationService = CreateNavigationService();
 


### PR DESCRIPTION
Updates Autofac implementation to better work with the way that the Autofac API is designed to work.

- Removes the `IContainer` dependency for Prism Services in favor of the `IComponentContext` which is actually resolvable by the container.
- Changes PrismApplication to use the `ContainerBuilder` rather than `IContainer` and exposes this through the `Builder` property, while overriding and exposing the `Container` property as the final built container.
- Removes unnecessary factory registrations for Prism Services
- Updates View registration extensions to be extensions of the `ContainerBuilder` and not `IContainer`.
- Removes all deprecated uses of `builder.Update(Container)`
- Exposes the platform initializer as a protected property in `PrismApplicationBase` so that the Autofac `PrismApplication` can properly initialize with any platform initializations.

**NOTE: This will be a breaking change for all existing Prism.Autofac.Forms applications**