### PR TITLE
Tabbed page behavior change

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Droid/HelloWorld.Droid.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Droid/HelloWorld.Droid.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -57,7 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -106,16 +106,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.AppIndexing, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.GooglePlayServices.AppIndexing.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.AppIndexing.dll</HintPath>
@@ -184,8 +184,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props'))" />
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props'))" />
+    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets')" />
 </Project>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Droid/packages.config
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Droid/packages.config
@@ -10,7 +10,7 @@
   <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Forms" version="2.4.0.280" targetFramework="monoandroid71" />
+  <package id="Xamarin.Forms" version="2.4.0.282" targetFramework="monoandroid71" />
   <package id="Xamarin.GooglePlayServices.AppIndexing" version="29.0.0.1" targetFramework="monoandroid60" />
   <package id="Xamarin.GooglePlayServices.Base" version="29.0.0.1" targetFramework="monoandroid60" />
   <package id="Xamarin.GooglePlayServices.Basement" version="29.0.0.1" targetFramework="monoandroid60" />

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.UWP/project.json
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.UWP/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3",
     "Unity": "4.0.1",
-    "Xamarin.Forms": "2.4.0.280"
+    "Xamarin.Forms": "2.4.0.282"
   },
   "frameworks": {
     "uap10.0.10240": {}

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/HelloWorld.iOS.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/HelloWorld.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
@@ -152,16 +152,16 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
@@ -170,8 +170,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props'))" />
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.props'))" />
+    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\netstandard1.0\Xamarin.Forms.targets')" />
 </Project>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/packages.config
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="xamarinios1" />
   <package id="Unity" version="4.0.1" targetFramework="xamarinios1" />
-  <package id="Xamarin.Forms" version="2.4.0.280" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.4.0.282" targetFramework="xamarinios10" />
 </packages>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -33,7 +33,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA/ViewB", animated: false); //works
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
 
-            NavigationService.NavigateAsync($"MyTabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ViewB/ViewA", animated: false);
+            NavigationService.NavigateAsync($"MyTabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ViewB", animated: false);
         }
 
         protected override void RegisterTypes()
@@ -45,8 +45,9 @@ namespace HelloWorld
         }
 
         protected override void ConfigureModuleCatalog()
-        {
-            ModuleCatalog.AddModule(new ModuleInfo(typeof(ModuleA.ModuleAModule)));
+        {            
+            ModuleCatalog.AddModule<ModuleA.ModuleAModule>();
+            //ModuleCatalog.AddModule(new ModuleInfo(typeof(ModuleA.ModuleAModule)));
             //ModuleCatalog.AddModule(new ModuleInfo("ModuleA", typeof(ModuleA.ModuleAModule), InitializationMode.OnDemand));
         }
     }

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -24,7 +24,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync("NavigationPage/ViewA/MyTabbedPage/ViewC/ViewA/ViewB", animated: false); //works
             //NavigationService.NavigateAsync("MyMasterDetail/NavigationPage/MyTabbedPage/ViewC", animated: false); //works
 
-            //NavigationService.NavigateAsync($"MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewA", animated: false); //works
+            //NavigationService.NavigateAsync($"MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewA", animated: false); //works --
             //NavigationService.NavigateAsync($"NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC", animated: false); //works
             //NavigationService.NavigateAsync($"NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
             //NavigationService.NavigateAsync($"NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA", animated: false); //works

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -22,8 +22,18 @@ namespace HelloWorld
             //NavigationService.NavigateAsync("NavigationPage/ViewA/MyTabbedPage", animated: false); //works
             //NavigationService.NavigateAsync("NavigationPage/ViewA/MyTabbedPage/ViewC", animated: false); //works
             //NavigationService.NavigateAsync("NavigationPage/ViewA/MyTabbedPage/ViewC/ViewA/ViewB", animated: false); //works
+            //NavigationService.NavigateAsync("MyMasterDetail/NavigationPage/MyTabbedPage/ViewC", animated: false); //works
 
-            NavigationService.NavigateAsync("MyMasterDetail/NavigationPage/MyTabbedPage/ViewC", animated: false); //
+            //NavigationService.NavigateAsync($"MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewA", animated: false); //works
+            //NavigationService.NavigateAsync($"NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC", animated: false); //works
+            //NavigationService.NavigateAsync($"NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
+            //NavigationService.NavigateAsync($"NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA", animated: false); //works
+            //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC", animated: false); //works
+            //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
+            //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA/ViewB", animated: false); //works
+            //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
+
+            NavigationService.NavigateAsync($"MyTabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ViewB/ViewA", animated: false);
         }
 
         protected override void RegisterTypes()

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -64,13 +64,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.282\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -113,11 +113,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets'))" />
   </Target>
 </Project>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/SomeOtherViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/SomeOtherViewModel.cs
@@ -4,6 +4,7 @@ using Prism.Mvvm;
 using Prism.Modularity;
 using System;
 using Prism.Services;
+using Prism.Navigation;
 
 namespace HelloWorld.ViewModels
 {
@@ -29,6 +30,21 @@ namespace HelloWorld.ViewModels
         void ShowDialog()
         {
             _dialogService.DisplayAlertAsync("Hello from SomeOtherViewModel", "This is a message from an exception to the ViewModelLocator rules.", "Cool");
+        }
+
+        public override void OnNavigatedFrom(NavigationParameters parameters)
+        {
+            base.OnNavigatedFrom(parameters);
+        }
+
+        public override void OnNavigatedTo(NavigationParameters parameters)
+        {
+            base.OnNavigatedTo(parameters);
+        }
+
+        public override void OnNavigatingTo(NavigationParameters parameters)
+        {
+            base.OnNavigatingTo(parameters);
         }
     }
 }

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/packages.config
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="portable45-net45+win8+wp8" />
   <package id="Unity" version="4.0.1" targetFramework="portable45-net45+win8+wp8" />
-  <package id="Xamarin.Forms" version="2.4.0.280" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.4.0.282" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleA.csproj
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleA.csproj
@@ -82,13 +82,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.4.0.280\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.4.0.282\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.4.0.280\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.4.0.282\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.4.0.280\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.4.0.282\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -125,11 +125,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.4.0.280\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.4.0.282\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets'))" />
   </Target>
 </Project>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/MyTabbedPageViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/MyTabbedPageViewModel.cs
@@ -1,8 +1,9 @@
 ﻿using Prism.Mvvm;
+using Prism.Navigation;
 
 namespace ModuleA.ViewModels
 {
-    public class MyTabbedPageViewModel : BindableBase
+    public class MyTabbedPageViewModel : BindableBase, INavigationAware
     {
         private IApplicationCommands _applicationCommands;
         public IApplicationCommands ApplicationCommands
@@ -14,6 +15,21 @@ namespace ModuleA.ViewModels
         public MyTabbedPageViewModel(IApplicationCommands applicationCommands)
         {
             _applicationCommands = applicationCommands;
+        }
+
+        public void OnNavigatedFrom(NavigationParameters parameters)
+        {
+            
+        }
+
+        public void OnNavigatedTo(NavigationParameters parameters)
+        {
+            
+        }
+
+        public void OnNavigatingTo(NavigationParameters parameters)
+        {
+            
         }
     }
 }

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/packages.config
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="portable45-net45+win8+wp8" />
   <package id="Unity" version="4.0.1" targetFramework="portable45-net45+win8+wp8" />
-  <package id="Xamarin.Forms" version="2.4.0.280" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xamarin.Forms" version="2.4.0.282" targetFramework="portable45-net45+win8+wp8" />
 </packages>

--- a/Source/Xamarin/Prism.Forms.Tests/Common/PageUtilitiesFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Common/PageUtilitiesFixture.cs
@@ -141,45 +141,80 @@ namespace Prism.Forms.Tests.Common
             var recorder = new PageNavigationEventRecorder();
             var tabbedPage = new TabbedPageMock(recorder);
             var tabbedPageViewModel = tabbedPage.BindingContext;
-            var childPage1 = tabbedPage.Children[0];
-            var childPage1ViewModel = childPage1.BindingContext;
-            var childPage2 = tabbedPage.Children[1];
-            var childPage2ViewModel = childPage2.BindingContext;
-            var childPage3 = tabbedPage.Children[2];
-            var childPage3ViewModel = childPage3.BindingContext;
+            var tab1 = tabbedPage.Children[0];
+            var tab1ViewModel = tab1.BindingContext;
+            var tab2 = tabbedPage.Children[1];
+            var tab2ViewModel = tab2.BindingContext;
+            var tab3 = tabbedPage.Children[2];
+            var tab3ViewModel = tab3.BindingContext;
+            var tab4 = tabbedPage.Children[3];
+            var tab4Child = ((NavigationPage)tab4).CurrentPage;
+            var tab4ViewModel = tab4.BindingContext;
+            var tab4ChildViewModel = tab4Child.BindingContext;
+            var tab5 = tabbedPage.Children[4];
+            var tab5Child = ((NavigationPage)tab5).CurrentPage;
+            var tab5ViewModel = tab5.BindingContext;
+            var tab5ChildViewModel = tab5Child.BindingContext;
+
 
             PageUtilities.DestroyPage(tabbedPage);
 
-            Assert.Equal(6, recorder.Records.Count);
+            Assert.Equal(13, recorder.Records.Count);
 
-            // childPage3
-            Assert.Equal(childPage3, recorder.Records[0].Sender);
-            Assert.Null(childPage3.BindingContext);
-            Assert.Equal(0, childPage3.Behaviors.Count);
+            //tab 5
+            Assert.Equal(tab5ViewModel, recorder.Records[0].Sender);
             Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[0].Event);
 
-            Assert.Equal(childPage3ViewModel, recorder.Records[1].Sender);
+            Assert.Equal(tab5, recorder.Records[1].Sender);
+            Assert.Equal(0, tab5.Behaviors.Count);
             Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[1].Event);
-
-            // childPage2 : PageMck has no binding context so it has no entries.
-
-            // childPage1
-            Assert.Equal(childPage1, recorder.Records[2].Sender);
-            Assert.Null(childPage1.BindingContext);
-            Assert.Equal(0, childPage1.Behaviors.Count);
+            
+            Assert.Equal(tab5ChildViewModel, recorder.Records[2].Sender);
             Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[2].Event);
 
-            Assert.Equal(childPage1ViewModel, recorder.Records[3].Sender);
+            //tab 4
+            Assert.Equal(tab4Child, recorder.Records[3].Sender);
+            Assert.Equal(0, tab4Child.Behaviors.Count);
             Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[3].Event);
 
-            // tabbedPage
-            Assert.Equal(tabbedPage, recorder.Records[4].Sender);
-            Assert.Null(tabbedPage.BindingContext);
-            Assert.Equal(0, tabbedPage.Behaviors.Count);
+            Assert.Equal(tab4ChildViewModel, recorder.Records[4].Sender);
             Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[4].Event);
 
-            Assert.Equal(tabbedPageViewModel, recorder.Records[5].Sender);
+            Assert.Equal(tab4, recorder.Records[5].Sender);
+            Assert.Equal(0, tab4.Behaviors.Count);
             Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[5].Event);
+
+            Assert.Equal(tab4ViewModel, recorder.Records[6].Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[6].Event);
+
+            //tab 3
+            Assert.Equal(tab3, recorder.Records[7].Sender);
+            Assert.Null(tab3.BindingContext);
+            Assert.Equal(0, tab3.Behaviors.Count);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[7].Event);
+
+            Assert.Equal(tab3ViewModel, recorder.Records[8].Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[8].Event);
+
+            //tab 2 : PageMock has no binding context so it has no entries.
+
+            //tab 1
+            Assert.Equal(tab1, recorder.Records[9].Sender);
+            Assert.Null(tab1.BindingContext);
+            Assert.Equal(0, tab1.Behaviors.Count);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[9].Event);
+
+            Assert.Equal(tab1ViewModel, recorder.Records[10].Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[10].Event);
+
+            //TabbedPage
+            Assert.Equal(tabbedPage, recorder.Records[11].Sender);
+            Assert.Null(tabbedPage.BindingContext);
+            Assert.Equal(0, tabbedPage.Behaviors.Count);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[11].Event);
+
+            Assert.Equal(tabbedPageViewModel, recorder.Records[12].Sender);
+            Assert.Equal(PageNavigationEvent.Destroy, recorder.Records[12].Event);
         }
 
         [Fact]

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationRecord.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationRecord.cs
@@ -10,5 +10,10 @@
             Sender = sender;
             Event = @event;
         }
+
+        public override string ToString()
+        {
+            return $"{Sender} - {Event}";
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/NavigationPageMock.cs
@@ -29,7 +29,7 @@ namespace Prism.Forms.Tests.Mocks.Views
         public void Destroy()
         {
             DestroyCalled = true;
-            PageNavigationEventRecorder.Record(this, PageNavigationEvent.Destroy);
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.Destroy);
         }
 
         public bool ClearNavigationStackOnNavigation { get; set; } = true;

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
@@ -20,6 +20,8 @@ namespace Prism.Forms.Tests.Mocks.Views
             Children.Add(new ContentPageMock(recorder) { Title = "Page 1" });
             Children.Add(new PageMock() { Title = "Page 2", BindingContext = null });
             Children.Add(new ContentPageMock(recorder) { Title = "Page 3" });
+            Children.Add(new NavigationPageMock(recorder, new ContentPageMock(recorder)) { Title = "Page 4" });
+            Children.Add(new NavigationPageMock(recorder, new PageMock()) { Title = "Page 5" });
 
             PageNavigationEventRecorder = recorder;
 

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -198,7 +198,7 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(recorder.IsEmpty);
         }
 
-      
+
 
         [Fact]
         public async void Navigate_ToContentPage_ByName_WithNavigationParameters()
@@ -258,7 +258,7 @@ namespace Prism.Forms.Tests.Navigation
             var tabbedPageMock = rootPage.CurrentPage as TabbedPageMock;
             Assert.NotNull(tabbedPageMock);
             var viewModel = (ViewModelBase)tabbedPageMock.BindingContext;
-            
+
             await navigationService.GoBackAsync();
 
             Assert.True(rootPage.Navigation.NavigationStack.Count == 1);
@@ -1024,22 +1024,6 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(rootPage.Navigation.ModalStack[0].Navigation.ModalStack.Count == 1);
         }
 
-
-        [Fact]
-        public async void Navigate_ToTabbedPage_SelectedTab()
-        {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var rootPage = new Xamarin.Forms.ContentPage();
-            ((IPageAware)navigationService).Page = rootPage;
-
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
-
-            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
-            Assert.NotNull(tabbedPage);
-            Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
-        }
-
         [Fact]
         public async void DeepNavigate_ToCarouselPage_ToContentPage()
         {
@@ -1347,6 +1331,218 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         #endregion
+
+        #region TabbedPage
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromNavigationPage_ToTabbedPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage");
+
+            Assert.True(rootPage.Navigation.NavigationStack.Count == 1);
+            Assert.IsType<TabbedPageMock>(rootPage.Navigation.NavigationStack[0]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage/ContentPage");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+
+            Assert.True(tabbedPage.Navigation.ModalStack.Count > 0);
+
+            Assert.IsType<ContentPageMock>(tabbedPage.Navigation.ModalStack[0]);
+        }
+
+        [Fact]
+        public async void Navigate_FromNavigationPage_ToTabbedPage_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage/ContentPage");
+
+            Assert.True(rootPage.Navigation.NavigationStack.Count == 2);
+            Assert.IsType<TabbedPageMock>(rootPage.Navigation.NavigationStack[0]);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.NavigationStack[1]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_NavigationPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ContentPage");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+
+            var navPage = tabbedPage.CurrentPage as NavigationPageMock;
+            Assert.NotNull(navPage);
+            Assert.IsType<ContentPageMock>(navPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+
+            var contentPage = tabbedPage.Navigation.ModalStack[0] as ContentPageMock;
+            Assert.NotNull(contentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromNavigationPage_ToTabbedPage_SelectedTab_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
+
+            Assert.True(rootPage.Navigation.NavigationStack.Count == 2);
+
+            var tabbedPage = rootPage.Navigation.NavigationStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+
+            var contentPage = tabbedPage.Navigation.NavigationStack[1] as ContentPageMock;
+            Assert.NotNull(contentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromNavigationPage_ToTabbedPage_SelectedTab_NavigationPage_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ContentPage/ContentPage");
+
+            Assert.True(rootPage.Navigation.NavigationStack.Count == 2);
+
+            var tabbedPage = rootPage.Navigation.NavigationStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType<NavigationPageMock>(tabbedPage.CurrentPage);
+
+            var navPage = tabbedPage.CurrentPage as NavigationPageMock;
+            Assert.NotNull(navPage);
+            Assert.IsType<ContentPageMock>(navPage.CurrentPage);
+
+            var contentPage = tabbedPage.Navigation.NavigationStack[1] as ContentPageMock;
+            Assert.NotNull(contentPage);            
+        }
+
+        [Fact]
+        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.MasterDetailPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"NavigationPage/TabbedPage/ContentPage");
+
+            Assert.IsType<NavigationPageMock>(rootPage.Detail);
+
+            Assert.True(rootPage.Detail.Navigation.NavigationStack.Count == 2);
+
+            Assert.IsType<TabbedPageMock>(rootPage.Detail.Navigation.NavigationStack[0]);
+            Assert.IsType<ContentPageMock>(rootPage.Detail.Navigation.NavigationStack[1]);
+        }
+
+        [Fact]
+        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_SelectedTab()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.MasterDetailPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+
+            Assert.IsType<NavigationPageMock>(rootPage.Detail);
+
+            Assert.True(rootPage.Detail.Navigation.NavigationStack.Count == 1);
+
+            var tabbedPage = rootPage.Detail.Navigation.NavigationStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_SelectedTab_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.MasterDetailPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
+
+            Assert.IsType<NavigationPageMock>(rootPage.Detail);
+
+            Assert.True(rootPage.Detail.Navigation.NavigationStack.Count == 2);
+
+            Assert.IsType<TabbedPageMock>(rootPage.Detail.Navigation.NavigationStack[0]);            
+            Assert.IsType<PageMock>(((TabbedPageMock)rootPage.Detail.Navigation.NavigationStack[0]).CurrentPage);
+
+            Assert.IsType<ContentPageMock>(rootPage.Detail.Navigation.NavigationStack[1]);
+        }
+
+        #endregion
+
 
         public void Dispose()
         {

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -803,13 +803,13 @@ namespace Prism.Forms.Tests.Navigation
 
 
         [Fact]
-        public async Task DeepNavigate_ToNavigationPage_ToTabbedPage_ToContentPage()
+        public async Task DeepNavigate_ToNavigationPage_ToTabbedPage_SelectContentPage()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync("NavigationPage/ContentPage/TabbedPage/PageMock");
+            await navigationService.NavigateAsync($"NavigationPage/ContentPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
 
             var navPage = rootPage.Navigation.ModalStack[0] as NavigationPageMock;
             Assert.NotNull(navPage);
@@ -1024,14 +1024,15 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(rootPage.Navigation.ModalStack[0].Navigation.ModalStack.Count == 1);
         }
 
+
         [Fact]
-        public async void DeepNavigate_ToTabbedPage_ToPage()
+        public async void Navigate_ToTabbedPage_SelectedTab()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync("TabbedPage/PageMock");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
 
             var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
@@ -1309,13 +1310,13 @@ namespace Prism.Forms.Tests.Navigation
 
 
         [Fact]
-        public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToTabbedPage_ToPage()
+        public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToTabbedPage_SelectTab()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync("MasterDetailPage-Empty/NavigationPage/TabbedPage/PageMock");
+            await navigationService.NavigateAsync($"MasterDetailPage-Empty/NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
 
             var mdpPage = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
             var navPage = mdpPage.Detail as NavigationPageMock;
@@ -1327,13 +1328,13 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToContentPage_ToTabbedPage_ToPage()
+        public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToContentPage_ToTabbedPage_SelectTab()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync("MasterDetailPage-Empty/NavigationPage/ContentPage/TabbedPage/PageMock");
+            await navigationService.NavigateAsync($"MasterDetailPage-Empty/NavigationPage/ContentPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
 
             var mdpPage = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
             var navPage = mdpPage.Detail as NavigationPageMock;

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -1024,21 +1024,6 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(rootPage.Navigation.ModalStack[0].Navigation.ModalStack.Count == 1);
         }
 
-        [Fact]
-        public async void DeepNavigate_ToCarouselPage_ToContentPage()
-        {
-            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
-            var rootPage = new Xamarin.Forms.ContentPage();
-            ((IPageAware)navigationService).Page = rootPage;
-
-            await navigationService.NavigateAsync("CarouselPage/ContentPage");
-
-            var tabbedPage = rootPage.Navigation.ModalStack[0] as CarouselPageMock;
-            Assert.NotNull(tabbedPage);
-            Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<ContentPageMock>(tabbedPage.CurrentPage);
-        }
-
         #region MasterDetailPage
 
         [Fact]
@@ -1539,6 +1524,56 @@ namespace Prism.Forms.Tests.Navigation
             Assert.IsType<PageMock>(((TabbedPageMock)rootPage.Detail.Navigation.NavigationStack[0]).CurrentPage);
 
             Assert.IsType<ContentPageMock>(rootPage.Detail.Navigation.NavigationStack[1]);
+        }
+
+        #endregion
+
+        #region CarouselPage
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToCarouselPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("CarouselPage");
+
+            Assert.True(rootPage.Navigation.ModalStack.Count == 1);
+            Assert.IsType<CarouselPageMock>(rootPage.Navigation.ModalStack[0]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToCarouselPage_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync("CarouselPage/ContentPage");
+
+            Assert.True(rootPage.Navigation.ModalStack.Count == 1);
+            Assert.IsType<CarouselPageMock>(rootPage.Navigation.ModalStack[0]);
+
+            var carouselPage = (CarouselPageMock)rootPage.Navigation.ModalStack[0];
+
+            Assert.True(carouselPage.Navigation.ModalStack.Count == 1);
+            Assert.IsType<ContentPageMock>(carouselPage.Navigation.ModalStack[0]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToCarouselPage_SelectedPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"CarouselPage?{KnownNavigationParameters.SelectedTab}=ContentPage");
+
+            var carouselPage = rootPage.Navigation.ModalStack[0] as CarouselPageMock;
+            Assert.NotNull(carouselPage);
+            Assert.NotNull(carouselPage.CurrentPage);
+            Assert.IsType<ContentPageMock>(carouselPage.CurrentPage);
         }
 
         #endregion

--- a/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
@@ -3,5 +3,6 @@
     public static class KnownNavigationParameters
     {
         public const string NavigationMode = "__NavigationMode";
+        public const string SelectedTab = "__SelectedTab";
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
@@ -2,7 +2,8 @@
 {
     public static class KnownNavigationParameters
     {
-        public const string NavigationMode = "navigationMode";
+        public const string NavigationMode = "__NavigationMode";
+
         public const string SelectedTab = "selectedTab";
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
@@ -2,7 +2,7 @@
 {
     public static class KnownNavigationParameters
     {
-        public const string NavigationMode = "__NavigationMode";
-        public const string SelectedTab = "__SelectedTab";
+        public const string NavigationMode = "navigationMode";
+        public const string SelectedTab = "selectedTab";
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -488,21 +488,13 @@ namespace Prism.Navigation
                     if (child is NavigationPage)
                     {
                         var childTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabChildSegment));
-                        var navPage = (NavigationPage)child;
-                        if (navPage.CurrentPage.GetType() != childTabType)
+                        if (((NavigationPage)child).CurrentPage.GetType() != childTabType)
                             continue;
                     }
 
                     tabbedPage.CurrentPage = child;
                     break;
                 }
-
-                //TODO: figure out how to perform nested navigation without invoking the INavAware methods twice
-                //if (tabbedPage.CurrentPage is NavigationPage && selectedTabSegements.Count > 0)
-                //{
-                //    var nextSegment = selectedTabSegements.Dequeue();
-                //    await ProcessNavigationForNavigationPage((NavigationPage)tabbedPage.CurrentPage, nextSegment, selectedTabSegements, null, false, false, false);
-                //}
             }
         }
 

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -241,8 +241,6 @@ namespace Prism.Navigation
                 if (segments.Count > 0)
                     await UseReverseNavigation(topPage, segments.Dequeue(), segments, parameters, false, animated);
 
-                //await ProcessNavigation(topPage, segments, parameters, false, animated);
-
                 await DoNavigateAction(topPage, nextSegment, topPage, parameters);
             }
             else
@@ -261,30 +259,18 @@ namespace Prism.Navigation
 
         protected virtual async Task ProcessNavigationForTabbedPage(TabbedPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
-            var nextSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
-            foreach (var child in currentPage.Children)
-            {
-                if (child.GetType() != nextSegmentType)
-                    continue;
-
-                await ProcessNavigation(child, segments, parameters, useModalNavigation, animated);
-                await DoNavigateAction(null, nextSegment, child, parameters, onNavigationActionCompleted: () =>
-                {
-                    currentPage.CurrentPage = child;
-                });
-                return;
-            }
-
+            //TODO: find a way to control how you navigate from the tab during deep link
             var nextPage = CreatePageFromSegment(nextSegment);
             await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
-            await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
+            await DoNavigateAction(currentPage.CurrentPage, nextSegment, nextPage, parameters, async () => //not sure about the CurrentPage.
             {
-                await DoPush(currentPage, nextPage, useModalNavigation, animated);
+                await DoPush(currentPage.CurrentPage, nextPage, useModalNavigation, animated);
             });
         }
 
         protected virtual async Task ProcessNavigationForCarouselPage(CarouselPage currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
+            //TODO: do the same thing we did for TabbedPage
             var nextSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
             foreach (var child in currentPage.Children)
             {
@@ -395,17 +381,64 @@ namespace Prism.Navigation
             if (!canNavigate)
                 return;
 
-            PageUtilities.OnNavigatingTo(toPage, segmentParameters);
+            OnNavigatingTo(toPage, segmentParameters);
 
             if (navigationAction != null)
                 await navigationAction();
 
-            PageUtilities.OnNavigatedFrom(fromPage, segmentParameters);
+            OnNavigatedFrom(fromPage, segmentParameters);
 
             onNavigationActionCompleted?.Invoke();
 
-            PageUtilities.OnNavigatedTo(toPage, segmentParameters);
+            OnNavigatedTo(toPage, segmentParameters);
         }
+
+        static void OnNavigatingTo(Page toPage, NavigationParameters parameters)
+        {
+            PageUtilities.OnNavigatingTo(toPage, parameters);
+
+            if (toPage is TabbedPage)
+            {
+                var tabbedPage = (TabbedPage)toPage;
+                foreach (var child in tabbedPage.Children)
+                {
+                    if (child is NavigationPage)
+                    {
+                        var navigationPage = (NavigationPage)child;
+                        PageUtilities.OnNavigatingTo(navigationPage.CurrentPage, parameters);
+                    }
+                    else
+                    {
+                        PageUtilities.OnNavigatingTo(child, parameters);
+                    }
+                }
+            }
+        }
+
+        private static void OnNavigatedTo(Page toPage, NavigationParameters parameters)
+        {
+            PageUtilities.OnNavigatedTo(toPage, parameters);
+        }
+
+        private static void OnNavigatedFrom(Page fromPage, NavigationParameters parameters)
+        {
+            PageUtilities.OnNavigatedFrom(fromPage, parameters);
+
+            if (fromPage is TabbedPage)
+            {
+                var tabbedPage = (TabbedPage)fromPage;
+                if (tabbedPage.CurrentPage is NavigationPage)
+                {
+                    var navigationPage = (NavigationPage)tabbedPage.CurrentPage;
+                    PageUtilities.OnNavigatedFrom(navigationPage.CurrentPage, parameters);
+                }
+                else
+                {
+                    PageUtilities.OnNavigatedFrom(tabbedPage.CurrentPage, parameters);
+                }
+            }
+        }
+
 
         protected abstract Page CreatePage(string segmentName);
 
@@ -418,6 +451,11 @@ namespace Prism.Navigation
                 if (page == null)
                     throw new NullReferenceException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
 
+                if (page is TabbedPage)
+                {
+                    ConfigureTabbedPage((TabbedPage)page, segment);
+                }
+
                 SetAutowireViewModelOnPage(page);
                 ApplyPageBehaviors(page);
 
@@ -427,6 +465,35 @@ namespace Prism.Navigation
             {
                 _logger.Log(e.ToString(), Category.Exception, Priority.High);
                 throw;
+            }
+        }
+
+        void ConfigureTabbedPage(TabbedPage tabbedPage, string segment)
+        {
+            //TODO: handle adding dynamic tabs
+
+            var selectedTab = UriParsingHelper.GetSegmentParameters(segment).GetValue<string>(KnownNavigationParameters.SelectedTab);
+            if (!string.IsNullOrWhiteSpace(selectedTab))
+            {
+                //selected tab can be a single view or a view nested in a navigationpage with the syntax "NavigationPage-View"
+                var selectedTabSegements = selectedTab.Split('|');    //we will have at least one, and no more than two            
+                var selectedTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabSegements[0]));                
+
+                foreach (var child in tabbedPage.Children)
+                {
+                    if (child.GetType() != selectedTabType)
+                        continue;
+
+                    if (child is NavigationPage)
+                    {
+                        var childTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabSegements[1]));
+                        var navPage = (NavigationPage)child;
+                        if (navPage.CurrentPage.GetType() != childTabType)
+                            continue;
+                    }
+
+                    tabbedPage.CurrentPage = child;
+                }
             }
         }
 
@@ -462,8 +529,11 @@ namespace Prism.Navigation
         {
             bool useModalNavigation = true;
 
+
             if (useModalNavigationDefault.HasValue)
                 useModalNavigation = useModalNavigationDefault.Value;
+            else if (currentPage is NavigationPage)
+                useModalNavigation = false;
             else
                 useModalNavigation = !HasNavigationPageParent(currentPage);
 
@@ -488,49 +558,17 @@ namespace Prism.Navigation
 
         protected virtual async Task UseReverseNavigation(Page currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
-            if (String.IsNullOrWhiteSpace(nextSegment))
-                return;
-
             var navigationStack = new Stack<string>();
-            
-            var nextSegmentPageType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
-            if (IsSameOrSubclassOf<TabbedPage>(nextSegmentPageType))
-            {
-                var tabbedPage = (TabbedPage)CreatePageFromSegment(nextSegment);
 
-                if (segments.Count > 0)
-                {
-                    nextSegment = segments.Dequeue();
-                    nextSegmentPageType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
-
-                    foreach (var child in tabbedPage.Children)
-                    {
-                        if (child.GetType() != nextSegmentPageType)
-                            continue;
-
-                        tabbedPage.CurrentPage = child;
-                    }
-                }                
-
-                await DoNavigateAction(currentPage, nextSegment, tabbedPage, parameters, async () =>
-                {
-                    await DoPush(currentPage, tabbedPage, useModalNavigation, animated, false);
-                });
-
-                currentPage = tabbedPage;
-            }
-            else
-            {
+            if (!String.IsNullOrWhiteSpace(nextSegment))
                 navigationStack.Push(nextSegment);
-            }
-
 
             var illegalSegments = new Queue<string>();
 
             bool illegalPageFound = false;
             foreach (var item in segments)
             {
-                //if we run into an illegal page, we need to create new navigation segments to properly handle the deep link
+                //if we run itno an illegal page, we need to create new navigation segments to properly handle the deep link
                 if (illegalPageFound)
                 {
                     illegalSegments.Enqueue(item);
@@ -556,48 +594,12 @@ namespace Prism.Navigation
             bool insertBefore = false;
             while (navigationStack.Count > 0)
             {
-                Page nextPage = null;
                 var segment = navigationStack.Pop();
-
-                if (navigationStack.Count > 0)
-                {
-                    //since we are building the stack backwards, check next segment to see if it's a tabbedpage
-                    var peekSegment = navigationStack.Peek();
-                    var peekSegmentType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(peekSegment));
-
-                    //if we have a TabbedPage we must see if the prior segment is a child so we can select the tab
-                    if (IsSameOrSubclassOf<TabbedPage>(peekSegmentType))
-                    {
-                        var tabbedPageSegment = navigationStack.Pop();
-                        var tabbedPage = (TabbedPage)CreatePageFromSegment(tabbedPageSegment);
-
-                        var childPageType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(segment));
-
-                        foreach (var child in tabbedPage.Children)
-                        {
-                            if (child.GetType() != childPageType)
-                                continue;
-
-                            await DoNavigateAction(null, segment, child, parameters, onNavigationActionCompleted: () =>
-                            {
-                                tabbedPage.CurrentPage = child;
-                            });
-                        }
-
-                        nextPage = tabbedPage;
-                    }
-                }  
-                
-                if (nextPage == null)
-                {
-                    nextPage = CreatePageFromSegment(segment);
-                }               
-
+                var nextPage = CreatePageFromSegment(segment);
                 await DoNavigateAction(currentPage, segment, nextPage, parameters, async () =>
                 {
                     await DoPush(currentPage, nextPage, useModalNavigation, animated, insertBefore, pageOffset);
                 });
-
                 insertBefore = true;
             }
 


### PR DESCRIPTION
We are making a **breaking change** to the behavior of navigating to a TabbedPage.

## Current Behavior (v6.3.0)
`NavigateAsync("TabbedPage/ViewA/ViewB")` will select the tab ViewA in the TabbedPage if it exists, then continue navigating.  If ViewA does not exist as a tab, then you will continue to navigate as expected.

`NavigateAsync("TabbedPage/NavigationPage/ViewA/ViewB")` would search the TabbedPage for the first instance of a tab that was a NavigationPage, then navigate within the Navigation page the remaining ViewA and ViewB pages.  This provided the ability to deep link into a tab's nested navigation page, but there was no way to opt-out of this behavior.

Also, the INavigationAware methods did not get called to all tabs meaning that you would be responsible for forwarding any parameters to all your tabs.

## New Behavior
`NavigateAsync("TabbedPage/ViewA/ViewB")` will **no longer** select any tabs, but rather continue processing the navigation as separate pages on the navigation stack.

If you wish to select a tab, you will now use a parameter called "selectedTab" to indicate which tab you would like to select.

`NavigateAsync("TabbedPage?selectedTab=MiddleTab/ViewA/ViewB")`

This will navigate to the TabbedPage, selected the "MiddleTab" and continue navigating ViewA and ViewB onto the navigation stack.

For tabs that are wrapped inside a NavigationPage, you can use the "|" symbol to indicate the hierarchy.

`NavigateAsync("TabbedPage?selectedTab=NavigationPage|MiddleTab")`

There is a constant in the `KnownNavigationParameters` called `SelectedTab` that you can use instead of a string.

`NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=MiddleTab")`

This will search each tab to see if it is a navigation page and if the first page on the stack matches "MiddleTab".  This is much more flexible than the existing behavior as before it would take the first instance of the NavigationPage found.  Now you can choose which tab exactly.

Some INavigationAware methods are now fired on all Tabs:
- OnNavigatingTo will be invoked on the TabbedPage and ALL TABS.
- OnNavigatedTo will be invoked on the TabbedPage and only the SELECTED TAB.
- OnNavigatedFrom will be invoked on the TabbedPage and only the SELECTED TAB.

**Note**: the parameter key `selectedTab` is now a reserved parameter name.  Similar to a reserved keyword in C#.  If you use this in your app as a key, you may experience undesired behavior.

**Note**: At this time there is no native support for deep linking into a Tab that is a navigation page.  Please let me know if you need this functionality.

