### PR TITLE
Test updates

### DIFF
--- a/Source/Prism.Tests/Events/DelegateReferenceFixture.cs
+++ b/Source/Prism.Tests/Events/DelegateReferenceFixture.cs
@@ -1,6 +1,7 @@
 using System;
-using Xunit;
+using System.Threading.Tasks;
 using Prism.Events;
+using Xunit;
 
 namespace Prism.Tests.Events
 {
@@ -19,19 +20,20 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
-        public void NotKeepAliveAllowsDelegateToBeCollected()
+        public async Task NotKeepAliveAllowsDelegateToBeCollected()
         {
             var delegates = new SomeClassHandler();
             var delegateReference = new DelegateReference((Action<string>)delegates.DoEvent, false);
 
             delegates = null;
+            await Task.Delay(100);
             GC.Collect();
 
             Assert.Null(delegateReference.Target);
         }
 
         [Fact]
-        public void NotKeepAliveKeepsDelegateIfStillAlive()
+        public async Task NotKeepAliveKeepsDelegateIfStillAlive()
         {
             var delegates = new SomeClassHandler();
             var delegateReference = new DelegateReference((Action<string>)delegates.DoEvent, false);
@@ -42,6 +44,7 @@ namespace Prism.Tests.Events
 
             GC.KeepAlive(delegates);  //Makes delegates ineligible for garbage collection until this point (to prevent oompiler optimizations that may release the referenced object prematurely).
             delegates = null;
+            await Task.Delay(100);
             GC.Collect();
 
             Assert.Null(delegateReference.Target);
@@ -60,7 +63,7 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
-        public void ShouldAllowCollectionOfOriginalDelegate()
+        public async Task ShouldAllowCollectionOfOriginalDelegate()
         {
             var classHandler = new SomeClassHandler();
             Action<string> myAction = new Action<string>(classHandler.MyAction);
@@ -69,6 +72,7 @@ namespace Prism.Tests.Events
 
             var originalAction = new WeakReference(myAction);
             myAction = null;
+            await Task.Delay(100);
             GC.Collect();
             Assert.False(originalAction.IsAlive);
 
@@ -77,7 +81,7 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
-        public void ShouldReturnNullIfTargetNotAlive()
+        public async Task ShouldReturnNullIfTargetNotAlive()
         {
             SomeClassHandler handler = new SomeClassHandler();
             var weakHandlerRef = new WeakReference(handler);
@@ -85,6 +89,7 @@ namespace Prism.Tests.Events
             var action = new DelegateReference((Action<string>)handler.DoEvent, false);
 
             handler = null;
+            await Task.Delay(100);
             GC.Collect();
             Assert.False(weakHandlerRef.IsAlive);
 

--- a/Source/Prism.Tests/Events/PubSubEventFixture.cs
+++ b/Source/Prism.Tests/Events/PubSubEventFixture.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Xunit;
+using System.Threading.Tasks;
 using Prism.Events;
+using Xunit;
 
 namespace Prism.Tests.Events
 {
@@ -293,7 +294,7 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
-        public void ShouldNotExecuteOnGarbageCollectedDelegateReferenceWhenNotKeepAlive()
+        public async Task ShouldNotExecuteOnGarbageCollectedDelegateReferenceWhenNotKeepAlive()
         {
             var PubSubEvent = new TestablePubSubEvent<string>();
 
@@ -305,6 +306,7 @@ namespace Prism.Tests.Events
 
             WeakReference actionEventReference = new WeakReference(externalAction);
             externalAction = null;
+            await Task.Delay(100);
             GC.Collect();
             Assert.False(actionEventReference.IsAlive);
 
@@ -312,7 +314,7 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
-        public void ShouldNotExecuteOnGarbageCollectedDelegateReferenceWhenNotKeepAliveNonGeneric()
+        public async Task ShouldNotExecuteOnGarbageCollectedDelegateReferenceWhenNotKeepAliveNonGeneric()
         {
             var pubSubEvent = new TestablePubSubEvent();
 
@@ -324,6 +326,7 @@ namespace Prism.Tests.Events
 
             var actionEventReference = new WeakReference(externalAction);
             externalAction = null;
+            await Task.Delay(100);
             GC.Collect();
             Assert.False(actionEventReference.IsAlive);
 
@@ -331,7 +334,7 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
-        public void ShouldNotExecuteOnGarbageCollectedFilterReferenceWhenNotKeepAlive()
+        public async Task ShouldNotExecuteOnGarbageCollectedFilterReferenceWhenNotKeepAlive()
         {
             var PubSubEvent = new TestablePubSubEvent<string>();
 
@@ -347,6 +350,7 @@ namespace Prism.Tests.Events
             wasCalled = false;
             WeakReference filterReference = new WeakReference(filter);
             filter = null;
+            await Task.Delay(100);
             GC.Collect();
             Assert.False(filterReference.IsAlive);
 

--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Linq.Expressions;
+using System.Windows.Input;
 using Prism.Properties;
 
 namespace Prism.Commands
 {
     /// <summary>
-    /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute"/> and <see cref="CanExecute"/>.
+    /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute()"/> and <see cref="CanExecute()"/>.
     /// </summary>
     /// <see cref="DelegateCommandBase"/>
     /// <see cref="DelegateCommand{T}"/>
@@ -17,7 +18,7 @@ namespace Prism.Commands
         /// <summary>
         /// Creates a new instance of <see cref="DelegateCommand"/> with the <see cref="Action"/> to invoke on execution.
         /// </summary>
-        /// <param name="executeMethod">The <see cref="Action"/> to invoke when <see cref="ICommand.Execute"/> is called.</param>
+        /// <param name="executeMethod">The <see cref="Action"/> to invoke when <see cref="ICommand.Execute(object)"/> is called.</param>
         public DelegateCommand(Action executeMethod)
             : this(executeMethod, () => true)
         {
@@ -57,11 +58,20 @@ namespace Prism.Commands
             return _canExecuteMethod();
         }
 
+        /// <summary>
+        /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
+        /// </summary>
+        /// <param name="parameter">Command Parameter</param>
         protected override void Execute(object parameter)
         {
             Execute();
         }
 
+        /// <summary>
+        /// Handle the internal invocation of <see cref="ICommand.CanExecute(object)"/>
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
         protected override bool CanExecute(object parameter)
         {
             return CanExecute();

--- a/Source/Prism/Commands/DelegateCommandBase.cs
+++ b/Source/Prism/Commands/DelegateCommandBase.cs
@@ -22,8 +22,6 @@ namespace Prism.Commands
         /// <summary>
         /// Creates a new instance of a <see cref="DelegateCommandBase"/>, specifying both the execute action and the can execute function.
         /// </summary>
-        /// <param name="executeMethod">The <see cref="Action"/> to execute when <see cref="ICommand.Execute"/> is invoked.</param>
-        /// <param name="canExecuteMethod">The <see cref="Func{Object,Bool}"/> to invoked when <see cref="ICommand.CanExecute"/> is invoked.</param>
         protected DelegateCommandBase()
         {
             _synchronizationContext = SynchronizationContext.Current;
@@ -51,9 +49,9 @@ namespace Prism.Commands
         }
 
         /// <summary>
-        /// Raises <see cref="DelegateCommandBase.CanExecuteChanged"/> so every command invoker
+        /// Raises <see cref="CanExecuteChanged"/> so every command invoker
         /// can requery to check if the command can execute.
-        /// <remarks>Note that this will trigger the execution of <see cref="DelegateCommandBase.InvokeCanExecute"/> once for each invoker.</remarks>
+        /// <remarks>Note that this will trigger the execution of <see cref="CanExecuteChanged"/> once for each invoker.</remarks>
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
         public void RaiseCanExecuteChanged()
@@ -71,8 +69,17 @@ namespace Prism.Commands
             return CanExecute(parameter);
         }
 
+        /// <summary>
+        /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
+        /// </summary>
+        /// <param name="parameter">Command Parameter</param>
         protected abstract void Execute(object parameter);
 
+        /// <summary>
+        /// Handle the internal invocation of <see cref="ICommand.CanExecute(object)"/>
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
         protected abstract bool CanExecute(object parameter);
 
         /// <summary>

--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -2,11 +2,12 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Windows.Input;
 
 namespace Prism.Commands
 {
     /// <summary>
-    /// An <see cref="ICommand"/> whose delegates can be attached for <see cref="Execute"/> and <see cref="CanExecute"/>.
+    /// An <see cref="ICommand"/> whose delegates can be attached for <see cref="Execute(T)"/> and <see cref="CanExecute(T)"/>.
     /// </summary>
     /// <typeparam name="T">Parameter type.</typeparam>
     /// <remarks>
@@ -38,7 +39,7 @@ namespace Prism.Commands
         /// Initializes a new instance of <see cref="DelegateCommand{T}"/>.
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
-        /// <remarks><see cref="CanExecute"/> will always return true.</remarks>
+        /// <remarks><see cref="CanExecute(T)"/> will always return true.</remarks>
         public DelegateCommand(Action<T> executeMethod)
             : this(executeMethod, (o) => true)
         {
@@ -93,11 +94,20 @@ namespace Prism.Commands
             return _canExecuteMethod(parameter);
         }
 
+        /// <summary>
+        /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
+        /// </summary>
+        /// <param name="parameter">Command Parameter</param>
         protected override void Execute(object parameter)
         {
             Execute((T)parameter);
         }
 
+        /// <summary>
+        /// Handle the internal invocation of <see cref="ICommand.CanExecute(object)"/>
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
         protected override bool CanExecute(object parameter)
         {
             return CanExecute((T)parameter);


### PR DESCRIPTION
﻿### Description of Change ###

Fixes tests that were randomly failing because the Garbage Collection wasn't collecting a nulled reference. Updated tests now add a slight delay between setting a reference to null and performing the Garbage Collection allowing the runtime to properly identify the reference as needing collection.

### Bugs Fixed ###

- Fixes Tests Only

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard