### PR TITLE
[DryIoc] Update default container rules.

### DIFF
--- a/Source/Wpf/Prism.DryIoc.Wpf/PrismApplication.cs
+++ b/Source/Wpf/Prism.DryIoc.Wpf/PrismApplication.cs
@@ -13,7 +13,9 @@ namespace Prism.DryIoc
         /// Create <see cref="Rules" /> to alter behavior of <see cref="IContainer" />
         /// </summary>
         /// <returns>An instance of <see cref="Rules" /></returns>
-        protected virtual Rules CreateContainerRules() => Rules.Default.WithAutoConcreteTypeResolution();
+        protected virtual Rules CreateContainerRules() => Rules.Default.WithAutoConcreteTypeResolution()
+                                                                       .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
+                                                                       .WithDefaultIfAlreadyRegistered(IfAlreadyRegistered.Replace);
 
         protected override IContainerExtension CreateContainerExtension()
         {

--- a/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
@@ -20,29 +20,22 @@ namespace Prism.DryIoc
 
         public void RegisterInstance(Type type, object instance)
         {
-            Instance.UseInstance(type, instance, IfAlreadyRegistered.Replace);
+            Instance.UseInstance(type, instance);
         }
 
         public void RegisterSingleton(Type from, Type to)
         {
-            Instance.Register(from, to, Reuse.Singleton,
-                              made: Made.Of(FactoryMethod.ConstructorWithResolvableArguments),
-                              ifAlreadyRegistered: IfAlreadyRegistered.Replace);
+            Instance.Register(from, to, Reuse.Singleton);
         }
 
         public void Register(Type from, Type to)
         {
-            Instance.Register(from, to,
-                              made: Made.Of(FactoryMethod.ConstructorWithResolvableArguments),
-                              ifAlreadyRegistered: IfAlreadyRegistered.Replace);
+            Instance.Register(from, to);
         }
 
         public void Register(Type from, Type to, string name)
         {
-            Instance.Register(from, to,
-                              made: Made.Of(FactoryMethod.ConstructorWithResolvableArguments),
-                              ifAlreadyRegistered: IfAlreadyRegistered.Replace,
-                              serviceKey: name);
+            Instance.Register(from, to, serviceKey: name);
         }
 
         public object Resolve(Type type)

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -27,7 +27,9 @@ namespace Prism.DryIoc
         /// Create <see cref="Rules" /> to alter behavior of <see cref="IContainer" />
         /// </summary>
         /// <returns>An instance of <see cref="Rules" /></returns>
-        protected virtual Rules CreateContainerRules() => Rules.Default.WithAutoConcreteTypeResolution();
+        protected virtual Rules CreateContainerRules() => Rules.Default.WithAutoConcreteTypeResolution()
+                                                                       .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
+                                                                       .WithDefaultIfAlreadyRegistered(IfAlreadyRegistered.Replace);
 
         /// <summary>
         /// Configures the Container.


### PR DESCRIPTION
﻿### Description of Change ###

Update default container rules in Prism.DryIoc.Wpf and Prism.DryIoc.Forms.

Type registration from DryIocContainerExtension has become inconsistent between WPF and Xamarin since commit 9b82533.
This commit makes both platforms behave the same way again.

Moving the mentioned changes to the default container rules makes type registration from the container and container extension behave consistently and allows to override the behavior of the container extension.

### Bugs Fixed ###

Fixes a bug equivalent to #1304 on WPF platform.

### API Changes ###

None

### Behavioral Changes ###

By default, the container will resolve types using the constructor with the most resolvable arguments.
The container extension will use default rules for registration (no change for WPF).

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard