### PR TITLE
Upgrade CommonServiceLocator to version 2.0.1

### DIFF
--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/AutofacBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/AutofacBootstrapperFixture.cs
@@ -5,7 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Autofac;
 using Autofac.Core.Registration;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.IocContainer.Wpf.Tests.Support;
 using Prism.IocContainer.Wpf.Tests.Support.Mocks;

--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/AutofacBootstrapperRunMethodFixture.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/AutofacBootstrapperRunMethodFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using Autofac;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Events;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/Mocks/MockServiceLocator.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/Mocks/MockServiceLocator.cs
@@ -1,7 +1,7 @@
 ﻿//using System;
 //using System.Collections.Generic;
 //using Autofac;
-//using Microsoft.Practices.ServiceLocation;
+//using CommonServiceLocator;
 //using Prism.Regions;
 
 //namespace Prism.Autofac.Tests.Mocks

--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/Prism.Autofac.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/Prism.Autofac.Wpf.Tests.csproj
@@ -41,8 +41,8 @@
     <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.7.127.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.7.127\lib\net45\Moq.dll</HintPath>

--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Autofac" version="4.6.0" targetFramework="net45" />
   <package id="Castle.Core" version="4.1.1" targetFramework="net45" />
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="Moq" version="4.7.127" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Autofac.Wpf/AutofacBootstrapper.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf/AutofacBootstrapper.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using Autofac;
 using Autofac.Features.ResolveAnything;
 using AutofacCore = Autofac.Core;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Autofac.Properties;
 using Prism.Events;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Autofac.Wpf/AutofacServiceLocatorAdapter.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf/AutofacServiceLocatorAdapter.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Autofac;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.Autofac
 {

--- a/Source/Wpf/Prism.Autofac.Wpf/Prism.Autofac.Wpf.csproj
+++ b/Source/Wpf/Prism.Autofac.Wpf/Prism.Autofac.Wpf.csproj
@@ -40,8 +40,8 @@
     <Reference Include="Autofac, Version=4.6.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autofac.4.6.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/Source/Wpf/Prism.Autofac.Wpf/Regions/AutofacRegionNavigationContentLoader.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf/Regions/AutofacRegionNavigationContentLoader.cs
@@ -1,6 +1,6 @@
 ﻿using Autofac;
 using Autofac.Core;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Regions;
 using System;
 using System.Collections.Generic;

--- a/Source/Wpf/Prism.Autofac.Wpf/packages.config
+++ b/Source/Wpf/Prism.Autofac.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.6.0" targetFramework="net45" />
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/DefaultPrismServiceRegistrarFixture.cs
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/DefaultPrismServiceRegistrarFixture.cs
@@ -3,7 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Events;

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/MefBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/MefBootstrapperFixture.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Windows;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Events;

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/MefBootstrapperRunMethodFixture.cs
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/MefBootstrapperRunMethodFixture.cs
@@ -36,7 +36,7 @@ namespace Prism.Mef.Wpf.Tests
             var bootstrapper = new DefaultMefBootstrapper();
             bootstrapper.Run();
 
-            Assert.IsTrue(Microsoft.Practices.ServiceLocation.ServiceLocator.Current is MefServiceLocatorAdapter);
+            Assert.IsTrue(CommonServiceLocator.ServiceLocator.Current is MefServiceLocatorAdapter);
         }
 
         [TestMethod]

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/MefModuleInitializerFixture.cs
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/MefModuleInitializerFixture.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/MefRegionNavigationContentLoaderFixture.cs
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/MefRegionNavigationContentLoaderFixture.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Mef.Regions;
 using Prism.Regions;

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/MefServiceLocatorAdapterFixture.cs
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/MefServiceLocatorAdapterFixture.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Prism.Mef.Wpf.Tests

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/Prism.Mef.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/Prism.Mef.Wpf.Tests.csproj
@@ -43,10 +43,10 @@
     <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Moq, Version=4.7.127.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.7.127\lib\net45\Moq.dll</HintPath>

--- a/Source/Wpf/Prism.Mef.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Mef.Wpf.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.1.1" targetFramework="net45" />
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="Moq" version="4.7.127" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Mef.Wpf/MefBootstrapper.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/MefBootstrapper.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Logging;
 using Prism.Mef.Properties;
 using Prism.Modularity;

--- a/Source/Wpf/Prism.Mef.Wpf/MefServiceLocatorAdapter.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/MefServiceLocatorAdapter.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.Mef
 {

--- a/Source/Wpf/Prism.Mef.Wpf/Modularity/MefModuleInitializer.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Modularity/MefModuleInitializer.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
 using System.Globalization;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Logging;
 using Prism.Modularity;
 

--- a/Source/Wpf/Prism.Mef.Wpf/Prism.Mef.Wpf.csproj
+++ b/Source/Wpf/Prism.Mef.Wpf/Prism.Mef.Wpf.csproj
@@ -41,8 +41,8 @@
     <AssemblyOriginatorKeyFile>..\..\prism.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionBehaviorFactory.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionBehaviorFactory.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Regions;
 
 namespace Prism.Mef.Regions

--- a/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionNavigationContentLoader.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionNavigationContentLoader.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Regions;
 
 namespace Prism.Mef.Regions

--- a/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionNavigationService.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionNavigationService.cs
@@ -1,7 +1,7 @@
 
 
 using System.ComponentModel.Composition;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Regions;
 
 namespace Prism.Mef.Regions

--- a/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionViewRegistry.cs
+++ b/Source/Wpf/Prism.Mef.Wpf/Regions/MefRegionViewRegistry.cs
@@ -1,7 +1,7 @@
 
 
 using System.ComponentModel.Composition;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Regions;
 
 namespace Prism.Mef.Regions

--- a/Source/Wpf/Prism.Mef.Wpf/packages.config
+++ b/Source/Wpf/Prism.Mef.Wpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/Mocks/MockServiceLocator.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/Mocks/MockServiceLocator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Ninject;
 using Prism.Ninject.Regions;
 using Prism.Regions;

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/NinjectRegionNavigationContentLoaderFixture.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/NinjectRegionNavigationContentLoaderFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Ninject;
 using Prism.IocContainer.Wpf.Tests.Support.Mocks.Views;

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/Prism.Ninject.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/Prism.Ninject.Wpf.Tests.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net461" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net461" />

--- a/Source/Wpf/Prism.Ninject.Wpf/NinjectBootstrapper.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/NinjectBootstrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Reflection;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Ninject;
 using Prism;
 using Prism.Events;

--- a/Source/Wpf/Prism.Ninject.Wpf/NinjectServiceLocatorAdapter.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/NinjectServiceLocatorAdapter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Ninject;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.Ninject
 {

--- a/Source/Wpf/Prism.Ninject.Wpf/Prism.Ninject.Wpf.csproj
+++ b/Source/Wpf/Prism.Ninject.Wpf/Prism.Ninject.Wpf.csproj
@@ -37,8 +37,8 @@
     <AssemblyOriginatorKeyFile>..\..\prism.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>

--- a/Source/Wpf/Prism.Ninject.Wpf/Regions/NinjectRegionNavigationContentLoader.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/Regions/NinjectRegionNavigationContentLoader.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Ninject;
 using Prism.Regions;
 

--- a/Source/Wpf/Prism.Ninject.Wpf/packages.config
+++ b/Source/Wpf/Prism.Ninject.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.StructureMap.Wpf.Tests/Prism.StructureMap.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.StructureMap.Wpf.Tests/Prism.StructureMap.Wpf.Tests.csproj
@@ -66,8 +66,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore">

--- a/Source/Wpf/Prism.StructureMap.Wpf.Tests/StructureMapBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.StructureMap.Wpf.Tests/StructureMapBootstrapperFixture.cs
@@ -127,7 +127,7 @@ namespace Prism.StructureMap.Wpf.Tests
             bootstrapper.CallRegisterFrameworkExceptionTypes();
 
             Assert.IsTrue(ExceptionExtensions.IsFrameworkExceptionRegistered(
-                typeof(Microsoft.Practices.ServiceLocation.ActivationException)));
+                typeof(CommonServiceLocator.ActivationException)));
         }
 
         [TestMethod]

--- a/Source/Wpf/Prism.StructureMap.Wpf.Tests/StructureMapBootstrapperNullModuleManagerFixture.cs
+++ b/Source/Wpf/Prism.StructureMap.Wpf.Tests/StructureMapBootstrapperNullModuleManagerFixture.cs
@@ -1,5 +1,5 @@
 using System.Windows;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Logging;
 using Prism.Regions;

--- a/Source/Wpf/Prism.StructureMap.Wpf.Tests/StructureMapBootstrapperRunMethodFixture.cs
+++ b/Source/Wpf/Prism.StructureMap.Wpf.Tests/StructureMapBootstrapperRunMethodFixture.cs
@@ -31,7 +31,7 @@ namespace Prism.StructureMap.Wpf.Tests
             var bootstrapper = new DefaultStructureMapBootstrapper();
             bootstrapper.Run();
 
-            Assert.IsTrue(Microsoft.Practices.ServiceLocation.ServiceLocator.Current is StructureMapServiceLocatorAdapter);
+            Assert.IsTrue(CommonServiceLocator.ServiceLocator.Current is StructureMapServiceLocatorAdapter);
         }
 
         [TestMethod]

--- a/Source/Wpf/Prism.StructureMap.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.StructureMap.Wpf.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" userInstalled="true" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" userInstalled="true" />
   <package id="StructureMap" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.StructureMap.Wpf/Prism.StructureMap.Wpf.csproj
+++ b/Source/Wpf/Prism.StructureMap.Wpf/Prism.StructureMap.Wpf.csproj
@@ -31,9 +31,8 @@
     <DocumentationFile>bin\Release\Prism.StructureMap.Wpf.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="StructureMap, Version=4.3.0.449, Culture=neutral, processorArchitecture=MSIL">

--- a/Source/Wpf/Prism.StructureMap.Wpf/StructureMapBootstrapper.cs
+++ b/Source/Wpf/Prism.StructureMap.Wpf/StructureMapBootstrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using StructureMap;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.StructureMap.Properties;
 using Prism.Events;
 using Prism.Logging;

--- a/Source/Wpf/Prism.StructureMap.Wpf/StructureMapServiceLocatorAdapter.cs
+++ b/Source/Wpf/Prism.StructureMap.Wpf/StructureMapServiceLocatorAdapter.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using StructureMap;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.StructureMap
 {

--- a/Source/Wpf/Prism.StructureMap.Wpf/packages.config
+++ b/Source/Wpf/Prism.StructureMap.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="StructureMap" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/Mocks/MockServiceLocator.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/Mocks/MockServiceLocator.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using Prism.Regions;
 using Prism.Unity.Regions;

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
@@ -69,8 +69,8 @@
     <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperFixture.cs
@@ -129,7 +129,7 @@ namespace Prism.Unity.Wpf.Tests
             bootstrapper.CallRegisterFrameworkExceptionTypes();
 
             Assert.IsTrue(ExceptionExtensions.IsFrameworkExceptionRegistered(
-                typeof(Microsoft.Practices.ServiceLocation.ActivationException)));
+                typeof(CommonServiceLocator.ActivationException)));
         }
 
         [TestMethod]

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullModuleManagerFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperNullModuleManagerFixture.cs
@@ -1,7 +1,7 @@
 
 
 using System.Windows;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Logging;

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperRunMethodFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityBootstrapperRunMethodFixture.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -37,7 +37,7 @@ namespace Prism.Unity.Wpf.Tests
             var bootstrapper = new DefaultUnityBootstrapper();
             bootstrapper.Run();
 
-            Assert.IsTrue(Microsoft.Practices.ServiceLocation.ServiceLocator.Current is UnityServiceLocatorAdapter);
+            Assert.IsTrue(CommonServiceLocator.ServiceLocator.Current is UnityServiceLocatorAdapter);
         }
 
         [TestMethod]

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityRegionNavigationContentLoaderFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityRegionNavigationContentLoaderFixture.cs
@@ -1,7 +1,7 @@
 
 
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.IocContainer.Wpf.Tests.Support.Mocks;

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/UnityServiceLocatorAdapterFixture.cs
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/UnityServiceLocatorAdapterFixture.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.1.1" targetFramework="net45" />
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="Moq" version="4.7.127" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
@@ -40,8 +40,8 @@
     <AssemblyOriginatorKeyFile>..\..\prism.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>

--- a/Source/Wpf/Prism.Unity.Wpf/Regions/UnityRegionNavigationContentLoader.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/Regions/UnityRegionNavigationContentLoader.cs
@@ -1,7 +1,7 @@
 
 
 using Prism.Regions;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using System;
 using System.Collections.Generic;

--- a/Source/Wpf/Prism.Unity.Wpf/UnityBootstrapper.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityBootstrapper.cs
@@ -7,7 +7,7 @@ using Prism.Logging;
 using Prism.Modularity;
 using Prism.Regions;
 using Prism.Unity.Properties;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 using Prism.Mvvm;
 using Prism.Unity.Regions;

--- a/Source/Wpf/Prism.Unity.Wpf/UnityServiceLocatorAdapter.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityServiceLocatorAdapter.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.Practices.Unity;
 
 namespace Prism.Unity

--- a/Source/Wpf/Prism.Unity.Wpf/packages.config
+++ b/Source/Wpf/Prism.Unity.Wpf/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Wpf.Tests/BootstrapperFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/BootstrapperFixture.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Logging;
@@ -99,7 +99,7 @@ namespace Prism.Wpf.Tests
             bootstrapper.CallRegisterFrameworkExceptionTypes();
 
             Assert.IsTrue(ExceptionExtensions.IsFrameworkExceptionRegistered(
-                typeof(Microsoft.Practices.ServiceLocation.ActivationException)));
+                typeof(CommonServiceLocator.ActivationException)));
         }
 
         [TestMethod]

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.Wpf.Tests.Mocks
 {

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/MockServiceLocator.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/MockServiceLocator.cs
@@ -1,7 +1,7 @@
 
 
 using System;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.Wpf.Tests.Mocks
 {

--- a/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleInitializerFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Modularity/ModuleInitializerFixture.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Logging;
 using Prism.Modularity;

--- a/Source/Wpf/Prism.Wpf.Tests/Prism.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Wpf.Tests/Prism.Wpf.Tests.csproj
@@ -69,8 +69,8 @@
     <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>

--- a/Source/Wpf/Prism.Wpf.Tests/Regions/LocatorNavigationTargetHandlerFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/LocatorNavigationTargetHandlerFixture.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Windows;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Regions;

--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Regions;

--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionManagerFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionManagerFixture.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prism.Regions;
 using Prism.Wpf.Tests.Mocks;

--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationServiceFixture.new.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationServiceFixture.new.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Prism.Regions;

--- a/Source/Wpf/Prism.Wpf.Tests/ServiceLocatorExtensionsFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/ServiceLocatorExtensionsFixture.cs
@@ -2,8 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Practices.ServiceLocation;
 
 namespace Prism.Wpf.Tests
 {

--- a/Source/Wpf/Prism.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Wpf.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.1.1" targetFramework="net45" />
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
   <package id="Moq" version="4.7.127" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Wpf/Bootstrapper.cs
+++ b/Source/Wpf/Prism.Wpf/Bootstrapper.cs
@@ -8,7 +8,7 @@ using Prism.Logging;
 using Prism.Modularity;
 using Prism.Regions;
 using Prism.Regions.Behaviors;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Mvvm;
 
 namespace Prism
@@ -92,7 +92,7 @@ namespace Prism
         protected virtual void RegisterFrameworkExceptionTypes()
         {
             ExceptionExtensions.RegisterFrameworkExceptionType(
-                typeof(Microsoft.Practices.ServiceLocation.ActivationException));
+                typeof(ActivationException));
         }
 
         /// <summary>

--- a/Source/Wpf/Prism.Wpf/Extensions/ServiceLocatorExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Extensions/ServiceLocatorExtensions.cs
@@ -1,5 +1,5 @@
 
-
+using CommonServiceLocator;
 using System;
 
 namespace Microsoft.Practices.ServiceLocation

--- a/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/PopupWindowAction.cs
@@ -6,7 +6,7 @@ using Prism.Interactivity.InteractionRequest;
 using System;
 using System.Windows;
 using System.Windows.Interactivity;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Prism.Interactivity
 {

--- a/Source/Wpf/Prism.Wpf/Modularity/ModuleInitializer.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/ModuleInitializer.cs
@@ -1,6 +1,6 @@
 
 
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Logging;
 using System;
 using System.Globalization;

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -40,8 +40,8 @@
     <AssemblyOriginatorKeyFile>..\..\prism.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="CommonServiceLocator, Version=2.0.1.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.2.0.1\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Source/Wpf/Prism.Wpf/Regions/Region.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/Region.cs
@@ -1,6 +1,6 @@
 
 
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Properties;
 using System;
 using System.Collections.ObjectModel;

--- a/Source/Wpf/Prism.Wpf/Regions/RegionBehaviorFactory.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionBehaviorFactory.cs
@@ -1,6 +1,6 @@
 
 
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Properties;
 using System;
 using System.Collections;

--- a/Source/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -1,4 +1,4 @@
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Common;
 using Prism.Events;
 using Prism.Properties;

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
@@ -1,4 +1,4 @@
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Common;
 using Prism.Properties;
 using System;

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
@@ -1,6 +1,6 @@
 
 
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Common;
 using Prism.Properties;
 using System;

--- a/Source/Wpf/Prism.Wpf/Regions/RegionViewRegistry.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionViewRegistry.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Reflection;
 using Prism.Events;
 using Prism.Properties;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using Prism.Common;
 
 namespace Prism.Regions

--- a/Source/Wpf/Prism.Wpf/packages.config
+++ b/Source/Wpf/Prism.Wpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes issue #1211.

This is a breaking change and results in breaking the DryIoc package.

All projects except DryIoc are passing the tests. DryIoc has a
dependency on DryIoc.CommonServiceLocator.dll version 2.2.1 which is
incompatible with the latest CommonServiceLocator version.

Any help in resolving the DryIoc problem appreciated.