### PR TITLE
Added ability to navigate to type

### DIFF
--- a/Source/Windows10/Prism.Windows.Tests/FrameNavigationServiceFixture.cs
+++ b/Source/Windows10/Prism.Windows.Tests/FrameNavigationServiceFixture.cs
@@ -39,6 +39,25 @@ namespace Prism.Windows.Tests
         }
 
         [TestMethod]
+        public async Task Navigate_To_Valid_Page_by_Type()
+        {
+            await DispatcherHelper.ExecuteOnUIThread(() =>
+            {
+                var frame = new FrameFacadeAdapter(new Frame());
+                var sessionStateService = new MockSessionStateService();
+                sessionStateService.GetSessionStateForFrameDelegate = (currentFrame) => new Dictionary<string, object>();
+                var navigationService = new FrameNavigationService(frame, null, sessionStateService);
+
+                bool result = navigationService.Navigate(typeof(MockPage), 1);
+
+                Assert.IsTrue(result);
+                Assert.IsNotNull(frame.Content);
+                Assert.IsInstanceOfType(frame.Content, typeof(MockPage));
+                Assert.AreEqual(1, ((MockPage)frame.Content).PageParameter);
+            });
+        }
+
+        [TestMethod]
         public async Task Navigate_To_Invalid_Page()
         {
             await DispatcherHelper.ExecuteOnUIThread(() =>

--- a/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
@@ -56,20 +56,36 @@ namespace Prism.Windows.Navigation
                 var error = string.Format(CultureInfo.CurrentCulture, resourceLoader.GetString("FrameNavigationServiceUnableResolveMessage"), pageToken);
                 throw new ArgumentException(error, nameof(pageToken));
             }
+            else 
 
-            // Get the page type and parameter of the last navigation to check if we
-            // are trying to navigate to the exact same page that we are currently on
-            var lastNavigationParameter = _sessionStateService.SessionState.ContainsKey(LastNavigationParameterKey) ? _sessionStateService.SessionState[LastNavigationParameterKey] : null;
-            var lastPageTypeFullName = _sessionStateService.SessionState.ContainsKey(LastNavigationPageKey) ? _sessionStateService.SessionState[LastNavigationPageKey] as string : string.Empty;
+            return Navigate(pageType, parameter);
+        }
 
-            if (lastPageTypeFullName != pageType.FullName || !AreEquals(lastNavigationParameter, parameter))
+        /// <summary>
+        /// Navigates to the page with the specified type, passing the specified parameter.
+        /// </summary>
+        /// <param name="pageType">The page type.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>Returns <c>true</c> if the navigation succeeds: otherwise, <c>false</c>.</returns>
+        public bool Navigate(Type pageType, object parameter)
+        {
+            if (pageType != null)
             {
-                return _frame.Navigate(pageType, parameter);
+                // Get the page type and parameter of the last navigation to check if we
+                // are trying to navigate to the exact same page that we are currently on
+                var lastNavigationParameter = _sessionStateService.SessionState.ContainsKey(LastNavigationParameterKey) ? _sessionStateService.SessionState[LastNavigationParameterKey] : null;
+                var lastPageTypeFullName = _sessionStateService.SessionState.ContainsKey(LastNavigationPageKey) ? _sessionStateService.SessionState[LastNavigationPageKey] as string : string.Empty;
+
+                if (lastPageTypeFullName != pageType.FullName || !AreEquals(lastNavigationParameter, parameter))
+                {
+                    return _frame.Navigate(pageType, parameter);
+                }
             }
+            else
+                throw new ArgumentException("parameter 'pageType' can't be null");
 
             return false;
         }
-
 
         /// <summary>
         /// Goes to the previous page in the navigation stack.

--- a/Source/Windows10/Prism.Windows/Navigation/INavigationService.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/INavigationService.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Prism.Windows.Navigation
 {
     /// <summary>
@@ -14,6 +16,14 @@ namespace Prism.Windows.Navigation
         /// <param name="parameter">The parameter.</param>
         /// <returns>Returns <c>true</c> if navigation succeeds; otherwise, <c>false</c></returns>
         bool Navigate(string pageToken, object parameter);
+
+        /// <summary>
+        /// Navigates to the page with the specified page Type, passing the specified parameter
+        /// </summary>
+        /// <param name="pageType">The type of the page.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns></returns>
+        bool Navigate(Type pageType, object parameter);
 
         /// <summary>
         /// Goes to the previous page in the navigation stack.


### PR DESCRIPTION
### Benefits:
You can now Navigate like this (to a Page named **MainPage**):
`navigationService.Navigate(typeof(MainPage), parameter);`
instead of 
`navigationService.Navigate("Main", parameter);`

- No Magic Strings
- Faster than an Extension Method that tries to accomplish getting rid of magic strings (**Example: AsNavString**)
```
public static string AsNavString(this Type type)
{
        if (type.Name.EndsWith("Page"))
                return type.Name.Remove(type.Name.Length - 4);
        else
            throw new Exception("Invalide type, name must end with 'Page'");
}
```

### Changes proposed in this pull request:

#### INavigationService.cs
- Added Additional **Navigate** method. Now there are two:
`bool Navigate(string pageToken, object parameter);`
`bool Navigate(Type pageType, object parameter);`

#### FrameNavigationService.cs 

- Implemented Navigate(Type, object) method
- Navigate(string, object) now only resolves the type and then calls Navigate(Type, object)

```
        public bool Navigate(string pageToken, object parameter)
        {
            Type pageType = _navigationResolver(pageToken);

            if (pageType == null)
            {
                var resourceLoader = ResourceLoader.GetForCurrentView(Constants.InfrastructureResourceMapId);
                var error = string.Format(CultureInfo.CurrentCulture, resourceLoader.GetString("FrameNavigationServiceUnableResolveMessage"), pageToken);
                throw new ArgumentException(error, nameof(pageToken));
            }
            else 

            return Navigate(pageType, parameter);
        }

        public bool Navigate(Type pageType, object parameter)
        {
            if (pageType != null)
            {
                // Get the page type and parameter of the last navigation to check if we
                // are trying to navigate to the exact same page that we are currently on
                var lastNavigationParameter = _sessionStateService.SessionState.ContainsKey(LastNavigationParameterKey) ? _sessionStateService.SessionState[LastNavigationParameterKey] : null;
                var lastPageTypeFullName = _sessionStateService.SessionState.ContainsKey(LastNavigationPageKey) ? _sessionStateService.SessionState[LastNavigationPageKey] as string : string.Empty;

                if (lastPageTypeFullName != pageType.FullName || !AreEquals(lastNavigationParameter, parameter))
                {
                    return _frame.Navigate(pageType, parameter);
                }
            }
            else
                throw new ArgumentException("parameter 'pageType' can't be null");

           return false;
        }
```


#### FrameNavigationServiceFixture.cs
- Added Test 
