### PR TITLE
Symbols

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ end_of_line = CRLF
 [*.cs]
 indent_style = space
 indent_size = 4
+
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,4 +1,31 @@
 <Project>
   <!-- Workaround for https://github.com/dotnet/sdk/pull/908 -->
   <Target Name="GetPackagingOutputs" />
+
+  <PropertyGroup>
+    <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <NeutralLanguage>en</NeutralLanguage>
+    <PackageTags Condition=" '$(IsCoreProject)' == 'True' ">prism;wpf;xamarin;uwp;uap;xaml</PackageTags>
+    <PackageTags Condition=" '$(IsUwpProject)' == 'True' ">prism;mvvm;uwp;dependency injection;di</PackageTags>
+    <PackageTags Condition=" '$(IsWpfProject)' == 'True' ">prism;mvvm;wpf;dependency injection;di</PackageTags>
+    <PackageTags Condition=" '$(IsFormsProject)' == 'True' ">prism;mvvm;uwp;android;ios;xamarin;xamarin.forms;dependency injection;di</PackageTags>
+    <Authors>Brian Lagunas;Brian Noyes</Authors>
+    <Owners>Brian Lagunas;Brian Noyes</Owners>
+    <PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
+    <IncludeSymbols>True</IncludeSymbols>
+    <IncludeSource>True</IncludeSource>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>
+    <PackageOutputPath Condition=" '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">$(BUILD_ARTIFACTSTAGINGDIRECTORY)</PackageOutputPath>
+    <IsCoreProject Condition=" '$(IsCoreProject)' == '' ">False</IsCoreProject>
+    <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
+    <IsUwpProject>$(MSBuildProjectName.Contains('Windows'))</IsUwpProject>
+    <IsWpfProject>$(MSBuildProjectName.Contains('Wpf'))</IsWpfProject>
+    <IsFormsProject>$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
+    <IsPackable>!$(IsTestProject)</IsPackable>
+  </PropertyGroup>
 </Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -9,8 +9,8 @@
     <PackageTags Condition=" '$(IsUwpProject)' == 'True' ">prism;mvvm;uwp;dependency injection;di</PackageTags>
     <PackageTags Condition=" '$(IsWpfProject)' == 'True' ">prism;mvvm;wpf;dependency injection;di</PackageTags>
     <PackageTags Condition=" '$(IsFormsProject)' == 'True' ">prism;mvvm;uwp;android;ios;xamarin;xamarin.forms;dependency injection;di</PackageTags>
-    <Authors>Brian Lagunas;Brian Noyes</Authors>
-    <Owners>Brian Lagunas;Brian Noyes</Owners>
+    <Authors>Brian Lagunas;Bart Lannoeye;Dan Siegel</Authors>
+    <Owners>Brian Lagunas;Bart Lannoeye;Dan Siegel</Owners>
     <PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -28,4 +28,9 @@
     <IsFormsProject>$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
     <IsPackable>!$(IsTestProject)</IsPackable>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <GenerateDocumentationFile>!$(IsTestProject)</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>!$(IsTestProject)</GeneratePackageOnBuild>
+  </PropertyGroup>
 </Project>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -5,10 +5,6 @@
   <PropertyGroup>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageTags Condition=" '$(IsCoreProject)' == 'True' ">prism;wpf;xamarin;uwp;uap;xaml</PackageTags>
-    <PackageTags Condition=" '$(IsUwpProject)' == 'True' ">prism;mvvm;uwp;dependency injection;di</PackageTags>
-    <PackageTags Condition=" '$(IsWpfProject)' == 'True' ">prism;mvvm;wpf;dependency injection;di</PackageTags>
-    <PackageTags Condition=" '$(IsFormsProject)' == 'True' ">prism;mvvm;uwp;android;ios;xamarin;xamarin.forms;dependency injection;di</PackageTags>
     <Authors>Brian Lagunas;Bart Lannoeye;Dan Siegel</Authors>
     <Owners>Brian Lagunas;Bart Lannoeye;Dan Siegel</Owners>
     <PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
@@ -27,6 +23,10 @@
     <IsWpfProject>$(MSBuildProjectName.Contains('Wpf'))</IsWpfProject>
     <IsFormsProject>$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
     <IsPackable>!$(IsTestProject)</IsPackable>
+    <PackageTags Condition=" '$(IsCoreProject)' == 'True' ">prism;wpf;xamarin;uwp;uap;xaml</PackageTags>
+    <PackageTags Condition=" '$(IsUwpProject)' == 'True' ">prism;mvvm;uwp;dependency injection;di</PackageTags>
+    <PackageTags Condition=" '$(IsWpfProject)' == 'True' ">prism;mvvm;wpf;dependency injection;di</PackageTags>
+    <PackageTags Condition=" '$(IsFormsProject)' == 'True' ">prism;mvvm;uwp;android;ios;xamarin;xamarin.forms;dependency injection;di</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -1,47 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<AssemblyName>Prism</AssemblyName>
-		<PackageId>Prism.Core</PackageId>
-		<NeutralLanguage>en</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
-		<Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.</Description>
-		<PackageTags>prism;wpf;xamarin;mvvm;uwp;uap;xaml</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;</TargetFrameworks>
+    <AssemblyName>Prism</AssemblyName>
+    <PackageId>Prism.Core</PackageId>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
+    <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.</Description>
+    <PackageTags>prism;wpf;xamarin;mvvm;uwp;uap;xaml</PackageTags>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-		<SignAssembly>True</SignAssembly>
-		<AssemblyOriginatorKeyFile>..\prism.snk</AssemblyOriginatorKeyFile>
-		<DelaySign>False</DelaySign>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\prism.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>False</DelaySign>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
-		<EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
+    <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -17,7 +17,6 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\prism.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -14,6 +14,10 @@
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">ci</VersionSuffix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\prism.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -1,43 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.1;</TargetFrameworks>
-		<AssemblyName>Prism.Autofac.Forms</AssemblyName>
-		<PackageId>Prism.Autofac.Forms</PackageId>
-		<Title>Autofac for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Autofac extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and Autofac.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;autofac;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  <PropertyGroup>
+   <TargetFrameworks>netstandard1.1;</TargetFrameworks>
+   <Title>Autofac for Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Autofac extensions for Prism for Xamarin.Forms.</Summary>-->
+    <Description>Use these extensions to build Xamarin.Forms applications with Prism and Autofac.</Description>
+    <PackageTags>prism;xamarin;xamarin.forms;autofac;dependency injection</PackageTags>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Autofac" Version="4.6.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.6.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -13,6 +13,10 @@
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">ci</VersionSuffix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -15,11 +15,6 @@
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.0" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -1,43 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<AssemblyName>Prism.DryIoc.Forms</AssemblyName>
-		<PackageId>Prism.DryIoc.Forms</PackageId>
-		<Title>DryIoc for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>DryIoc extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and DryIoc.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;dryioc;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;</TargetFrameworks>
+    <Title>DryIoc for Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>DryIoc extensions for Prism for Xamarin.Forms.</Summary>-->
+    <Description>Use these extensions to build Xamarin.Forms applications with Prism and DryIoc.</Description>
+    <PackageTags>prism;xamarin;xamarin.forms;dryioc;dependency injection</PackageTags>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DryIoc.dll" Version="2.12.2" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="DryIoc.dll" Version="2.12.2" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -13,6 +13,10 @@
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">ci</VersionSuffix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -1,43 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<AssemblyName>Prism.Forms</AssemblyName>
-		<PackageId>Prism.Forms</PackageId>
-		<Title>Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
-		<Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform. Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;mvvm;uwp;ios;android;xaml</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;</TargetFrameworks>
+    <Title>Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
+    <Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform. Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Description>
+    <PackageTags>prism;xamarin;xamarin.forms;mvvm;uwp;ios;android;xaml</PackageTags>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\Prism\Prism.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Prism\Prism.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -13,6 +13,10 @@
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">ci</VersionSuffix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -1,45 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<!-- Targeting netstandard1.3 & netstandard1.5 to match Ninject -->
-		<TargetFrameworks>netstandard1.3;netstandard1.5;</TargetFrameworks>
-		<AssemblyName>Prism.Ninject.Forms</AssemblyName>
-		<PackageId>Prism.Ninject.Forms</PackageId>
-		<Title>Ninject for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Ninject extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and Ninject.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  <PropertyGroup>
+    <!-- Targeting netstandard1.3 & netstandard1.5 to match Ninject -->
+    <TargetFrameworks>netstandard1.3;netstandard1.5;</TargetFrameworks>
+    <Title>Ninject for Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Ninject extensions for Prism for Xamarin.Forms.</Summary>-->
+    <Description>Use these extensions to build Xamarin.Forms applications with Prism and Ninject.</Description>
+    <PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -15,6 +15,10 @@
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">ci</VersionSuffix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -1,45 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard1.0;</TargetFrameworks>
-		<PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
-		<AssemblyName>Prism.Unity.Forms</AssemblyName>
-		<PackageId>Prism.Unity.Forms</PackageId>
-		<Title>Unity for Prism for Xamarin.Forms</Title>
-		<NeutralLanguage>en-US</NeutralLanguage>
-		<!-- Summary is not actually supported at this time. Including the summary for future support. -->
-		<!--<Summary>Unity extensions for Prism for Xamarin.Forms.</Summary>-->
-		<Description>Use these extensions to build Xamarin.Forms applications with Prism and Unity.</Description>
-		<PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
-		<Authors>Brian Lagunas;Brian Noyes</Authors>
-		<Owners>Brian Lagunas;Brian Noyes</Owners>
-		<PackageIconUrl>http://prismlibrary.github.io/images/prism-logo-graphic-128.png</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
-		<PackageLicenseUrl>https://github.com/PrismLibrary/Prism/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
-		<PackageOutputPath>../../Build</PackageOutputPath>
-		<Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-		<!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-		<VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;</TargetFrameworks>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
+    <Title>Unity for Prism for Xamarin.Forms</Title>
+    <!-- Summary is not actually supported at this time. Including the summary for future support. -->
+    <!--<Summary>Unity extensions for Prism for Xamarin.Forms.</Summary>-->
+    <Description>Use these extensions to build Xamarin.Forms applications with Prism and Unity.</Description>
+    <PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
+    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
+    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">7.0.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Unity" Version="4.0.1" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Unity" Version="4.0.1" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Prism.Forms/Prism.Forms.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -15,6 +15,10 @@
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>
+    <!-- This will create CI builds as 7.0.0.1234-ci -->
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">ci</VersionSuffix>
+    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Adds Symbols package to build output
- Refractors build versioning so all projects can set their base version number (7.0.0) with the full prefix being $(VersionSuffix).$(BuildNumber) and the suffix being set simply to ci or pre
- Adding a pre Version Suffix simply requires setting a build variable IS_PREVIEW = true
- Migrates the common PropertyGroup properties into the Directory.Build.props