### PR TITLE
Container provider

### DIFF
--- a/Source/Prism.Tests/Prism.Tests.csproj
+++ b/Source/Prism.Tests/Prism.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <ProjectReference Include="..\Prism\Prism.csproj" />
   </ItemGroup>
 

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
@@ -22,6 +23,8 @@
   <ItemGroup>
     <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="..\Prism.DI.Forms.Tests\**\*.cs" />
+    <Compile Update="..\Prism.DI.Forms.Tests\**\*.xaml.cs" DependentUpon="%(Filename)" />
+    <EmbeddedResource Include="..\Prism.DI.Forms.Tests\**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -20,7 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs" />
+    <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\Prism.DI.Forms.Tests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/ContainerProviderFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/ContainerProviderFixture.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using Prism.DI.Forms.Tests;
+using Prism.DI.Forms.Tests.Mocks;
+using Prism.DI.Forms.Tests.Mocks.ViewModels;
+using Prism.DI.Forms.Tests.Mocks.Views;
+using Prism.Events;
+using Prism.Forms.Tests.Mocks.Events;
+using Prism.Ioc;
+using Xunit;
+using Xunit.Abstractions;
+
+#if Autofac
+namespace Prism.Autofac.Forms.Tests.Fixtures
+#elif DryIoc
+namespace Prism.DryIoc.Forms.Tests.Fixtures
+#elif Ninject
+namespace Prism.Ninject.Forms.Tests.Fixtures
+#elif Unity
+namespace Prism.Unity.Forms.Tests.Fixtures
+#endif
+{
+    public class ContainerProviderFixture
+    {
+        ITestOutputHelper _testOutputHelper { get; }
+
+        public ContainerProviderFixture(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            Xamarin.Forms.Mocks.MockForms.Init();
+        }
+
+        private PrismApplicationMock CreateMockApplication()
+        {
+            var initializer = new XunitPlatformInitializer(_testOutputHelper);
+            return new PrismApplicationMock(initializer);
+        }
+
+        [Fact]
+        public void CanResolveUnnamedType()
+        {
+            var app = CreateMockApplication();
+            
+            var containerProvider = new ContainerProvider<ConcreteTypeMock>();
+            ConcreteTypeMock type = (ConcreteTypeMock) containerProvider;
+            Assert.NotNull(type);
+
+            Assert.IsType<ConcreteTypeMock>(type);
+        }
+
+        [Fact]
+        public void CanResolvedNamedType()
+        {
+            var app = CreateMockApplication();
+            var containerProvider = new ContainerProvider<ViewModelBMock>
+            {
+                Name = ViewModelBMock.Key
+            };
+
+            ViewModelBMock vm = (ViewModelBMock)containerProvider;
+            Assert.NotNull(vm);
+            Assert.IsType<ViewModelBMock>(vm);
+        }
+
+        [Fact]
+        public void ProvidesValueFromResourceDictionary()
+        {
+            var app = CreateMockApplication();
+            var ea = app.Container.Resolve<IEventAggregator>();
+            var events = new List<string>();
+            ea.GetEvent<TestActionEvent>().Subscribe((m) => events.Add(m));
+            app.NavigationService.NavigateAsync("XamlViewMock");
+            Assert.Contains(events, e => e == "Convert");
+            Assert.NotNull(app.MainPage);
+            var xamlView = app.MainPage as XamlViewMock;
+            var viewModel = xamlView.BindingContext as XamlViewMockViewModel;
+
+            xamlView.TestEntry.Text = "Foo Bar";
+            Assert.Contains(events, e => e == "ConvertBack");
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Converters/MockValueConverter.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Converters/MockValueConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using Xamarin.Forms;
+using Prism.Forms.Tests.Mocks.Events;
+using Prism.Events;
+
+namespace Prism.Forms.Tests.Mocks.Converters
+{
+    public class MockValueConverter : IValueConverter
+    {
+        private IEventAggregator _eventAggreator { get; }
+
+        public MockValueConverter(IEventAggregator eventAggreator)
+        {
+            _eventAggreator = eventAggreator;
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            _eventAggreator.GetEvent<TestActionEvent>().Publish("Convert");
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            _eventAggreator.GetEvent<TestActionEvent>().Publish("ConvertBack");
+            return value;
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Events/TestActionEvent.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Events/TestActionEvent.cs
@@ -1,0 +1,9 @@
+using Prism.Events;
+
+namespace Prism.Forms.Tests.Mocks.Events
+{
+    public class TestActionEvent : PubSubEvent<string>
+    {
+        
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationMock.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationMock.cs
@@ -61,6 +61,7 @@ namespace Prism.DI.Forms.Tests
             containerRegistry.RegisterForNavigation<ViewAMock, ViewModelAMock>();
             containerRegistry.RegisterForNavigation<AutowireView, AutowireViewModel>();
             containerRegistry.RegisterForNavigation<ConstructorArgumentView, ConstructorArgumentViewModel>();
+            containerRegistry.RegisterForNavigation<XamlViewMock>();
 
             DependencyService.Register<IDependencyServiceMock, DependencyServiceMock>();
         }

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/XamlViewMockViewModel.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/XamlViewMockViewModel.cs
@@ -1,0 +1,14 @@
+using Prism.Mvvm;
+
+namespace Prism.DI.Forms.Tests.Mocks.ViewModels
+{
+    public class XamlViewMockViewModel : BindableBase
+    {
+        private string _test = "Initial Value";
+        public string Test
+        {
+            get => _test;
+            set => SetProperty(ref _test, value);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/XamlViewMock.xaml
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/XamlViewMock.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:prism="clr-namespace:Prism.Ioc;assembly=Prism.Forms"
+    xmlns:converters="using:Prism.Forms.Tests.Mocks.Converters"
+    Title="{Binding Title}"
+    x:Class="Prism.DI.Forms.Tests.Mocks.Views.XamlViewMock">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <prism:ContainerProvider x:TypeArguments="converters:MockValueConverter" x:Key="mockValueConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Entry x:Name="testEntry"
+           Text="{Binding Test,Converter={StaticResource mockValueConverter}}" />
+</ContentPage>

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/XamlViewMock.xaml.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/XamlViewMock.xaml.cs
@@ -1,0 +1,16 @@
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Prism.DI.Forms.Tests.Mocks.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class XamlViewMock : ContentPage
+    {
+        public XamlViewMock()
+        {
+            InitializeComponent();
+        }
+
+        public Entry TestEntry => this.testEntry;
+    }
+}

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
@@ -22,6 +23,8 @@
   <ItemGroup>
     <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="..\Prism.DI.Forms.Tests\**\*.cs" />
+    <Compile Update="..\Prism.DI.Forms.Tests\**\*.xaml.cs" DependentUpon="%(Filename)" />
+    <EmbeddedResource Include="..\Prism.DI.Forms.Tests\**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -20,7 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs" />
+    <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\Prism.DI.Forms.Tests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="..\Prism.DI.Forms.Tests\MockForms.cs" Link="MockForms.cs" />
   </ItemGroup>
 

--- a/Source/Xamarin/Prism.Forms/Ioc/ContainerProvider.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/ContainerProvider.cs
@@ -54,6 +54,7 @@
         public static implicit operator T(ContainerProvider<T> containerProvider)
         {
             var container = PrismApplicationBase.Current.Container;
+            if (container == null) return default(T);
             if (string.IsNullOrWhiteSpace(containerProvider.Name))
             {
                 return container.Resolve<T>();

--- a/Source/Xamarin/Prism.Forms/Ioc/ContainerProvider.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/ContainerProvider.cs
@@ -1,0 +1,65 @@
+﻿namespace Prism.Ioc
+{
+    /// <summary>
+    /// Provides Types and Services registered with the Container
+    /// </summary>
+    /// <typeparam name="T">The type to Resolve</typeparam>
+    /// <example>
+    /// We can use this to build better types such as ValueConverters with full dependency injection
+    /// <code>
+    /// public class MyValueConverter : IValueConverter
+    /// {
+    ///     private ILoggerFacade _logger { get; }
+    ///     public MyValueConverter(ILoggerFacade logger)
+    ///     {
+    ///         _logger = logger;
+    ///     }
+    /// 
+    ///     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    ///     {
+    ///         _logger.Log($"Converting {value.GetType().Name} to {targetType.Name}", Category.Debug, Priority.None);
+    ///         // do stuff
+    ///     }
+    /// 
+    ///     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    ///     {
+    ///         _logger.Log($"Converting back from {value.GetType().Name} to {targetType.Name}", Category.Debug, Priority.None);
+    ///         return null;
+    ///     }
+    /// }
+    /// </code>
+    /// We can then simply use our ValueConveter or other class directly in XAML
+    /// <![CDATA[
+    /// <ContentPage xmlns:prism="clr-namespace:Prism.Ioc;assembly=Prism.Forms">
+    ///     <ContentPage.Resources>
+    ///         <ResourceDictionary>
+    ///             <prism:ContainerProvider x:TypeArguments="MyValueConverter" x:Key="myValueConverter" />
+    ///         <ResourceDictionary>
+    ///     <ContentPage.Resources>
+    ///     <Label Text="{Binding SomeProp,Converter={StaticResource myValueConverter}}" />
+    /// </ContentPage>
+    /// ]]>
+    /// </example>
+    public class ContainerProvider<T>
+    {
+        /// <summary>
+        /// The Name used to register the type with the Container
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Resolves the specified type from the Application's Container
+        /// </summary>
+        /// <param name="containerProvider"></param>
+        public static implicit operator T(ContainerProvider<T> containerProvider)
+        {
+            var container = PrismApplicationBase.Current.Container;
+            if (string.IsNullOrWhiteSpace(containerProvider.Name))
+            {
+                return container.Resolve<T>();
+            }
+
+            return container.Resolve<T>(containerProvider.Name);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -17,6 +17,7 @@ namespace Prism
 {
     public abstract class PrismApplicationBase : Application
     {
+        public new static PrismApplicationBase Current => (PrismApplicationBase) Application.Current;
         public const string NavigationServiceName = "PageNavigationService";
         public const string NavigationServiceParameterName = "navigationService";
         IContainerExtension _containerExtension;

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
@@ -22,6 +23,8 @@
   <ItemGroup>
     <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="..\Prism.DI.Forms.Tests\**\*.cs" />
+    <Compile Update="..\Prism.DI.Forms.Tests\**\*.xaml.cs" DependentUpon="%(Filename)" />
+    <EmbeddedResource Include="..\Prism.DI.Forms.Tests\**\*.xaml" SubType="Designer" Generator="MSBuild:UpdateDesignTimeXaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -20,7 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Prism.DI.Forms.Tests/**/*.cs" />
+    <None Include="..\..\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\Prism.DI.Forms.Tests\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/xunit.runner.json
+++ b/Source/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "maxParallelThreads": 1
+}


### PR DESCRIPTION
﻿### Description of Change ###

Adds ContainerProvider to resolve types in XAML

### Bugs Fixed ###

- Fixes #1347 
- Should fix randomly failing tests...

### API Changes ###

Added:

- ContainerProvider<T> to allow resolving types in XAML

```xml
<ContentPage xmlns:ioc="clr-namespace:Prism.Ioc;assembly=Prism.Forms"
             xmlns:converters="using:MyApp.Converters">
    <ContentPage.Resources>
        <ResourceDictionary>
            <ioc:ContainerProvider x:TypeArguments="converters:MyAwesomeConverter" 
                                   x:Key="myConverter" />
        </ResourceDictionary>
    </ContentPage.Resources>
    <Label Text="{Binding Foo,Converter={StaticResource myConverter}}" />
</ContentPage
```

### Behavioral Changes ###

none

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard