### PR TITLE
Fix xUnit2004 warning

### DIFF
--- a/Source/Prism.Tests/Commands/DelegateCommandFixture.cs
+++ b/Source/Prism.Tests/Commands/DelegateCommandFixture.cs
@@ -78,7 +78,7 @@ namespace Prism.Tests.Commands
 
             bool retVal = command.CanExecute(null);
 
-            Assert.Equal(true, retVal);
+            Assert.True(retVal);
         }
 
         [Fact]


### PR DESCRIPTION
Please take a moment to fill out the following:

Changes proposed in this pull request:
-  Fix xUnit2004 warning. use Assert.True(b) instead of Assert.Equal(true, b).
