### PR TITLE
Fix Typo in using StackLayout instead of ListView

### DIFF
--- a/docs/Xamarin-Forms/6-EventToCommandBehavior.md
+++ b/docs/Xamarin-Forms/6-EventToCommandBehavior.md
@@ -26,7 +26,7 @@ Bind or declare a parameter that will be sent to the `ICommand.Execute(object)` 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              x:Class="MyNamespace.ContentPage"
              xmlns:b="clr-namespace:Prism.Behaviors;assembly=Prism.Forms">
-    <StackLayout>
+    <ListView>
         <ListView.Behaviors>
             <b:EventToCommandBehavior EventName="ItemTapped" 
                                       Command="{Binding ItemTappedCommand}"


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes issue # .

Changes proposed in this pull request:
- Fix typo in docs: EventToCommandBehavior tried to use StackLayout instead of ListView