### PR TITLE
Notification now implements INotifyPropertyChanged

### DIFF
--- a/Source/Wpf/Prism.Wpf/Interactivity/InteractionRequest/Notification.cs
+++ b/Source/Wpf/Prism.Wpf/Interactivity/InteractionRequest/Notification.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,7 +12,7 @@ namespace Prism.Interactivity.InteractionRequest
     /// <summary>
     /// Basic implementation of <see cref="INotification"/>.
     /// </summary>
-    public class Notification : INotification
+    public class Notification : INotification, INotifyPropertyChanged
     {
         /// <summary>
         /// Gets or sets the title to use for the notification.
@@ -22,5 +23,10 @@ namespace Prism.Interactivity.InteractionRequest
         /// Gets or sets the content of the notification.
         /// </summary>
         public object Content { get; set; }
+
+        /// <summary>
+        /// This is implemented to prevent a memeory leak from occuring due to WPF binding to a class that does not implement INotifyPropertyChanged.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }


### PR DESCRIPTION
﻿### Description of Change ###

Notification now implements INotifyPropertyChanged, but doesn't actually call it. This is done to fix a known issues with the WPF binding system creating a memory leak when binding to an object that isn't a DO or implements INPC.

### Bugs Fixed ###

- #1297

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard