### PR TITLE
bump to 7.1

### DIFF
--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -12,7 +12,7 @@
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <Version Condition=" '$(PRISM_CORE_VERSION)' != '' ">$(PRISM_CORE_VERSION)</Version>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_CORE_VERSION)' == '' ">7.0.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_CORE_VERSION)' == '' ">7.1.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_CORE_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_CORE_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -10,7 +10,7 @@
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <Version Condition=" '$(PRISM_AUTOFAC_FORMS_VERSION)' != '' ">$(PRISM_AUTOFAC_FORMS_VERSION)</Version>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_AUTOFAC_FORMS_VERSION)' == '' ">7.0.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_AUTOFAC_FORMS_VERSION)' == '' ">7.1.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_AUTOFAC_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_AUTOFAC_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -10,7 +10,7 @@
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <Version Condition=" '$(PRISM_DRYIOC_FORMS_VERSION)' != '' ">$(PRISM_DRYIOC_FORMS_VERSION)</Version>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_DRYIOC_FORMS_VERSION)' == '' ">7.0.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_DRYIOC_FORMS_VERSION)' == '' ">7.1.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_DRYIOC_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_DRYIOC_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -10,7 +10,7 @@
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <Version Condition=" '$(PRISM_FORMS_VERSION)' != '' ">$(PRISM_FORMS_VERSION)</Version>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_FORMS_VERSION)' == '' ">7.0.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_FORMS_VERSION)' == '' ">7.1.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -11,7 +11,7 @@
     <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
     <Version Condition=" '$(PRISM_UNITY_FORMS_VERSION)' != '' ">$(PRISM_UNITY_FORMS_VERSION)</Version>
     <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_UNITY_FORMS_VERSION)' == '' ">7.0.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_UNITY_FORMS_VERSION)' == '' ">7.1.0</VersionPrefix>
     <!-- This will create CI builds as 7.0.0.1234-ci -->
     <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_UNITY_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(VersionPrefix).$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
     <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(PRISM_UNITY_FORMS_VERSION)' == '' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">ci</VersionSuffix>


### PR DESCRIPTION
﻿### Description of Change ###

Due to the breaking changes that have been made for cross platform compatibility with INavigationService, and other upcoming changes Prism Core and all Prism Forms projects are bumping to 7.1. Prism WPF/Windows are staying at 7.0 since they have yet to release a stable package.