### PR TITLE
added support for GetNavigationUriPath

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -33,8 +33,17 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC/ViewA/ViewB"); //works
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC"); //works
 
+            //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC/ViewC");
+            //NavigationService.NavigateAsync($"NavigationPage/ViewA/MyTabbedPage/ViewA/ViewB/ViewC");
+            //NavigationService.NavigateAsync($"NavigationPage/ViewA/ViewB/NavigationPage?{KnownNavigationParameters.UseModalNavigation}=true/ViewB/ViewC");
             //NavigationService.NavigateAsync($"NavigationPage/ViewA/ViewB/ViewC?{KnownNavigationParameters.UseModalNavigation}=true");
-            NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage/ViewC?{KnownNavigationParameters.UseModalNavigation}=true/ViewA");
+            //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage/ViewA/ViewC?{KnownNavigationParameters.UseModalNavigation}=true");
+            //NavigationService.NavigateAsync($"ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewC");
+            //NavigationService.NavigateAsync($"ViewA/ViewB/MyMasterDetail/ViewA/ViewC");
+            //NavigationService.NavigateAsync($"ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewB?{KnownNavigationParameters.UseModalNavigation}=true/ViewA/ViewC");
+            //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC");            
+
+            NavigationService.NavigateAsync($"ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewB?{KnownNavigationParameters.UseModalNavigation}=true/ViewA/ViewC");
         }
 
         protected override void RegisterTypes()

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
@@ -25,14 +25,14 @@ namespace ModuleA.ViewModels
         {
             _navigationService = navigationService;
 
-            NavigateCommand = new DelegateCommand(async () => await Navigate());
+            NavigateCommand = new DelegateCommand(Navigate);
         }
 
-        async Task Navigate()
+        void Navigate()
         {
             try
             {
-                await _navigationService.NavigateAsync("../../../MainPage");                
+                var uri = _navigationService.GetNavigationUriPath();
 
                 Debug.WriteLine("After _navigationService.NavigateAsync(ViewB) ...");
             }

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyTabbedPage.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyTabbedPage.xaml
@@ -7,10 +7,10 @@
             xmlns:local="clr-namespace:ModuleA.Views;assembly=ModuleA"
             x:Class="ModuleA.Views.MyTabbedPage">
 
-	<TabbedPage.ToolbarItems>
-		<ToolbarItem Text="Save" Command="{Binding ApplicationCommands.SaveCommand}"/>
-		<ToolbarItem Text="Reset" Command="{Binding ApplicationCommands.ResetCommand}"/>
-	</TabbedPage.ToolbarItems>
+    <TabbedPage.ToolbarItems>
+        <ToolbarItem Text="Save" Command="{Binding ApplicationCommands.SaveCommand}"/>
+        <ToolbarItem Text="Reset" Command="{Binding ApplicationCommands.ResetCommand}"/>
+    </TabbedPage.ToolbarItems>
 
     <!--<NavigationPage Title="View A">
         <x:Arguments>
@@ -26,7 +26,8 @@
 
 	<local:ViewC Title="View C" />-->
 
-	<local:ViewA Title="View A" />
-  <local:ViewB Title="View B"/>
+    <local:ViewA Title="View A" />
+    <local:ViewB Title="View B"/>
+    <local:ViewC Title="View C"/>
 
 </TabbedPage>

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/NavigationPathPageMockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/ViewModels/NavigationPathPageMockViewModel.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Navigation;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.ViewModels
+{
+    public class NavigationPathPageMockViewModel
+    {
+        public INavigationService NavigationService { get; }
+
+        public NavigationPathPageMockViewModel(INavigationService navigationService)
+        {
+            NavigationService = navigationService;
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/NaviationPagePathPageMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/Mocks/Views/NaviationPagePathPageMock.cs
@@ -1,0 +1,60 @@
+﻿using Prism.Common;
+using Prism.Forms.Tests.Mocks;
+using Prism.Forms.Tests.Navigation.Mocks.ViewModels;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Navigation.Mocks.Views
+{
+    public class NavigationPathPageMock : ContentPage
+    {
+        public NavigationPathPageMockViewModel ViewModel { get; }
+        public NavigationPathPageMock()
+        {
+            var navService = new PageNavigationServiceMock(null, new ApplicationProviderMock(), null, null);
+            ((IPageAware)navService).Page = this;
+
+            BindingContext = ViewModel = new NavigationPathPageMockViewModel(navService);
+        }
+    }
+
+    public class NavigationPathPageMock2 : NavigationPathPageMock
+    {
+        public NavigationPathPageMock2()
+        {
+
+        }
+    }
+
+    public class NavigationPathPageMock3 : NavigationPathPageMock
+    {
+        public NavigationPathPageMock3()
+        {
+
+        }
+    }
+
+    public class NavigationPathPageMock4 : NavigationPathPageMock
+    {
+        public NavigationPathPageMock4()
+        {
+
+        }
+    }
+
+    public class NavigationPathTabbedPageMock : TabbedPage
+    {
+        public NavigationPathPageMockViewModel ViewModel { get; }
+
+        public NavigationPathTabbedPageMock()
+        {
+            var navService = new PageNavigationServiceMock(null, new ApplicationProviderMock(), null, null);
+            ((IPageAware)navService).Page = this;
+
+            BindingContext = ViewModel = new NavigationPathPageMockViewModel(navService);
+
+            Children.Add(new NavigationPathPageMock());
+            Children.Add(new NavigationPathPageMock2());
+            Children.Add(new NavigationPathPageMock3());
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationRegistryFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationRegistryFixture.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Prism.Forms.Tests.Navigation
 {
+    [Collection("PageNavigationRegistry")]
     public class PageNavigationRegistryFixture
     {
         [Fact]

--- a/Source/Xamarin/Prism.Forms/Navigation/INavigationServiceExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/INavigationServiceExtensions.cs
@@ -1,5 +1,10 @@
-﻿using System;
+﻿using Prism.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 
 namespace Prism.Navigation
 {
@@ -55,5 +60,189 @@ namespace Prism.Navigation
         {
             return ((INavigateInternal)navigationService).NavigateInternal(uri, parameters, useModalNavigation, animated);
         }
+
+        /// <summary>
+        /// Gets an absolute path of the current page as it relates to it's position in the navigation stack.
+        /// </summary>
+        /// <returns>The absolute path of the current Page</returns>
+        public static string GetNavigationUriPath(this INavigationService navigationService)
+        {
+            var currentpage = ((IPageAware)navigationService).Page;
+
+            Stack<string> stack = new Stack<string>();
+            currentpage = ProcessCurrentPageNavigationPath(currentpage, stack);
+            ProcessNavigationPath(currentpage, stack);
+
+            StringBuilder sb = new StringBuilder();
+            while (stack.Count > 0)
+            {
+                sb.Append($"/{stack.Pop()}");
+            }
+            return sb.ToString();
+        }
+
+        private static void ProcessNavigationPath(Page page, Stack<string> stack)
+        {
+            var parent = page.Parent as Page;
+            if (parent != null)
+            {
+                if (parent is NavigationPage)
+                {
+                    var index = PageUtilities.GetCurrentPageIndex(page, page.Navigation.NavigationStack);
+                    if (index > 0)
+                    {
+                        int previousPageIndex = index - 1;
+                        for (int x = previousPageIndex; x >= 0; x--)
+                        {
+                            AddSegmentToStack(page.Navigation.NavigationStack[x], stack);
+                        }
+                    }
+
+                    AddSegmentToStack(parent, stack);
+                }
+                else if (parent is MasterDetailPage)
+                {
+                    AddSegmentToStack(parent, stack);
+                }
+
+                ProcessNavigationPath(parent, stack);
+            }
+            else
+            {
+                ProcessModalNavigation(page, stack);
+            }
+        }
+
+        private static void ProcessModalNavigation(Page page, Stack<string> stack)
+        {
+            var index = PageUtilities.GetCurrentPageIndex(page, page.Navigation.ModalStack);
+            int previousPageIndex = index - 1;
+            for (int x = previousPageIndex; x >= 0; x--)
+            {
+                var childPage = page.Navigation.ModalStack[x];
+                if (childPage is NavigationPage)
+                {
+                    AddUseModalNavigationParameter(stack);
+                    ProcessModalNavigationPagePath((NavigationPage)childPage, stack);
+                }
+                else if (childPage is MasterDetailPage)
+                {
+                    ProcessModalMasterDetailPagePath((MasterDetailPage)childPage, stack);
+                }
+                else
+                {
+                    AddSegmentToStack(childPage, stack);
+                }
+            }
+
+            ProcessMainPagePath(Application.Current?.MainPage, page, stack);
+        }
+
+        private static void ProcessMainPagePath(Page mainPage, Page previousPage, Stack<string> stack)
+        {
+            if (mainPage == null)
+                return;
+
+            if (previousPage == mainPage)
+                return;
+
+            if (mainPage is NavigationPage)
+            {
+                AddUseModalNavigationParameter(stack);
+                ProcessModalNavigationPagePath((NavigationPage)mainPage, stack);
+            }
+            else if (mainPage is MasterDetailPage)
+            { 
+                var detail = ((MasterDetailPage)mainPage).Detail;
+                if (detail is NavigationPage)
+                {
+                    AddUseModalNavigationParameter(stack);
+                    ProcessModalNavigationPagePath((NavigationPage)detail, stack);
+                }
+                else
+                {
+                    AddSegmentToStack(detail, stack);
+                }
+
+                AddSegmentToStack(mainPage, stack);
+            }  
+            else
+            {
+                AddSegmentToStack(mainPage, stack);
+            }
+        }
+
+        private static void ProcessModalNavigationPagePath(NavigationPage page, Stack<string> stack)
+        {
+            var navStack = page.Navigation.NavigationStack.Reverse();
+            foreach (var child in navStack)
+            {
+                AddSegmentToStack(child, stack);
+            }
+
+            AddSegmentToStack(page, stack);
+        }
+
+        private static void ProcessModalMasterDetailPagePath(MasterDetailPage page, Stack<string> stack)
+        {
+            if (page.Detail is NavigationPage)
+            {
+                AddUseModalNavigationParameter(stack);
+                ProcessModalNavigationPagePath((NavigationPage)page.Detail, stack);
+            }
+            else
+            {
+                AddSegmentToStack(page.Detail, stack);
+            }
+
+            AddSegmentToStack(page, stack);
+        }
+
+        private static Page ProcessCurrentPageNavigationPath(Page page, Stack<string> stack)
+        {
+            var currentPageKeyInfo = PageNavigationRegistry.GetPageNavigationInfo(page.GetType());
+            string currentSegment = $"{currentPageKeyInfo.Name}";
+
+            var parent = page.Parent as Page;
+            if (parent != null)
+            {
+                var parentKeyInfo = PageNavigationRegistry.GetPageNavigationInfo(parent.GetType());
+
+                if (parent is TabbedPage || parent is CarouselPage)
+                {
+                    //set the selected tab to the current page
+                    currentSegment = $"{parentKeyInfo.Name}?{KnownNavigationParameters.SelectedTab}={currentPageKeyInfo.Name}";
+                    page = parent;
+                }
+                else if (parent is MasterDetailPage)
+                {
+                    currentSegment = $"{parentKeyInfo.Name}/{currentPageKeyInfo.Name}";
+                    page = parent;
+                }
+            }
+
+            stack.Push(currentSegment);
+
+            return page;
+        }
+
+        private static void AddSegmentToStack(Page page, Stack<string> stack)
+        {
+            if (page == null)
+                return;
+
+            var keyInfo = PageNavigationRegistry.GetPageNavigationInfo(page.GetType());
+            if (keyInfo != null)
+                stack.Push(keyInfo.Name);
+        }
+
+        private static void AddUseModalNavigationParameter(Stack<string> stack)
+        {
+            var lastPageName = stack.Pop();
+            lastPageName = $"{lastPageName}?{KnownNavigationParameters.UseModalNavigation}=true";
+            stack.Push(lastPageName);
+        }
     }
 }
+
+

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationRegistry.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationRegistry.cs
@@ -25,6 +25,17 @@ namespace Prism.Navigation
             return null;
         }
 
+        public static PageNavigationInfo GetPageNavigationInfo(Type pageType)
+        {
+            foreach (var item in _pageRegistrationCache)
+            {
+                if (item.Value.Type == pageType)
+                    return item.Value;
+            }
+
+            return null;
+        }
+
         public static Type GetPageType(string name)
         {
             return GetPageNavigationInfo(name)?.Type;

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 using Prism.Behaviors;
+using System.Text;
 
 namespace Prism.Navigation
 {


### PR DESCRIPTION
Fixes issue #1109 

You can now get the absolute navigation path of a page by calling `INavigationService.GetNavigationUriPath`.

There may be some edge cases that I may have missed but so far it works with the most complex navigation stacks I have tried.  These are just a few of the paths I have tested.

```
/NavigationPage/ViewA/MyTabbedPage/ViewC

/NavigationPage/ViewA/MyTabbedPage/ViewA/ViewB/ViewC

/NavigationPage/ViewA/ViewB/NavigationPage?useModalNavigation=true/ViewB/ViewC

/NavigationPage/ViewA/ViewB/ViewC?useModalNavigation=true

/MyMasterDetail/NavigationPage/MyTabbedPage/ViewA/ViewC?useModalNavigation=true

/ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewC

/ViewA/ViewB/MyMasterDetail/ViewA/ViewC

/ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewB?useModalNavigation=true/ViewA/ViewC

/MyMasterDetail/MyTabbedPage/ViewA/NavigationPage/ViewC

/MyMasterDetail/NavigationPage/MyTabbedPage?selectedTab=ViewC
```

The only scenario that I know is **not** supported is any type of navigation stack in which you are nested inside a NavigationPage which is a child of a Tab inside a TabbedPage.  Also, if you have a page type registered twice for navigation, but with different names, the first registration will be used.