### PR TITLE
Allow type based resolution for INavigationService in ViewModels

### DIFF
--- a/Source/Xamarin/Prism.Autofac.Forms/AutofacContainerExtension.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/AutofacContainerExtension.cs
@@ -1,6 +1,8 @@
 ﻿using Autofac;
+using Autofac.Core;
 using Autofac.Features.ResolveAnything;
 using Prism.Ioc;
+using Prism.Navigation;
 using System;
 using Xamarin.Forms;
 
@@ -58,10 +60,10 @@ namespace Prism.Autofac
 
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
-            NamedParameter parameter = null;
+            Parameter parameter = null;
             if (view is Page page)
             {
-                parameter = new NamedParameter(PrismApplicationBase.NavigationServiceParameterName, this.CreateNavigationService(page));
+                parameter = new TypedParameter(typeof(INavigationService), this.CreateNavigationService(page));
             }
 
             return Instance.Resolve(viewModelType, parameter);

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
@@ -236,6 +236,16 @@ namespace Prism.Unity.Forms.Tests.Fixtures
             Assert.IsType<CustomNavigationServiceMock>(vm.NavigationService);
         }
 
+        [Fact]
+        public void CustomNamedNavigationService_Resolved_In_ViewModel()
+        {
+            var app = CreateMockApplication(new CustomNamedNavService());
+            var vm = app.MainPage.BindingContext as CustomNamedNavServiceViewModel;
+
+            Assert.NotNull(vm);
+            Assert.NotNull(vm.NavigationService);
+        }
+
         private static INavigationService ResolveAndSetRootPage(PrismApplicationMock app)
         {
             var navigationService = app.NavigationService;

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/CustomNamedNavServiceViewModel.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/CustomNamedNavServiceViewModel.cs
@@ -1,0 +1,12 @@
+using Prism.Navigation;
+
+namespace Prism.DI.Forms.Tests.Mocks.ViewModels
+{
+    public class CustomNamedNavServiceViewModel
+    {
+        public INavigationService NavigationService { get; }
+
+        public CustomNamedNavServiceViewModel(INavigationService meaninglessName) => 
+            NavigationService = meaninglessName;
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/CustomNamedNavService.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/CustomNamedNavService.cs
@@ -1,0 +1,13 @@
+using Prism.Mvvm;
+using Xamarin.Forms;
+
+namespace Prism.DI.Forms.Tests.Mocks.Views
+{
+    public class CustomNamedNavService : Page
+    {
+        public CustomNamedNavService()
+        {
+            ViewModelLocator.SetAutowireViewModel(this, true);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Unity.Forms/UnityContainerExtension.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityContainerExtension.cs
@@ -47,14 +47,17 @@ namespace Prism.Unity
 
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
-            ParameterOverrides overrides = null;
+            ResolverOverride[] overrides = null;
 
-            if (view is Xamarin.Forms.Page page)
+            if(view is Xamarin.Forms.Page page)
             {
-                overrides = new ParameterOverrides
-                    {
-                        { PrismApplicationBase.NavigationServiceParameterName, this.CreateNavigationService(page) }
-                    };
+                overrides = new ResolverOverride[]
+                {
+                    new DependencyOverride(
+                        typeof(Navigation.INavigationService),
+                        this.CreateNavigationService(page)
+                    )
+                };
             }
 
             return Instance.Resolve(viewModelType, overrides);


### PR DESCRIPTION
﻿### Description of Change ###

Fixes #1464 

Unity and Autofac now allow INavigationService to have any name inside of a ViewModel.

### API Changes ###

None

### Behavioral Changes ###

ViewModels may now name INavigationService anything when resolving inside of a ViewModel handled by the ViewModelLocator.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard