### PR TITLE
#1338 adds IContainerProvider to OnInitialized, removes Initialize

### DIFF
--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Modules/ModuleMock.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Modules/ModuleMock.cs
@@ -8,12 +8,7 @@ namespace Prism.DI.Forms.Tests.Mocks.Modules
         public bool Initialized { get; private set; }
         public bool RegisterTypesCalled { get; private set; }
 
-        public void Initialize()
-        {
-            
-        }
-
-        public void OnInitialized()
+        public void OnInitialized(IContainerProvider containerProvider)
         {
             Initialized = true;
         }

--- a/Source/Xamarin/Prism.Forms/Modularity/IModule.cs
+++ b/Source/Xamarin/Prism.Forms/Modularity/IModule.cs
@@ -9,12 +9,6 @@ namespace Prism.Modularity
     public interface IModule
     {
         /// <summary>
-        /// Notifies the module that it is being initialized.
-        /// </summary>
-        [Obsolete("Please move all code into the RegisterTypes and OnInitialized methods. This method will be removed.")]
-        void Initialize();
-
-        /// <summary>
         /// Used to register types with the container that will be used by your application.
         /// </summary>
         void RegisterTypes(IContainerRegistry containerRegistry);
@@ -22,6 +16,6 @@ namespace Prism.Modularity
         /// <summary>
         /// Notifies the module that it has be initialized.
         /// </summary>
-        void OnInitialized();
+        void OnInitialized(IContainerProvider containerProvider);
     }
 }

--- a/Source/Xamarin/Prism.Forms/Modularity/ModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Forms/Modularity/ModuleInitializer.cs
@@ -17,9 +17,8 @@ namespace Prism.Modularity
             var module = CreateModule(moduleInfo.ModuleType);
             if (module != null)
             {
-                module.Initialize();
                 module.RegisterTypes(_container);
-                module.OnInitialized();
+                module.OnInitialized(_container);
             }
         }
 


### PR DESCRIPTION
﻿### Description of Change ###

- Removes Initialize method
- Adds IContainerProvider to OnInitialized

### Bugs Fixed ###

- #1338 
- Prevents new modules from implementing the deprecated Initialize method as there is no warning that it is obsolete
- Aligns Prism.Forms `IModule` with Prism.Wpf `IModule` #1339 

### API Changes ###

List all API changes here (or just put None), example:

Removed:
 - `IModule.Initialize()`

Changed:
 - `IModule.OnInitialized()` => `IModule.OnInitialized(IContainerProvider)`

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard