### PR TITLE
Rename IApplicationLifecycle to IApplicationLifecycleAware

### DIFF
--- a/Source/Xamarin/Prism.Forms/AppModel/IApplicationLifecycleAware.cs
+++ b/Source/Xamarin/Prism.Forms/AppModel/IApplicationLifecycleAware.cs
@@ -1,6 +1,6 @@
 ﻿namespace Prism.AppModel
 {
-    public interface IApplicationLifecycle
+    public interface IApplicationLifecycleAware
     {
         void OnResume();
 

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -170,13 +170,13 @@ namespace Prism
         protected override void OnResume()
         {
             var page = PageUtilities.GetCurrentPage(MainPage);
-            PageUtilities.InvokeViewAndViewModelAction<AppModel.IApplicationLifecycle>(page, x => x.OnResume());
+            PageUtilities.InvokeViewAndViewModelAction<AppModel.IApplicationLifecycleAware>(page, x => x.OnResume());
         }
 
         protected override void OnSleep()
         {
             var page = PageUtilities.GetCurrentPage(MainPage);
-            PageUtilities.InvokeViewAndViewModelAction<AppModel.IApplicationLifecycle>(page, x => x.OnSleep());
+            PageUtilities.InvokeViewAndViewModelAction<AppModel.IApplicationLifecycleAware>(page, x => x.OnSleep());
         }
 
         private void PrismApplicationBase_ModalPopping(object sender, ModalPoppingEventArgs e)


### PR DESCRIPTION
Fixes issue #1198.

Changes proposed in this pull request:
- Rename IApplicationLifecycle to IApplicationLifecycleAware