### PR TITLE
Package updates

### DIFF
--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.4.0.280" />
+    <PackageReference Include="Xamarin.Forms" Version="2.4.0.282" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Ninject.Forms/Extensions/DependencyServiceBindingResolver.cs
+++ b/Source/Xamarin/Prism.Ninject.Forms/Extensions/DependencyServiceBindingResolver.cs
@@ -1,12 +1,12 @@
-﻿using Ninject.Planning.Bindings.Resolvers;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Ninject.Activation;
-using Ninject.Planning.Bindings;
 using Ninject.Components;
-
+using Ninject.Infrastructure;
+using Ninject.Planning.Bindings;
+using Ninject.Planning.Bindings.Resolvers;
 using Binding = Ninject.Planning.Bindings.Binding;
 
 namespace Prism.Ninject.Extensions
@@ -17,7 +17,7 @@ namespace Prism.Ninject.Extensions
     public class DependencyServiceBindingResolver : NinjectComponent, IMissingBindingResolver
     {
         /// <inheritDoc />
-        public IEnumerable<IBinding> Resolve(IDictionary<Type, IEnumerable<IBinding>> bindings, IRequest request)
+        public IEnumerable<IBinding> Resolve(Multimap<Type, IBinding> bindings, IRequest request)
         {
             var service = request.Service;
             if (!service.GetTypeInfo().IsInterface)
@@ -37,5 +37,6 @@ namespace Prism.Ninject.Extensions
             var provider = new DependencyServiceProvider(targetType);
             return ctx => provider;
         }
+
     }
 }

--- a/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
+++ b/Source/Xamarin/Prism.Ninject.Forms/Prism.Ninject.Forms.csproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Targeting netstandard1.3 & netstandard1.5 to match Ninject -->
-    <TargetFrameworks>netstandard1.3;netstandard1.5;</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>Ninject for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Ninject extensions for Prism for Xamarin.Forms.</Summary>-->
@@ -22,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ninject" Version="4.0.0-beta-0134" />
+    <PackageReference Include="Ninject" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
updates Xamarin.Forms to 2.4.0 SR1
updates/downgrades Ninject from 4.0 alpha to v3.3 stable. 
NOTE: change to Ninject version now requires targeting netstandard2.0