### PR TITLE
Support for non-Page View's

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -94,14 +94,13 @@ namespace Prism.Autofac
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
             {
-                NamedParameter parameter = null;
-                var page = view as Page;
-                if (page != null)
+                var navService = CreateNavigationService(view);
+                if (navService != null)
                 {
-                    parameter = new NamedParameter("navigationService", CreateNavigationService(page));
+                    return Container.Resolve(type, new NamedParameter("navigationService", navService));
                 }
 
-                return Container.Resolve(type, parameter);
+                return Container.Resolve(type);
             });
         }
 

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -111,14 +111,14 @@ namespace Prism.DryIoc
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
             {
-                var page = view as Page;
-                if(page != null)
+                var navService = CreateNavigationService(view);
+                if (navService != null)
                 {
-                    var navService = CreateNavigationService(page);
                     return Container.WithDependencies(
                     Parameters.Of.Type(_ => navService))
-                    .Resolve(type);
+                                    .Resolve(type);
                 }
+
                 return Container.Resolve(type);
             });
         }

--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -1,8 +1,9 @@
-﻿using Prism.Navigation;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Prism.Mvvm;
+using Prism.Navigation;
 using Xamarin.Forms;
 
 namespace Prism.Common
@@ -11,17 +12,19 @@ namespace Prism.Common
     {
         public static void InvokeViewAndViewModelAction<T>(object view, Action<T> action) where T : class
         {
-            T viewAsT = view as T;
-            if (viewAsT != null)
+            if(view is T viewAsT)
                 action(viewAsT);
 
-            var element = view as BindableObject;
-            if (element != null)
+            if(view is BindableObject bindable)
             {
-                var viewModelAsT = element.BindingContext as T;
-                if (viewModelAsT != null)
+                if(bindable.BindingContext is T viewModelAsT)
                 {
                     action(viewModelAsT);
+                }
+
+                foreach(Element child in ChildViewRegistry.GetChildViews(bindable))
+                {
+                    InvokeViewAndViewModelAction(child, action);
                 }
             }
         }

--- a/Source/Xamarin/Prism.Forms/Mvvm/ChildViewRegistry.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ChildViewRegistry.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+
+namespace Prism.Mvvm
+{
+    public static class ChildViewRegistry
+    {
+        public static readonly BindableProperty ChildViewsProperty =
+            BindableProperty.CreateAttached("ChildViews", typeof(IList<Element>), typeof(ChildViewRegistry), new List<Element>());
+
+        public static IList<Element> GetChildViews(BindableObject bindable) =>
+            (IList<Element>)bindable.GetValue(ChildViewsProperty);
+
+        public static void AddChildView(BindableObject bindable, Element element) =>
+            GetChildViews(bindable).Add(element);
+    }
+}

--- a/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/PrismApplication.cs
@@ -27,18 +27,16 @@ namespace Prism.Ninject
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
             {
-                IParameter[] overrides = null;
-
-                var page = view as Page;
-                if (page != null)
+                var navService = CreateNavigationService(view);
+                if (navService != null)
                 {
-                    overrides = new IParameter[]
+                    return Container.Get(type, new IParameter[]
                     {
-                        new ConstructorArgument("navigationService", CreateNavigationService(page))
-                    };
+                        new ConstructorArgument("navigationService", navService)
+                    });
                 }
 
-                return Container.Get(type, overrides);
+                return Container.Get(type);
             });
         }
 

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -25,18 +25,16 @@ namespace Prism.Unity
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
             {
-                ParameterOverrides overrides = null;
-
-                var page = view as Page;
-                if (page != null)
+                var navService = CreateNavigationService(view);
+                if(navService != null)
                 {
-                    overrides = new ParameterOverrides
+                    return Container.Resolve(type, new ParameterOverrides
                     {
-                        { "navigationService", CreateNavigationService(page) }
-                    };
+                        { "navigationService", navService }
+                    });
                 }
 
-                return Container.Resolve(type, overrides);
+                return Container.Resolve(type);
             });
         }
 


### PR DESCRIPTION
Updates the ViewModelLocator to be able to handle View's that are not Xamarin.Forms.Page's. This will ultimately allow for more reusable controls, and better support for the CarouselView.