### PR TITLE
[Fix] RestoreNavigation: Possible KeyNotFoundException

### DIFF
--- a/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/FrameNavigationService.cs
@@ -218,7 +218,7 @@ namespace Prism.Windows.Navigation
             NavigateToCurrentViewModel(new NavigatedToEventArgs()
             {
                 NavigationMode = NavigationMode.Refresh,
-                Parameter = _sessionStateService.SessionState[LastNavigationParameterKey]
+                Parameter = _sessionStateService.SessionState.ContainsKey(LastNavigationParameterKey) ? _sessionStateService.SessionState[LastNavigationParameterKey] : null
             });
         }
 


### PR DESCRIPTION
When following `App.xaml.cs` is used and the app is `suspended` when `resuming` then a KeyNotFoundException is raised:

~~~
sealed partial class App : PrismUnityApplication
{
    public App()
    {
        this.InitializeComponent();
    }

    protected override UIElement CreateShell(Frame rootFrame)
    {
        //only a sample initialization: I use a different one
        rootFrame.Content = new MainPage();
        return rootFrame;
    }

    protected override Task OnLaunchApplicationAsync(LaunchActivatedEventArgs args)
    {
        return Task.FromResult<object>(null);
    }

    protected override void ConfigureContainer()
    {
        base.ConfigureContainer();

        RegisterTypeIfMissing(typeof(IDataRepository), typeof(DataRepository), true);
    }
}
~~~

The reason why I use such a construct and is because I use the `HamburgerMenu` from `UWPCommunityToolkit` and therefore I need a custom initialization for the shell.

# Where does this exception appears

Anytime when the app opens and there is no initial navigation specified. e.g. `NavigationService.Navigate(...,...)`

# Reason for this PR

Fixes #1190

I suggest to merge this change because if, by reason, there is no initial navigation then closing and opening the application will immediately fail.
