### PR TITLE
added behavior and set VML to children

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Views/TabbedPageMock.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Mvvm;
+﻿using Prism.Forms.Tests.Navigation.Mocks.Views;
+using Prism.Mvvm;
 using Prism.Navigation;
 using Xamarin.Forms;
 
@@ -17,9 +18,9 @@ namespace Prism.Forms.Tests.Mocks.Views
         {
             ViewModelLocator.SetAutowireViewModel(this, true);
 
-            Children.Add(new ContentPageMock(recorder) { Title = "Page 1" });
-            Children.Add(new PageMock() { Title = "Page 2", BindingContext = null });
-            Children.Add(new ContentPageMock(recorder) { Title = "Page 3" });
+            Children.Add(new Tab1Mock(recorder) { Title = "Page 1" });
+            Children.Add(new Tab2Mock() { Title = "Page 2", BindingContext = null });
+            Children.Add(new Tab3Mock(recorder) { Title = "Page 3" });
             Children.Add(new NavigationPageMock(recorder, new ContentPageMock(recorder)) { Title = "Page 4" });
             Children.Add(new NavigationPageMock(recorder, new PageMock()) { Title = "Page 5" });
 

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/Tab1MockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/Tab1MockViewModel.cs
@@ -1,0 +1,8 @@
+﻿using Prism.Forms.Tests.Mocks.ViewModels;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.ViewModels
+{
+    public class Tab1MockViewModel : ViewModelBase
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/Tab2MockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/Tab2MockViewModel.cs
@@ -1,0 +1,8 @@
+﻿using Prism.Forms.Tests.Mocks.ViewModels;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.ViewModels
+{
+    public class Tab2MockViewModel : ViewModelBase
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/Tab3MockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/Tab3MockViewModel.cs
@@ -1,0 +1,8 @@
+﻿using Prism.Forms.Tests.Mocks.ViewModels;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.ViewModels
+{
+    public class Tab3MockViewModel : ViewModelBase
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/Tab1Mock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/Tab1Mock.cs
@@ -1,0 +1,17 @@
+﻿using Prism.Forms.Tests.Mocks;
+using Prism.Forms.Tests.Mocks.Views;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.Views
+{
+    public class Tab1Mock : ContentPageMock
+    {
+        public Tab1Mock() : this(null)
+        {
+        }
+
+        public Tab1Mock(PageNavigationEventRecorder recorder) : base (recorder)
+        {
+            
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/Tab2Mock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/Tab2Mock.cs
@@ -1,0 +1,17 @@
+﻿using Prism.Forms.Tests.Mocks;
+using Prism.Forms.Tests.Mocks.Views;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.Views
+{
+    public class Tab2Mock : ContentPageMock
+    {
+        public Tab2Mock() : this(null)
+        {
+        }
+
+        public Tab2Mock(PageNavigationEventRecorder recorder) : base (recorder)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/Tab3Mock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/Tab3Mock.cs
@@ -1,0 +1,17 @@
+﻿using Prism.Forms.Tests.Mocks;
+using Prism.Forms.Tests.Mocks.Views;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.Views
+{
+    public class Tab3Mock: ContentPageMock
+    {
+        public Tab3Mock() : this(null)
+        {
+        }
+
+        public Tab3Mock(PageNavigationEventRecorder recorder) : base (recorder)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -2,6 +2,7 @@
 using Prism.Forms.Tests.Mocks;
 using Prism.Forms.Tests.Mocks.ViewModels;
 using Prism.Forms.Tests.Mocks.Views;
+using Prism.Forms.Tests.Navigation.Mocks.Views;
 using Prism.Logging;
 using Prism.Navigation;
 using System;
@@ -41,6 +42,11 @@ namespace Prism.Forms.Tests.Navigation
 
 
             _container.Register("TabbedPage", typeof(TabbedPageMock));
+            _container.Register("Tab1", typeof(Tab1Mock));
+            _container.Register("Tab2", typeof(Tab2Mock));
+            _container.Register("Tab3", typeof(Tab3Mock));
+
+
             _container.Register("CarouselPage", typeof(CarouselPageMock));
 
             _applicationProvider = new ApplicationProviderMock();
@@ -809,7 +815,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"NavigationPage/ContentPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+            await navigationService.NavigateAsync($"NavigationPage/ContentPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2");
 
             var navPage = rootPage.Navigation.ModalStack[0] as NavigationPageMock;
             Assert.NotNull(navPage);
@@ -819,7 +825,7 @@ namespace Prism.Forms.Tests.Navigation
 
             var tabbedPage = navPage.Navigation.NavigationStack[1] as TabbedPageMock;
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
         }
 
         [Fact]
@@ -1276,8 +1282,6 @@ namespace Prism.Forms.Tests.Navigation
             Assert.False(rootPage.IsPresented);
         }
 
-
-
         [Fact]
         public async void DeepNavigate_ToMasterDetailPage_ToNavigationPage_ToTabbedPage_SelectTab()
         {
@@ -1285,7 +1289,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"MasterDetailPage-Empty/NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+            await navigationService.NavigateAsync($"MasterDetailPage-Empty/NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2");
 
             var mdpPage = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
             var navPage = mdpPage.Detail as NavigationPageMock;
@@ -1293,7 +1297,7 @@ namespace Prism.Forms.Tests.Navigation
             Assert.NotNull(mdpPage);
             Assert.NotNull(navPage);
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
         }
 
         [Fact]
@@ -1303,7 +1307,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"MasterDetailPage-Empty/NavigationPage/ContentPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+            await navigationService.NavigateAsync($"MasterDetailPage-Empty/NavigationPage/ContentPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2");
 
             var mdpPage = rootPage.Navigation.ModalStack[0] as MasterDetailPageEmptyMock;
             var navPage = mdpPage.Detail as NavigationPageMock;
@@ -1312,7 +1316,7 @@ namespace Prism.Forms.Tests.Navigation
             Assert.NotNull(mdpPage);
             Assert.NotNull(navPage);
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
         }
 
         #endregion
@@ -1383,12 +1387,12 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2");
 
             var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
         }
 
         [Fact]
@@ -1398,7 +1402,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ContentPage");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=ContentPage");
 
             var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
@@ -1416,12 +1420,12 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2/ContentPage");
 
             var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
 
             var contentPage = tabbedPage.Navigation.ModalStack[0] as ContentPageMock;
             Assert.NotNull(contentPage);
@@ -1434,14 +1438,14 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.NavigationPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2/ContentPage");
 
             Assert.True(rootPage.Navigation.NavigationStack.Count == 2);
 
             var tabbedPage = rootPage.Navigation.NavigationStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
 
             var contentPage = tabbedPage.Navigation.NavigationStack[1] as ContentPageMock;
             Assert.NotNull(contentPage);
@@ -1454,7 +1458,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.NavigationPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=NavigationPage|ContentPage/ContentPage");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
 
             Assert.True(rootPage.Navigation.NavigationStack.Count == 2);
 
@@ -1465,7 +1469,7 @@ namespace Prism.Forms.Tests.Navigation
 
             var navPage = tabbedPage.CurrentPage as NavigationPageMock;
             Assert.NotNull(navPage);
-            Assert.IsType<ContentPageMock>(navPage.CurrentPage);
+            Assert.IsType<PageMock>(navPage.CurrentPage);
 
             var contentPage = tabbedPage.Navigation.NavigationStack[1] as ContentPageMock;
             Assert.NotNull(contentPage);            
@@ -1495,7 +1499,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.MasterDetailPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock");
+            await navigationService.NavigateAsync($"NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2");
 
             Assert.IsType<NavigationPageMock>(rootPage.Detail);
 
@@ -1504,7 +1508,7 @@ namespace Prism.Forms.Tests.Navigation
             var tabbedPage = rootPage.Detail.Navigation.NavigationStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
             Assert.NotNull(tabbedPage.CurrentPage);
-            Assert.IsType<PageMock>(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
         }
 
         [Fact]
@@ -1514,14 +1518,14 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new Xamarin.Forms.MasterDetailPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=PageMock/ContentPage");
+            await navigationService.NavigateAsync($"NavigationPage/TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2/ContentPage");
 
             Assert.IsType<NavigationPageMock>(rootPage.Detail);
 
             Assert.True(rootPage.Detail.Navigation.NavigationStack.Count == 2);
 
             Assert.IsType<TabbedPageMock>(rootPage.Detail.Navigation.NavigationStack[0]);            
-            Assert.IsType<PageMock>(((TabbedPageMock)rootPage.Detail.Navigation.NavigationStack[0]).CurrentPage);
+            Assert.IsType<Tab2Mock>(((TabbedPageMock)rootPage.Detail.Navigation.NavigationStack[0]).CurrentPage);
 
             Assert.IsType<ContentPageMock>(rootPage.Detail.Navigation.NavigationStack[1]);
         }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -479,17 +479,15 @@ namespace Prism.Navigation
 
                     if (child is NavigationPage)
                     {
-                        child.Behaviors.Add(new Behaviors.NavigationPageActiveAwareBehavior());
+                        ApplyPageBehaviors(child);
 
                         var childTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabChildSegment));
                         if (((NavigationPage)child).CurrentPage.GetType() != childTabType)
                             continue;
                     }
 
-                    if (child.GetType() != selectedTabType)
-                        continue;
-
-                    tabbedPage.CurrentPage = child;
+                    if (child.GetType() == selectedTabType)
+                        tabbedPage.CurrentPage = child;
                 }
             }
         }
@@ -503,11 +501,10 @@ namespace Prism.Navigation
 
                 foreach (var child in carouselPage.Children)
                 {
-                    if (child.GetType() != selectedTabType)
-                        continue;
+                    SetAutowireViewModelOnPage(child);
 
-                    carouselPage.CurrentPage = child;
-                    break;
+                    if (child.GetType() == selectedTabType)
+                        carouselPage.CurrentPage = child;
                 }
             }
         }
@@ -517,6 +514,7 @@ namespace Prism.Navigation
             if (page is NavigationPage)
             {
                 page.Behaviors.Add(new Behaviors.NavigationPageSystemGoBackBehavior());
+                page.Behaviors.Add(new Behaviors.NavigationPageActiveAwareBehavior());
             }
             else if (page is TabbedPage)
             {

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -475,18 +475,21 @@ namespace Prism.Navigation
 
                 foreach (var child in tabbedPage.Children)
                 {
-                    if (child.GetType() != selectedTabType)
-                        continue;
+                    SetAutowireViewModelOnPage(child);
 
                     if (child is NavigationPage)
                     {
+                        child.Behaviors.Add(new Behaviors.NavigationPageActiveAwareBehavior());
+
                         var childTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabChildSegment));
                         if (((NavigationPage)child).CurrentPage.GetType() != childTabType)
                             continue;
                     }
 
+                    if (child.GetType() != selectedTabType)
+                        continue;
+
                     tabbedPage.CurrentPage = child;
-                    break;
                 }
             }
         }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -465,29 +465,29 @@ namespace Prism.Navigation
             var selectedTab = UriParsingHelper.GetSegmentParameters(segment).GetValue<string>(KnownNavigationParameters.SelectedTab);
             if (!string.IsNullOrWhiteSpace(selectedTab))
             {
-                //selected tab can be a single view or a view nested in a navigationpage with the syntax "NavigationPage|View"
-                var selectedTabSegements = new Queue<string>(selectedTab.Split('|'));
-                var selectedTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabSegements.Dequeue()));
+                var selectedTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTab));
 
-                string selectedTabChildSegment = string.Empty;
-                if (selectedTabSegements.Count > 0)
-                    selectedTabChildSegment = selectedTabSegements.Dequeue();
-
+                var childFound = false;
                 foreach (var child in tabbedPage.Children)
                 {
                     SetAutowireViewModelOnPage(child);
+
+                    if (!childFound && child.GetType() == selectedTabType)
+                    {
+                        tabbedPage.CurrentPage = child;
+                        childFound = true;
+                    }
 
                     if (child is NavigationPage)
                     {
                         ApplyPageBehaviors(child);
 
-                        var childTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTabChildSegment));
-                        if (((NavigationPage)child).CurrentPage.GetType() != childTabType)
-                            continue;
+                        if (!childFound && ((NavigationPage)child).CurrentPage.GetType() == selectedTabType)
+                        {
+                            tabbedPage.CurrentPage = child;
+                            childFound = true;
+                        }
                     }
-
-                    if (child.GetType() == selectedTabType)
-                        tabbedPage.CurrentPage = child;
                 }
             }
         }


### PR DESCRIPTION
Automatically adding VML.AutowireViewModel to tabs.

Also added the NavigationPageActiveAwareBehavior by default.

Removed the requirement of providing the `selectedTab=NaviationPage|TabToSelect` syntax to select a tab.  Now, just provide the `selectedTab=TabToSelect` and if it is in a NavigationPage, it will be selected automatically. 