### PR TITLE
added support for INavAware methods on CarouselPage

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.cs
@@ -45,7 +45,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewB?{KnownNavigationParameters.UseModalNavigation}=true/ViewA/ViewC");
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC");            
 
-            NavigationService.NavigateAsync($"MyMasterDetail/MyNavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC");
+            NavigationService.NavigateAsync($"MyCarouselPage?{KnownNavigationParameters.SelectedTab}=ViewB");
         }
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleA.csproj
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleA.csproj
@@ -38,12 +38,16 @@
     <Compile Include="ApplicationCommands.cs" />
     <Compile Include="ModuleAModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ViewModels\MyCarouselPageViewModel.cs" />
     <Compile Include="ViewModels\MyTabbedPageViewModel.cs" />
     <Compile Include="ViewModels\ViewAViewModel.cs" />
     <Compile Include="ViewModels\ViewBViewModel.cs" />
     <Compile Include="ViewModels\ViewCViewModel.cs" />
     <Compile Include="Views\MasterNavigation.xaml.cs">
       <DependentUpon>MasterNavigation.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\MyCarouselPage.xaml.cs">
+      <DependentUpon>MyCarouselPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\MyTabbedPage.xaml.cs">
       <DependentUpon>MyTabbedPage.xaml</DependentUpon>
@@ -118,6 +122,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\MyTabbedPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Views\MyCarouselPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleAModule.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleAModule.cs
@@ -25,6 +25,7 @@ namespace ModuleA
             containerRegistry.RegisterForNavigation<ViewA>();
             containerRegistry.RegisterForNavigation<ViewB>();
             containerRegistry.RegisterForNavigation<ViewC>();
+            containerRegistry.RegisterForNavigation<MyCarouselPage>();
 
             containerRegistry.RegisterSingleton<IApplicationCommands, ApplicationCommands>();
         }

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/MyCarouselPageViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/MyCarouselPageViewModel.cs
@@ -1,0 +1,32 @@
+﻿using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Navigation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ModuleA.ViewModels
+{
+    public class MyCarouselPageViewModel : BindableBase, INavigationAware
+    {
+        public MyCarouselPageViewModel()
+        {
+
+        }
+
+        public void OnNavigatedFrom(INavigationParameters parameters)
+        {
+            
+        }
+
+        public void OnNavigatedTo(INavigationParameters parameters)
+        {
+            
+        }
+
+        public void OnNavigatingTo(INavigationParameters parameters)
+        {
+            
+        }
+    }
+}

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyCarouselPage.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyCarouselPage.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CarouselPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
+             prism:ViewModelLocator.AutowireViewModel="True"
+              xmlns:local="clr-namespace:ModuleA.Views"
+             x:Class="ModuleA.Views.MyCarouselPage">
+    <local:ViewA />
+    <local:ViewB />
+    <local:ViewC />
+
+</CarouselPage>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyCarouselPage.xaml.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyCarouselPage.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace ModuleA.Views
+{
+    public partial class MyCarouselPage : CarouselPage
+    {
+        public MyCarouselPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -167,7 +167,7 @@ namespace Prism.Navigation
                 result.Exception = new Exception("GoBackToRootAsync can only be called when the calling Page is within a NavigationPage.", ex);
                 return result;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 result.Exception = ex;
                 return result;
@@ -275,14 +275,14 @@ namespace Prism.Navigation
                     await ProcessNavigationForAbsoulteUri(navigationSegments, parameters, useModalNavigation, animated);
                     result.Success = true;
                     return result;
-                }                    
+                }
                 else
                 {
                     await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
                     result.Success = true;
                     return result;
                 }
-                    
+
             }
             catch (Exception ex)
             {
@@ -600,14 +600,12 @@ namespace Prism.Navigation
         {
             PageUtilities.OnNavigatingTo(toPage, parameters);
 
-            if (toPage is TabbedPage)
+            if (toPage is TabbedPage tabbedPage)
             {
-                var tabbedPage = (TabbedPage)toPage;
                 foreach (var child in tabbedPage.Children)
                 {
-                    if (child is NavigationPage)
+                    if (child is NavigationPage navigationPage)
                     {
-                        var navigationPage = (NavigationPage)child;
                         PageUtilities.OnNavigatingTo(navigationPage.CurrentPage, parameters);
                     }
                     else
@@ -616,18 +614,23 @@ namespace Prism.Navigation
                     }
                 }
             }
+            else if (toPage is CarouselPage carouselPage)
+            {
+                foreach (var child in carouselPage.Children)
+                {
+                    PageUtilities.OnNavigatingTo(child, parameters);
+                }
+            }
         }
 
         private static void OnNavigatedTo(Page toPage, INavigationParameters parameters)
         {
             PageUtilities.OnNavigatedTo(toPage, parameters);
 
-            if (toPage is TabbedPage)
+            if (toPage is TabbedPage tabbedPage)
             {
-                var tabbedPage = (TabbedPage)toPage;
-                if (tabbedPage.CurrentPage is NavigationPage)
+                if (tabbedPage.CurrentPage is NavigationPage navigationPage)
                 {
-                    var navigationPage = (NavigationPage)tabbedPage.CurrentPage;
                     PageUtilities.OnNavigatedTo(navigationPage.CurrentPage, parameters);
                 }
                 else
@@ -636,18 +639,20 @@ namespace Prism.Navigation
                         PageUtilities.OnNavigatedTo(tabbedPage.CurrentPage, parameters);
                 }
             }
+            else if (toPage is CarouselPage carouselPage)
+            {
+                PageUtilities.OnNavigatedTo(carouselPage.CurrentPage, parameters);
+            }
         }
 
         private static void OnNavigatedFrom(Page fromPage, INavigationParameters parameters)
         {
             PageUtilities.OnNavigatedFrom(fromPage, parameters);
 
-            if (fromPage is TabbedPage)
+            if (fromPage is TabbedPage tabbedPage)
             {
-                var tabbedPage = (TabbedPage)fromPage;
-                if (tabbedPage.CurrentPage is NavigationPage)
+                if (tabbedPage.CurrentPage is NavigationPage navigationPage)
                 {
-                    var navigationPage = (NavigationPage)tabbedPage.CurrentPage;
                     PageUtilities.OnNavigatedFrom(navigationPage.CurrentPage, parameters);
                 }
                 else
@@ -655,6 +660,10 @@ namespace Prism.Navigation
                     if (tabbedPage.BindingContext != tabbedPage.CurrentPage.BindingContext)
                         PageUtilities.OnNavigatedFrom(tabbedPage.CurrentPage, parameters);
                 }
+            }
+            else if (fromPage is CarouselPage carouselPage)
+            {
+                PageUtilities.OnNavigatedFrom(carouselPage.CurrentPage, parameters);
             }
         }
 


### PR DESCRIPTION
﻿### Description of Change ###

Added support for the INavigationAware methods for the CarouselPage

### Bugs Fixed ###

- #1354 

### Behavioral Changes ###

The INavigationAware methods now properly fire for both the CarouselPage and the children of the CarouselPage.

Some INavigationAware methods are now fired on all Children:
- OnNavigatingTo will be invoked on the CarouselPage and ALL CHILDREN.
- OnNavigatedTo will be invoked on the CarouselPage and only the SELECTED PAGE.
- OnNavigatedFrom will be invoked on the CarouselPage and only the SELECTED PAGE.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard