### PR TITLE
Dynamic tab creation for TabbedPage

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -33,7 +33,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA/ViewB", animated: false); //works
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
 
-            NavigationService.NavigateAsync($"ViewA", animated: false);
+            NavigationService.NavigateAsync($"MyTabbedPage?createTab=NavigationPage|ViewA&createTab=ViewB&createTab=ViewC&selectedTab=ViewB", animated: false);
         }
 
         protected override void RegisterTypes()

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -33,7 +33,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA/ViewB", animated: false); //works
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
 
-            NavigationService.NavigateAsync($"MyTabbedPage?selectedTab=ViewB", animated: false);
+            NavigationService.NavigateAsync($"ViewA", animated: false);
         }
 
         protected override void RegisterTypes()

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -72,7 +72,7 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.NavigateAsync("ViewB/ViewC", useModalNavigation: false);
+            await _navigationService.NavigateAsync("MyTabbedPage?createTab=ViewA&createTab=ViewB&createTab=ViewC&selectedTab=ViewB");
             CanNavigate = true;
         }
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -72,7 +72,7 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.NavigateAsync("MyTabbedPage?createTab=ViewA&createTab=ViewB&createTab=ViewC&selectedTab=ViewB");
+            await _navigationService.NavigateAsync("MyTabbedPage?createTab=NavigationPage|ViewA&createTab=ViewB&createTab=ViewC&selectedTab=ViewB");
             CanNavigate = true;
         }
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyTabbedPage.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyTabbedPage.xaml
@@ -12,7 +12,7 @@
 		<ToolbarItem Text="Reset" Command="{Binding ApplicationCommands.ResetCommand}"/>
 	</TabbedPage.ToolbarItems>
 
-    <NavigationPage Title="View A">
+    <!--<NavigationPage Title="View A">
         <x:Arguments>
 			<local:ViewA Title="View A" />
 		</x:Arguments>
@@ -24,7 +24,7 @@
 		</x:Arguments>
 	</NavigationPage>
 
-	<local:ViewC Title="View C" />
+	<local:ViewC Title="View C" />-->
 
 	<!--<local:ViewA Title="View A" />
   <local:ViewB Title="View B"/>-->

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/TabbedPageEmptyMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/TabbedPageEmptyMock.cs
@@ -1,0 +1,8 @@
+﻿using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.Views
+{
+    public class TabbedPageEmptyMock : TabbedPage
+    {
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -42,6 +42,7 @@ namespace Prism.Forms.Tests.Navigation
 
 
             _container.Register("TabbedPage", typeof(TabbedPageMock));
+            _container.Register("TabbedPage-Empty", typeof(TabbedPageEmptyMock));
             _container.Register("Tab1", typeof(Tab1Mock));
             _container.Register("Tab2", typeof(Tab2Mock));
             _container.Register("Tab3", typeof(Tab3Mock));
@@ -1528,6 +1529,83 @@ namespace Prism.Forms.Tests.Navigation
             Assert.IsType<Tab2Mock>(((TabbedPageMock)rootPage.Detail.Navigation.NavigationStack[0]).CurrentPage);
 
             Assert.IsType<ContentPageMock>(rootPage.Detail.Navigation.NavigationStack[1]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_CreateTabs()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=Tab1&{KnownNavigationParameters.CreateTab}=Tab2&{KnownNavigationParameters.CreateTab}=Tab3");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageEmptyMock;
+            Assert.NotNull(tabbedPage);
+            Assert.Equal(3, tabbedPage.Children.Count());
+            Assert.IsType<Tab1Mock>(tabbedPage.Children[0]);
+            Assert.IsType<Tab2Mock>(tabbedPage.Children[1]);
+            Assert.IsType<Tab3Mock>(tabbedPage.Children[2]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_CreateTabs_SelectTab()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=Tab1&{KnownNavigationParameters.CreateTab}=Tab2&{KnownNavigationParameters.CreateTab}=Tab3&{KnownNavigationParameters.SelectedTab}=Tab2");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageEmptyMock;
+            Assert.NotNull(tabbedPage);
+            Assert.Equal(3, tabbedPage.Children.Count());
+            Assert.IsType<Tab1Mock>(tabbedPage.Children[0]);
+            Assert.IsType<Tab2Mock>(tabbedPage.Children[1]);
+            Assert.IsType<Tab3Mock>(tabbedPage.Children[2]);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_CreateTabs_WithNavigationPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=NavigationPage|Tab1&{KnownNavigationParameters.CreateTab}=Tab2&{KnownNavigationParameters.CreateTab}=Tab3");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageEmptyMock;
+            Assert.NotNull(tabbedPage);
+            Assert.Equal(3, tabbedPage.Children.Count());
+
+            var navPage = tabbedPage.Children[0] as NavigationPageMock;
+            Assert.IsType<NavigationPageMock>(navPage);
+            Assert.IsType<Tab1Mock>(navPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.Children[1]);
+            Assert.IsType<Tab3Mock>(tabbedPage.Children[2]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_CreateTabs_WithNavigationPage_SelectTab()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=Tab1&{KnownNavigationParameters.CreateTab}=NavigationPage|Tab2&{KnownNavigationParameters.CreateTab}=Tab3&{KnownNavigationParameters.SelectedTab}=Tab2");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageEmptyMock;
+            Assert.NotNull(tabbedPage);
+            Assert.Equal(3, tabbedPage.Children.Count());
+
+            Assert.IsType<Tab1Mock>(tabbedPage.Children[0]);
+
+            var navPage = tabbedPage.Children[1] as NavigationPageMock;
+            Assert.IsType<NavigationPageMock>(navPage);
+            Assert.IsType<Tab2Mock>(navPage.CurrentPage);
+            
+            Assert.IsType<Tab3Mock>(tabbedPage.Children[2]);
         }
 
         #endregion

--- a/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/KnownNavigationParameters.cs
@@ -4,6 +4,7 @@
     {
         public const string NavigationMode = "__NavigationMode";
 
+        public const string CreateTab = "createTab";
         public const string SelectedTab = "selectedTab";
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -483,8 +483,35 @@ namespace Prism.Navigation
             {
                 foreach (var tabToCreate in tabsToCreate)
                 {
-                    var tab = CreatePageFromSegment(tabToCreate);
-                    tabbedPage.Children.Add(tab);
+                    //created tab can be a single view or a view nested in a navigationpage with the syntax "NavigationPage|ViewToCreate"
+                    var tabSegements = tabToCreate.Split('|');
+                    if (tabSegements.Length > 1)
+                    {
+                        var navigationPage = CreatePageFromSegment(tabSegements[0]) as NavigationPage;
+                        if (navigationPage != null)
+                        {
+                            ApplyPageBehaviors(navigationPage);
+
+                            var navigationPageChild = CreatePageFromSegment(tabSegements[1]);
+
+                            navigationPage.PushAsync(navigationPageChild);
+
+                            //when creating a NavigationPage w/ DI, a blank Page object is injected into the ctor. Let's remove it
+                            if (navigationPage.Navigation.NavigationStack.Count > 1)
+                                navigationPage.Navigation.RemovePage(navigationPage.Navigation.NavigationStack[0]);
+
+                            //set the title because Xamarin doesn;t do this for us.
+                            navigationPage.Title = navigationPageChild.Title;
+                            navigationPage.Icon = navigationPageChild.Icon;
+
+                            tabbedPage.Children.Add(navigationPage);
+                        }
+                    }
+                    else
+                    {
+                        var tab = CreatePageFromSegment(tabToCreate);
+                        tabbedPage.Children.Add(tab);
+                    }
                 }
             }
 

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -476,7 +476,20 @@ namespace Prism.Navigation
 
         void ConfigureTabbedPage(TabbedPage tabbedPage, string segment)
         {
-            var selectedTab = UriParsingHelper.GetSegmentParameters(segment).GetValue<string>(KnownNavigationParameters.SelectedTab);
+            var parameters = UriParsingHelper.GetSegmentParameters(segment);
+
+            var tabsToCreate = parameters.GetValues<string>("createTab");
+            if (tabsToCreate.Count() > 0)
+            {
+                foreach (var tabToCreate in tabsToCreate)
+                {
+                    var tab = CreatePageFromSegment(tabToCreate);
+                    tabbedPage.Children.Add(tab);
+                }
+            }
+
+
+            var selectedTab = parameters.GetValue<string>(KnownNavigationParameters.SelectedTab);
             if (!string.IsNullOrWhiteSpace(selectedTab))
             {
                 var selectedTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTab));

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -489,7 +489,7 @@ namespace Prism.Navigation
 
             var parameters = UriParsingHelper.GetSegmentParameters(segment);
 
-            var tabsToCreate = parameters.GetValues<string>("createTab");
+            var tabsToCreate = parameters.GetValues<string>(KnownNavigationParameters.CreateTab);
             if (tabsToCreate.Count() > 0)
             {
                 foreach (var tabToCreate in tabsToCreate)


### PR DESCRIPTION
You can now dynamically create tabs when navigating to a TabbedPage by using the `KnownNavigationParameters.CreateTab` constant or by using the "createTab" parameter name.

`_navigationService.NavigateAsync("MyTabbedPage?createTab=ViewA&createTab=ViewB");`

This will create a TabbedPage and then create two tabs, ViewA and ViewB.

To create a tab that wraps a page in a NavigationPage, simply denote this as a nested hierarchy using the `|` character.

`_navigationService.NavigateAsync("MyTabbedPage?createTab=NavigationPage|ViewA");`
