### PR TITLE
Remove pages from navigation stack

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -33,7 +33,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA/ViewB", animated: false); //works
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC", animated: false); //works
 
-            NavigationService.NavigateAsync($"MyTabbedPage?createTab=NavigationPage|ViewA&createTab=ViewB&createTab=ViewC&selectedTab=ViewB", animated: false);
+            NavigationService.NavigateAsync($"NavigationPage/ViewA/ViewB/ViewC", animated: false);
         }
 
         protected override void RegisterTypes()

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -72,7 +72,7 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.NavigateAsync("MyTabbedPage?createTab=NavigationPage|ViewA&createTab=ViewB&createTab=ViewC&selectedTab=ViewB");
+            await _navigationService.NavigateAsync("ViewB/ViewC");
             CanNavigate = true;
         }
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
@@ -31,9 +31,7 @@ namespace ModuleA.ViewModels
         {
             try
             {
-                //await _navigationService.NavigateAsync("ViewB");
-
-                await _navigationService.GoBackToRootAsync();
+                await _navigationService.NavigateAsync("../../../MainPage");                
 
                 Debug.WriteLine("After _navigationService.NavigateAsync(ViewB) ...");
             }

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -1660,6 +1660,98 @@ namespace Prism.Forms.Tests.Navigation
 
         #endregion
 
+        #region Remove and Navigate - "../"
+
+        [Fact]
+        public async Task RemoveAndNavigate_OneLevel()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 1" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 2" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 3" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 4" });
+
+            Assert.Equal(4, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.NavigationStack.Last());
+
+            ((IPageAware)navigationService).Page = rootPage.Navigation.NavigationStack.Last();
+
+            await navigationService.NavigateAsync("../PageMock");
+
+            Assert.Equal(4, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<PageMock>(rootPage.Navigation.NavigationStack.Last());
+        }
+
+        [Fact]
+        public async Task RemoveAndNavigate_TwoLevels()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 1" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 2" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 3" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 4" });
+
+            Assert.Equal(4, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.NavigationStack.Last());
+
+            ((IPageAware)navigationService).Page = rootPage.Navigation.NavigationStack.Last();
+
+            await navigationService.NavigateAsync("../../PageMock");
+
+            Assert.Equal(3, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<PageMock>(rootPage.Navigation.NavigationStack.Last());
+        }
+
+        [Fact]
+        public async Task RemoveAndNavigate_ThreeLevels()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 1" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 2" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 3" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 4" });
+
+            Assert.Equal(4, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.NavigationStack.Last());
+
+            ((IPageAware)navigationService).Page = rootPage.Navigation.NavigationStack.Last();
+
+            await navigationService.NavigateAsync("../../../PageMock");
+
+            Assert.Equal(2, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<PageMock>(rootPage.Navigation.NavigationStack.Last());
+        }
+
+        [Fact]
+        public async Task RemoveAndNavigate_FourLevels()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new Xamarin.Forms.NavigationPage();
+
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 1" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 2" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 3" });
+            await rootPage.Navigation.PushAsync(new ContentPageMock() { Title = "Page 4" });
+
+            Assert.Equal(4, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<ContentPageMock>(rootPage.Navigation.NavigationStack.Last());
+
+            ((IPageAware)navigationService).Page = rootPage.Navigation.NavigationStack.Last();
+
+            await navigationService.NavigateAsync("../../../../PageMock");
+
+            Assert.Equal(1, rootPage.Navigation.NavigationStack.Count);
+            Assert.IsType<PageMock>(rootPage.Navigation.NavigationStack[0]);
+        }
+
+        #endregion
+
 
         public void Dispose()
         {

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -178,12 +178,15 @@ namespace Prism.Navigation
 
         protected virtual async Task ProcessNavigationForRemovePageSegments(Page currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
+            if (!HasNavigationPageParent(currentPage))
+                throw new InvalidOperationException("Removing views using the relative '../' syntax while navigating is only supported within a NavigationPage");
+
+            List<Page> pagesToRemove = new List<Page>();
+            pagesToRemove.Add(currentPage);
+
             var currentPageIndex = currentPage.Navigation.NavigationStack.Count;
             if (currentPage.Navigation.NavigationStack.Count > 0)
                 currentPageIndex = currentPage.Navigation.NavigationStack.Count - 1;
-
-            List<Page> pagesToRemove = new List<Page>();
-            pagesToRemove.Add(currentPage); //add current page to remove
 
             while (segments.Peek() == RemovePageSegment)
             {
@@ -191,10 +194,6 @@ namespace Prism.Navigation
                 pagesToRemove.Add(currentPage.Navigation.NavigationStack[currentPageIndex]);
                 nextSegment = segments.Dequeue();
             }
-
-            //this is only supported for views within NavigationPages
-            if (!HasNavigationPageParent(currentPage))
-                return;
 
             await ProcessNavigation(currentPage, segments, parameters, useModalNavigation, animated);
 

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -14,6 +14,10 @@ namespace Prism.Navigation
     /// </summary>
     public abstract class PageNavigationService : INavigationService, IPageAware
     {
+        internal const string RemovePageRelativePath = "../";
+        internal const string RemovePageInstruction = "__RemovePage/";
+        internal const string RemovePageSegment = "__RemovePage";
+
         //not sure I like this static property, think about this a little more
         protected internal static PageNavigationSource NavigationSource { get; protected set; } = PageNavigationSource.Device;
 
@@ -90,6 +94,9 @@ namespace Prism.Navigation
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
         public virtual Task NavigateAsync(string name, NavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
+            if (name.StartsWith(RemovePageRelativePath))
+                name = name.Replace(RemovePageRelativePath, RemovePageInstruction);
+
             return NavigateAsync(UriParsingHelper.Parse(name), parameters, useModalNavigation, animated);
         }
 
@@ -135,6 +142,12 @@ namespace Prism.Navigation
 
             var nextSegment = segments.Dequeue();
 
+            if (nextSegment == RemovePageSegment)
+            {
+                await ProcessNavigationForRemovePageSegments(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+                return;
+            }
+
             if (currentPage == null)
             {
                 await ProcessNavigationForRootPage(nextSegment, segments, parameters, useModalNavigation, animated);
@@ -160,6 +173,36 @@ namespace Prism.Navigation
             else if (currentPage is MasterDetailPage)
             {
                 await ProcessNavigationForMasterDetailPage((MasterDetailPage)currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+            }
+        }
+
+        protected virtual async Task ProcessNavigationForRemovePageSegments(Page currentPage, string nextSegment, Queue<string> segments, NavigationParameters parameters, bool? useModalNavigation, bool animated)
+        {
+            var currentPageIndex = currentPage.Navigation.NavigationStack.Count;
+            if (currentPage.Navigation.NavigationStack.Count > 0)
+                currentPageIndex = currentPage.Navigation.NavigationStack.Count - 1;
+
+            List<Page> pagesToRemove = new List<Page>();
+            pagesToRemove.Add(currentPage); //add current page to remove
+
+            while (segments.Peek() == RemovePageSegment)
+            {
+                currentPageIndex -= 1;
+                pagesToRemove.Add(currentPage.Navigation.NavigationStack[currentPageIndex]);
+                nextSegment = segments.Dequeue();
+            }
+
+            //this is only supported for views within NavigationPages
+            if (!HasNavigationPageParent(currentPage))
+                return;
+
+            await ProcessNavigation(currentPage, segments, parameters, useModalNavigation, animated);
+
+            var navigationPage = (NavigationPage)currentPage.Parent;
+            foreach (var page in pagesToRemove)
+            {
+                navigationPage.Navigation.RemovePage(page);
+                PageUtilities.DestroyPage(page);
             }
         }
 


### PR DESCRIPTION
This feature allows you to remove pages form the navigation stack of a NavigationPage while at the same time navigating to a new page.  For each page you wish to remove, prefix your navigation path with `../`.

**Example**
Our app requires a user to login in order to edit "User" profile information.  This will require the user to be prompted to login and then once successful continue to edit the profile.  This leaves us with the following navigation stack:

"NavigationPage/UserList/UserDetails/LoginPage/EditUser"

If we were to hit the back button from the `EditUser` page, we would be returned to the `LoginPage`.  This is not the desired experience.  Instead, we want to go back to the `UserDetails` which was just updated.  To achieve this we provide the following navigation URI from the **LoginPage** page with a successful login attempt.

`NavigationService.NavigateAsync("../EditUser");`

This would remove the LoginPage and then immediately navigate to the "EditUser" page which we now have access to.

You can chain the `../` instruction for each page that needs to be removed from the stack.

Given:  "NavigationPage/ViewA/ViewB/ViewC/ViewD"
Navigate from ViewD with: `NavigationService.NavigateAsync("../../../ViewE");`
Results in: "NavigationPage/ViewA/ViewE"

## This only works when navigating within a NavigationPage! Modal pages are not supported.

This fixes #921 