### PR TITLE
added RegisterTypeForNavigation for VM extensions

### DIFF
--- a/Source/Wpf/Prism.Autofac.Wpf/AutofacExtensions.cs
+++ b/Source/Wpf/Prism.Autofac.Wpf/AutofacExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Prism.Mvvm;
 using System;
 
 namespace Prism.Autofac
@@ -15,7 +16,39 @@ namespace Prism.Autofac
         {
             Type type = typeof(T);
             string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
-            builder.RegisterType<T>().Named<object>(viewName);
+            builder.RegisterTypeForNavigation(type, viewName);
+        }
+
+        /// <summary>
+        /// Registers an object for navigation
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="type">The type of object to register</param>
+        /// <param name="name">The unique name to register with the obect.</param>
+        public static void RegisterTypeForNavigation(this ContainerBuilder builder, Type type, string name)
+        {
+            builder.RegisterType(type).Named<object>(name);
+        }
+
+        /// <summary>
+        /// Registers an object for navigation.
+        /// </summary>
+        /// <typeparam name="TView">The Type of object to register as the view</typeparam>
+        /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the view</typeparam>
+        /// <param name="name">The unique name to register with the view</param>
+        public static void RegisterTypeForNavigation<TView, TViewModel>(this ContainerBuilder builder, string name = null)
+        {
+            builder.RegisterTypeForNavigationWithViewModel<TViewModel>(typeof(TView), name);
+        }
+
+        private static void RegisterTypeForNavigationWithViewModel<TViewModel>(this ContainerBuilder builder, Type viewType, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = viewType.Name;
+
+            ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
+
+            builder.RegisterTypeForNavigation(viewType, name);
         }
     }
 }

--- a/Source/Wpf/Prism.DryIoc.Wpf/DryIocExtensions.cs
+++ b/Source/Wpf/Prism.DryIoc.Wpf/DryIocExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using DryIoc;
+using Prism.Mvvm;
 using System;
 
 namespace Prism.DryIoc
@@ -14,7 +15,43 @@ namespace Prism.DryIoc
         {
             Type type = typeof(T);
             string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
-            container.Register(typeof(object), type, serviceKey: viewName);
+            container.RegisterTypeForNavigation(type, viewName);
+        }
+
+        /// <summary>
+        /// Registers an object for navigation
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="type">The type of object to register</param>
+        /// <param name="name">The unique name to register with the obect.</param>
+        public static void RegisterTypeForNavigation(this IContainer container, Type type, string name)
+        {
+            container.Register(typeof(object),
+                               type,
+                               made: Made.Of(FactoryMethod.ConstructorWithResolvableArguments),
+                               serviceKey: name);
+        }
+
+        /// <summary>
+        /// Registers an object for navigation.
+        /// </summary>
+        /// <typeparam name="TView">The Type of object to register as the view</typeparam>
+        /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the view</typeparam>
+        /// <param name="name">The unique name to register with the view</param>
+        /// <param name="container"></param>
+        public static void RegisterTypeForNavigation<TView, TViewModel>(this IContainer container, string name = null)
+        {
+            container.RegisterTypeForNavigationWithViewModel<TViewModel>(typeof(TView), name);
+        }
+
+        private static void RegisterTypeForNavigationWithViewModel<TViewModel>(this IContainer container, Type viewType, string name = null)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = viewType.Name;
+
+            ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
+
+            container.RegisterTypeForNavigation(viewType, name);
         }
     }
 }

--- a/Source/Wpf/Prism.Ninject.Wpf/NinjectExtensions.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/NinjectExtensions.cs
@@ -2,6 +2,7 @@
 using Ninject;
 using Ninject.Modules;
 using Ninject.Parameters;
+using Prism.Mvvm;
 
 namespace Prism.Ninject
 {
@@ -43,6 +44,17 @@ namespace Prism.Ninject
         }
 
         /// <summary>
+        /// Registers an object for navigation
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="type">The type of object to register</param>
+        /// <param name="name">The unique name to register with the obect.</param>
+        public static void RegisterTypeForNavigation(this IKernel container, Type type, string name)
+        {
+            container.Bind<object>().To(type).Named(name);
+        }
+
+        /// <summary>
         /// Registers an object for navigation.
         /// </summary>
         /// <typeparam name="T">The Type of the object to register</typeparam>
@@ -65,7 +77,29 @@ namespace Prism.Ninject
         {
             Type type = typeof(T);
             string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
-            kernel.Bind<object>().To<T>().Named(viewName);
+            kernel.RegisterTypeForNavigation(type, viewName);
+        }
+
+        /// <summary>
+        /// Registers an object for navigation.
+        /// </summary>
+        /// <typeparam name="TView">The Type of object to register as the view</typeparam>
+        /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the view</typeparam>
+        /// <param name="name">The unique name to register with the view</param>
+        /// <param name="container"></param>
+        public static void RegisterTypeForNavigation<TView, TViewModel>(this IKernel container, string name = null)
+        {
+            container.RegisterTypeForNavigationWithViewModel<TViewModel>(typeof(TView), name);
+        }
+
+        private static void RegisterTypeForNavigationWithViewModel<TViewModel>(this IKernel container, Type viewType, string name = null)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = viewType.Name;
+
+            ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
+
+            container.RegisterTypeForNavigation(viewType, name);
         }
     }
 }

--- a/Source/Wpf/Prism.Unity.Wpf/UnityExtensions.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/UnityExtensions.cs
@@ -1,21 +1,56 @@
 ﻿using Unity;
 using System;
+using Prism.Mvvm;
 
 namespace Prism.Unity
 {
     public static class UnityExtensions
     {
         /// <summary>
+        /// Registers an object for navigation
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="type">The type of object to register</param>
+        /// <param name="name">The unique name to register with the obect.</param>
+        /// <returns><see cref="IUnityContainer"/></returns>
+        public static IUnityContainer RegisterTypeForNavigation(this IUnityContainer container, Type type, string name)
+        {
+            return container.RegisterType(typeof(object), type, name);
+        }
+
+        /// <summary>
         /// Registers an object for navigation.
         /// </summary>
-        /// <typeparam name="T">The Type of the object to register</typeparam>
-        /// <param name="container"><see cref="IUnityContainer"/> used to register type for Navigation.</param>
+        /// <typeparam name="T">The Type of the object to register as the view</typeparam>
+        /// <param name="container"></param>
         /// <param name="name">The unique name to register with the object.</param>
         public static IUnityContainer RegisterTypeForNavigation<T>(this IUnityContainer container, string name = null)
         {
             Type type = typeof(T);
             string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
-            return container.RegisterType(typeof(object), type, viewName);
+            return container.RegisterTypeForNavigation(type, viewName);
+        }
+
+        /// <summary>
+        /// Registers an object for navigation.
+        /// </summary>
+        /// <typeparam name="TView">The Type of object to register as the view</typeparam>
+        /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the view</typeparam>
+        /// <param name="name">The unique name to register with the view</param>
+        /// <param name="container"></param>
+        public static IUnityContainer RegisterTypeForNavigation<TView, TViewModel>(this IUnityContainer container, string name = null)
+        {
+            return container.RegisterTypeForNavigationWithViewModel<TViewModel>(typeof(TView), name);
+        }
+
+        private static IUnityContainer RegisterTypeForNavigationWithViewModel<TViewModel>(this IUnityContainer container, Type viewType, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = viewType.Name;
+
+            ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
+
+            return container.RegisterTypeForNavigation(viewType, name);
         }
     }
 }


### PR DESCRIPTION
Added new `RegisterTypeForNavigation<View, ViewModel>(key)` method to make overriding the ViewModelLocator naming convention easier.