### PR TITLE
DryIoc tests

### DIFF
--- a/Source/Prism.Tests/Prism.Tests.csproj
+++ b/Source/Prism.Tests/Prism.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>Prism.Autofac.Forms.Tests</RootNamespace>
     <AssemblyName>Prism.Autofac.Forms.Tests</AssemblyName>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
@@ -14,6 +14,7 @@ using Prism.DI.Forms.Tests.Mocks.Modules;
 using Prism.DI.Forms.Tests.Mocks.Services;
 using Prism.DI.Forms.Tests.Mocks.ViewModels;
 using Prism.DI.Forms.Tests.Mocks.Views;
+using Prism.DI.Forms.Tests.Navigation;
 using Prism.Forms.Tests.Mocks.Logging;
 using Prism.Ioc;
 using Prism.Logging;
@@ -212,6 +213,27 @@ namespace Prism.Unity.Forms.Tests.Fixtures
             {
                 _testOutputHelper.WriteLine("Container Supports Modules");
             }
+        }
+
+        [Fact]
+        public void CustomNavigation_Resolved_In_PrismApplication()
+        {
+            var app = new PrismApplicationCustomNavMock(new XunitPlatformInitializer(_testOutputHelper));
+            var navService = app.GetNavigationService();
+            Assert.NotNull(navService);
+            Assert.IsType<CustomNavigationServiceMock>(navService);
+        }
+
+        [Fact]
+        public void CustomNavigation_Resolved_In_ViewModel()
+        {
+            var app = new PrismApplicationCustomNavMock(new XunitPlatformInitializer(_testOutputHelper));
+            app.MainPage = new AutowireView();
+            var vm = app.MainPage.BindingContext as AutowireViewModel;
+
+            Assert.NotNull(vm);
+            Assert.NotNull(vm.NavigationService);
+            Assert.IsType<CustomNavigationServiceMock>(vm.NavigationService);
         }
 
         private static INavigationService ResolveAndSetRootPage(PrismApplicationMock app)

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Navigation/CustomNavigationServiceMock.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Navigation/CustomNavigationServiceMock.cs
@@ -1,0 +1,17 @@
+using Prism.AppModel;
+using Prism.Behaviors;
+using Prism.Common;
+using Prism.Ioc;
+using Prism.Logging;
+using Prism.Navigation;
+
+namespace Prism.DI.Forms.Tests.Navigation
+{
+    public class CustomNavigationServiceMock : PageNavigationService
+    {
+        public CustomNavigationServiceMock(IContainerExtension container, IApplicationProvider applicationProvider, IPageBehaviorFactory pageBehaviorFactory, ILoggerFacade logger) 
+            : base(container, applicationProvider, pageBehaviorFactory, logger)
+        {
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationCustomNavMock.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationCustomNavMock.cs
@@ -1,0 +1,26 @@
+using Prism;
+using Prism.Ioc;
+using Prism.Navigation;
+using Prism.DI.Forms.Tests.Navigation;
+
+namespace Prism.DI.Forms.Tests
+{
+    public class PrismApplicationCustomNavMock : PrismApplicationMock
+    {
+        public PrismApplicationCustomNavMock(IPlatformInitializer initializer)
+            : base(initializer)
+        {
+            
+        }
+
+        protected override void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+#if DryIoc
+            containerRegistry.Register<INavigationService, CustomNavigationServiceMock>();
+#endif
+            containerRegistry.Register<INavigationService, CustomNavigationServiceMock>(NavigationServiceName);
+        }
+
+        public INavigationService GetNavigationService() => NavigationService;
+    }
+}

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>Prism.DryIoc.Forms.Tests</RootNamespace>
     <AssemblyName>Prism.DryIoc.Forms.Tests</AssemblyName>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;RELEASE;NETCOREAPP1_1</DefineConstants>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>Prism.Unity.Forms.Tests</RootNamespace>
     <AssemblyName>Prism.Unity.Forms.Tests</AssemblyName>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
﻿### Description of Change ###

Adding tests for Custom Navigation Service. Due to the very unique way that we are injecting the NavigationService in DryIoc we actually have `INavigationService` registered twice, once as a named service and once as an unnamed service. The Unnamed version is what gets used when we inject it into a ViewModel.

### Bugs Fixed ###

- #1381 Tests

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard