### PR TITLE
updated to Unity 5.0.0-beta targeting netstandard1.0

### DIFF
--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Mocks/PrismApplicationMock.cs
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Mocks/PrismApplicationMock.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.Unity;
+﻿using Unity;
 using Prism.DI.Forms.Tests.Mocks.Modules;
 using Prism.DI.Forms.Tests.Mocks.Services;
 using Prism.DI.Forms.Tests.Mocks.ViewModels;

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/PrismApplicationFixture.cs
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/PrismApplicationFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.Practices.Unity;
+using Unity;
 using Prism.Common;
 using Prism.Unity.Forms.Tests.Mocks;
 using Prism.DI.Forms.Tests.Mocks.Modules;

--- a/Source/Xamarin/Prism.Unity.Forms/Extensions/DependencyServiceExtension.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/Extensions/DependencyServiceExtension.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Practices.Unity;
-using Microsoft.Practices.Unity.ObjectBuilder;
+﻿using Unity;
+using Unity.ObjectBuilder;
 
 namespace Prism.Unity.Extensions
 {

--- a/Source/Xamarin/Prism.Unity.Forms/Extensions/DependencyServiceStrategy.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/Extensions/DependencyServiceStrategy.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Reflection;
-using Microsoft.Practices.ObjectBuilder2;
-using Microsoft.Practices.Unity;
+using Unity;
 using Xamarin.Forms;
+using ObjectBuilder2;
 
 namespace Prism.Unity.Extensions
 {

--- a/Source/Xamarin/Prism.Unity.Forms/IPlatformInitializer.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/IPlatformInitializer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.Unity;
+﻿using Unity;
 
 namespace Prism.Unity
 {

--- a/Source/Xamarin/Prism.Unity.Forms/Modularity/UnityModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/Modularity/UnityModuleInitializer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.Unity;
+﻿using Unity;
 using Prism.Modularity;
 using System;
 

--- a/Source/Xamarin/Prism.Unity.Forms/Navigation/UnityPageNavigationService.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/Navigation/UnityPageNavigationService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.Unity;
+﻿using Unity;
 using Prism.Common;
 using Prism.Logging;
 using Prism.Navigation;

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -35,7 +35,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Unity" Version="4.0.1" />
+		<PackageReference Include="Unity" Version="5.0.0-beta" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.Unity;
+﻿using Unity;
 using Prism.AppModel;
 using Prism.Common;
 using Prism.Events;

--- a/Source/Xamarin/Prism.Unity.Forms/UnityExtensions.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Microsoft.Practices.Unity;
+using Unity;
 using Xamarin.Forms;
 using Prism.Mvvm;
 using Prism.Navigation;


### PR DESCRIPTION
Unity has a new Maintainer and they just released a preview version of Unity 5.0 and a new ServiceLocator both targeting netstandard 1.0.

This is still preview, but since Prism 7.0.0-alpha is so far also depending on the preview version of Xamarin.Forms, this should be fine.