### PR TITLE
Make Xamarin.Forms DependencyResolver Opt-In

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -45,4 +45,8 @@
     <GenerateDocumentationFile>!$(IsTestProject)</GenerateDocumentationFile>
     <GeneratePackageOnBuild>!$(IsTestProject)</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <DefineConstants>$(DefineConstants);__ANDROID__</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/Source/Prism.Tests/Prism.Tests.csproj
+++ b/Source/Prism.Tests/Prism.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net45;uap10.0</TargetFrameworks>
@@ -32,9 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Condition=" '$(TargetFramework)' == 'netstandard1.0' " Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Condition=" '$(TargetFramework)' == 'uap10.0' " Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,5 +41,4 @@
     <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net45;uap10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net45;uap10.0.15063</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Prism</AssemblyName>
     <PackageId>Prism.Core</PackageId>
     <DebugType>pdbonly</DebugType>
@@ -23,12 +24,6 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\prism.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <!-- Targeting Creators Update -->
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
+++ b/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
@@ -26,7 +26,7 @@
 
    <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
-    <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="Autofac" Version="4.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
+++ b/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>
@@ -26,8 +26,6 @@
 
    <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
     <PackageReference Include="Autofac" Version="4.6.2" />
   </ItemGroup>
 
@@ -44,7 +42,5 @@
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 
 </Project>

--- a/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
+++ b/Source/Windows10/Prism.Autofac.Windows/Prism.Autofac.Windows.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>uap10.0</TargetFramework>
-	<!-- Targeting Creators Update -->
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetFramework>uap10.0.15063</TargetFramework>
     <Title>Autofac for Prism for UWP</Title>
     <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
@@ -32,15 +29,6 @@
   <ItemGroup>
     <!-- <ProjectReference Include="..\..\Prism\Prism.csproj" /> -->
     <ProjectReference Include="..\Prism.Windows\Prism.Windows.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
-      <Name>Windows Desktop Extensions for the UWP</Name>
-    </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=$(TargetPlatformVersion)">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
+++ b/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>uap10.0</TargetFramework>
-	<!-- Targeting Creators Update -->
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetFramework>uap10.0.15063</TargetFramework>
     <Title>SimpleInjector for Prism for UWP</Title>
     <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
@@ -33,17 +30,7 @@
     <!-- <EmbeddedResource Include="Properties\Prism.SimpleInjector.Windows.rd.xml" /> -->
   </ItemGroup>
   <ItemGroup>
-    <!-- <ProjectReference Include="..\..\Prism\Prism.csproj" /> -->
     <ProjectReference Include="..\Prism.Windows\Prism.Windows.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
-      <Name>Windows Desktop Extensions for the UWP</Name>
-    </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=$(TargetPlatformVersion)">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
+++ b/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>
@@ -26,8 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
     <PackageReference Include="SimpleInjector" Version="4.1.0" />
   </ItemGroup>
 
@@ -47,7 +45,5 @@
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 
 </Project>

--- a/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
+++ b/Source/Windows10/Prism.SimpleInjector.Windows/Prism.SimpleInjector.Windows.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
-    <PackageReference Include="SimpleInjector" Version="4.1.0" />
+    <PackageReference Include="SimpleInjector" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
+++ b/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
     <PackageReference Include="Unity.Container" Version="5.8.3" />
   </ItemGroup>
@@ -48,5 +47,4 @@
     </SDKReference>
   </ItemGroup>
 
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
+++ b/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
-    <PackageReference Include="Unity.Container" Version="5.8.3" />
+    <PackageReference Include="Unity.Container" Version="5.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
+++ b/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>uap10.0</TargetFramework>
-	<!-- Targeting Creators Update -->
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetFramework>uap10.0.15063</TargetFramework>
     <Title>Unity for Prism for UWP</Title>
     <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
@@ -30,21 +27,11 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
     <PackageReference Include="Unity.Container" Version="5.8.6" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Prism.Windows\Prism.Windows.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
-      <Name>Windows Desktop Extensions for the UWP</Name>
-    </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=$(TargetPlatformVersion)">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Windows10/Prism.Windows.Tests/Prism.Windows.Tests.csproj
+++ b/Source/Windows10/Prism.Windows.Tests/Prism.Windows.Tests.csproj
@@ -200,7 +200,7 @@
       <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.6</Version>
+      <Version>6.0.8</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -1,12 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>uap10.0</TargetFramework>
-	<!-- Targeting Creators Update -->
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetFramework>uap10.0.15063</TargetFramework>
     <Title>Prism for UWP</Title>
-    <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
     <Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform. Prism for UWP helps you more easily design and build rich, flexible, and easy to maintain UWP applications.</Description>
@@ -26,21 +22,11 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Properties\Prism.Windows.rd.xml" />
+    <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Prism\Prism.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PRIResource Include="Strings\en-US\Resources.resw" />
-  </ItemGroup>
-  <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
-      <Name>Windows Desktop Extensions for the UWP</Name>
-    </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=$(TargetPlatformVersion)">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
   </ItemGroup>
 
 </Project>

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>
@@ -29,11 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Prism\Prism.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -47,5 +42,5 @@
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
+
 </Project>

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -29,4 +29,13 @@
     <ProjectReference Include="..\..\Prism\Prism.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <SDKReference Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
+      <Name>Windows Desktop Extensions for the UWP</Name>
+    </SDKReference>
+    <SDKReference Include="WindowsMobile, Version=$(TargetPlatformVersion)">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+
 </Project>

--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/Prism.Autofac.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/Prism.Autofac.Wpf.Tests.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.8.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.4.8.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>

--- a/Source/Wpf/Prism.Autofac.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Autofac.Wpf.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.6.2" targetFramework="net45" />
+  <package id="Autofac" version="4.8.1" targetFramework="net45" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net45" />
   <package id="Moq" version="4.8.1" targetFramework="net45" />

--- a/Source/Wpf/Prism.Autofac.Wpf/Prism.Autofac.Wpf.csproj
+++ b/Source/Wpf/Prism.Autofac.Wpf/Prism.Autofac.Wpf.csproj
@@ -49,8 +49,8 @@
     <AssemblyOriginatorKeyFile>..\..\prism.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.8.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.4.8.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="CommonServiceLocator, Version=2.0.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommonServiceLocator.2.0.3\lib\net45\CommonServiceLocator.dll</HintPath>

--- a/Source/Wpf/Prism.Autofac.Wpf/packages.config
+++ b/Source/Wpf/Prism.Autofac.Wpf/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.6.2" targetFramework="net45" />
+  <package id="Autofac" version="4.8.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Source/Wpf/Prism.DryIoc.Wpf.Tests/Prism.DryIoc.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.DryIoc.Wpf.Tests/Prism.DryIoc.Wpf.Tests.csproj
@@ -38,8 +38,8 @@
     <Reference Include="CommonServiceLocator, Version=2.0.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommonServiceLocator.2.0.3\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
-    <Reference Include="DryIoc, Version=2.12.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DryIoc.dll.2.12.8\lib\net45\DryIoc.dll</HintPath>
+    <Reference Include="DryIoc, Version=2.12.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DryIoc.dll.2.12.10\lib\net45\DryIoc.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/Source/Wpf/Prism.DryIoc.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.DryIoc.Wpf.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net45" />
-  <package id="DryIoc.dll" version="2.12.8" targetFramework="net45" />
+  <package id="DryIoc.dll" version="2.12.10" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />

--- a/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
@@ -52,8 +52,8 @@
     <Reference Include="CommonServiceLocator, Version=2.0.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommonServiceLocator.2.0.3\lib\net45\CommonServiceLocator.dll</HintPath>
     </Reference>
-    <Reference Include="DryIoc, Version=2.12.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DryIoc.dll.2.12.8\lib\net45\DryIoc.dll</HintPath>
+    <Reference Include="DryIoc, Version=2.12.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DryIoc.dll.2.12.10\lib\net45\DryIoc.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/Source/Wpf/Prism.DryIoc.Wpf/packages.config
+++ b/Source/Wpf/Prism.DryIoc.Wpf/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net45" />
-  <package id="DryIoc.dll" version="2.12.8" targetFramework="net45" />
+  <package id="DryIoc.dll" version="2.12.10" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net45" developmentDependency="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/Prism.Ninject.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/Prism.Ninject.Wpf.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -43,10 +43,10 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Ninject, Version=3.3.4.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Ninject.3.3.4\lib\net45\Ninject.dll</HintPath>
@@ -82,8 +82,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net461" />
-  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
   <package id="Ninject" version="3.3.4" targetFramework="net461" />
 </packages>

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
@@ -99,8 +99,8 @@
     <Reference Include="Unity.Abstractions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Unity.Abstractions.3.3.0\lib\net45\Unity.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Container, Version=5.8.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.Container.5.8.3\lib\net45\Unity.Container.dll</HintPath>
+    <Reference Include="Unity.Container, Version=5.8.6.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.Container.5.8.6\lib\net45\Unity.Container.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/packages.config
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/packages.config
@@ -6,5 +6,5 @@
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
   <package id="Unity.Abstractions" version="3.3.0" targetFramework="net45" />
-  <package id="Unity.Container" version="5.8.3" targetFramework="net45" />
+  <package id="Unity.Container" version="5.8.6" targetFramework="net45" />
 </packages>

--- a/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
@@ -62,8 +62,8 @@
     <Reference Include="Unity.Abstractions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Unity.Abstractions.3.3.0\lib\net45\Unity.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Container, Version=5.8.3.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.Container.5.8.3\lib\net45\Unity.Container.dll</HintPath>
+    <Reference Include="Unity.Container, Version=5.8.6.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.Container.5.8.6\lib\net45\Unity.Container.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/Source/Wpf/Prism.Unity.Wpf/packages.config
+++ b/Source/Wpf/Prism.Unity.Wpf/packages.config
@@ -3,5 +3,5 @@
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net45" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net45" developmentDependency="true" />
   <package id="Unity.Abstractions" version="3.3.0" targetFramework="net45" />
-  <package id="Unity.Container" version="5.8.3" targetFramework="net45" />
+  <package id="Unity.Container" version="5.8.6" targetFramework="net45" />
 </packages>

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.550168-pre3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+   <TargetFrameworks>netstandard1.1;netstandard2.0;MonoAndroid71</TargetFrameworks>
    <Title>Autofac for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Autofac extensions for Prism for Xamarin.Forms.</Summary>-->

--- a/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms/Prism.Autofac.Forms.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="4.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/PrismApplication.cs
@@ -1,5 +1,12 @@
 ﻿using Autofac;
 using Prism.Ioc;
+#if __ANDROID__
+using Autofac.Core;
+using Prism.Logging;
+using System;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+#endif
 
 namespace Prism.Autofac
 {
@@ -8,14 +15,64 @@ namespace Prism.Autofac
     /// </summary>
     public abstract class PrismApplication : PrismApplicationBase
     {
-        protected PrismApplication(IPlatformInitializer platformInitializer = null)
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplication" /> using the default constructor
+        /// </summary>
+        protected PrismApplication() 
+            : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplication" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        protected PrismApplication(IPlatformInitializer platformInitializer)
             : base(platformInitializer) { }
 
         /// <summary>
-        /// Creates the <see cref="IAutofacContainerExtension"/>
+        /// Initializes a new instance of <see cref="PrismApplication" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// Also determines whether to set the <see cref="DependencyResolver" /> for resolving Renderers and Platform Effects.
         /// </summary>
-        /// <returns></returns>
-        protected override IContainerExtension CreateContainerExtension()
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        /// <param name="setFormsDependencyResolver">Should <see cref="PrismApplication" /> set the <see cref="DependencyResolver" />.</param>
+        protected PrismApplication(IPlatformInitializer platformInitializer, bool setFormsDependencyResolver)
+            : base(platformInitializer, setFormsDependencyResolver) { }
+
+#if __ANDROID__
+        /// <summary>
+        /// Sets the <see cref="DependencyResolver" /> to use the App Container for resolving types
+        /// </summary>
+        protected override void SetDependencyResolver(IContainerProvider containerProvider)
+        {
+            base.SetDependencyResolver(containerProvider);
+            DependencyResolver.ResolveUsing((Type type, object[] dependencies) =>
+            {
+                var container = containerProvider.GetContainer();
+                var parameters = new List<Parameter>();
+                foreach(var dependency in dependencies)
+                {
+                    if(dependency is Android.Content.Context context)
+                    {
+                        parameters.Add(new TypedParameter(typeof(Android.Content.Context), context));
+                    }
+                    else
+                    {
+                        container.Resolve<ILoggerFacade>().Log($"Resolving an unknown type {dependency.GetType().Name}", Category.Warn, Priority.High);
+                        parameters.Add(new TypedParameter(dependency.GetType(), dependency));
+                    }
+                }
+
+                return container.Resolve(type, parameters.ToArray());
+            });
+        }
+#endif
+
+    /// <summary>
+    /// Creates the <see cref="IAutofacContainerExtension"/>
+    /// </summary>
+    /// <returns></returns>
+    protected override IContainerExtension CreateContainerExtension()
         {
             return new AutofacContainerExtension(new ContainerBuilder());
         }

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationMock.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationMock.cs
@@ -27,7 +27,7 @@ namespace Prism.DI.Forms.Tests
     public class PrismApplicationMock : PrismApplication
     {
         public PrismApplicationMock(IPlatformInitializer platformInitializer)
-            : base(platformInitializer)
+            : base(platformInitializer, true)
         {
         }
 

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.550168-pre3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid71</TargetFrameworks>
     <Title>DryIoc for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>DryIoc extensions for Prism for Xamarin.Forms.</Summary>-->

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -1,8 +1,13 @@
-﻿using DryIoc;
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using DryIoc;
 using Prism.Common;
 using Prism.Ioc;
+using Prism.Logging;
 using Prism.Navigation;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Prism.DryIoc
 {
@@ -11,8 +16,29 @@ namespace Prism.DryIoc
     /// </summary>
     public abstract class PrismApplication : PrismApplicationBase
     {
-        protected PrismApplication(IPlatformInitializer platformInitializer = null)
+        /// <summary>
+        /// Initializes a new instance of PrismApplication using the default constructor
+        /// </summary>
+        protected PrismApplication() 
+            : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplication" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        protected PrismApplication(IPlatformInitializer platformInitializer)
             : base(platformInitializer) { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplication" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// Also determines whether to set the <see cref="DependencyResolver" /> for resolving Renderers and Platform Effects.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        /// <param name="setFormsDependencyResolver">Should <see cref="PrismApplication" /> set the <see cref="DependencyResolver" />.</param>
+        protected PrismApplication(IPlatformInitializer platformInitializer, bool setFormsDependencyResolver)
+            : base(platformInitializer, setFormsDependencyResolver) { }
 
         /// <summary>
         /// Creates the <see cref="IContainerExtension"/> for DryIoc
@@ -22,6 +48,31 @@ namespace Prism.DryIoc
         {
             return new DryIocContainerExtension(new Container(CreateContainerRules()));
         }
+
+#if __ANDROID__
+        /// <summary>
+        /// Sets the <see cref="DependencyResolver" /> to use the App Container for resolving types
+        /// </summary>
+        protected override void SetDependencyResolver(IContainerProvider containerProvider)
+        {
+            base.SetDependencyResolver(containerProvider);
+            DependencyResolver.ResolveUsing((Type type, object[] dependencies) =>
+            {
+                var container = containerProvider.GetContainer();
+
+                foreach(var dependency in dependencies)
+                {
+                    if(dependency is Android.Content.Context context)
+                    {
+                        var resolver = container.Resolve<Func<Android.Content.Context, object>>(type);
+                        return resolver.Invoke(context);
+                    }
+                }
+                container.Resolve<ILoggerFacade>().Log($"Could not locate an Android.Content.Context to resolve {type.Name}", Category.Warn, Priority.High);
+                return container.Resolve(type);
+            });
+        }
+#endif
 
         /// <summary>
         /// Create <see cref="Rules" /> to alter behavior of <see cref="IContainer" />
@@ -38,8 +89,8 @@ namespace Prism.DryIoc
         protected override void RegisterRequiredTypes(IContainerRegistry containerRegistry)
         {
             base.RegisterRequiredTypes(containerRegistry);
-            Container.GetContainer().Register<INavigationService, PageNavigationService>();
-            Container.GetContainer().Register<INavigationService>(
+            containerRegistry.GetContainer().Register<INavigationService, PageNavigationService>();
+            containerRegistry.GetContainer().Register<INavigationService>(
                 made: Made.Of(() => SetPage(Arg.Of<INavigationService>(), Arg.Of<Page>())),
                 setup: Setup.Decorator);
         }

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.550168-pre3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.550168-pre3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -24,6 +24,7 @@ namespace Prism
         IContainerExtension _containerExtension;
         IModuleCatalog _moduleCatalog;
         Page _previousPage = null;
+        bool _setFormsDependencyResolver { get; }
 
         /// <summary>
         /// The dependency injection container used to resolve objects
@@ -40,12 +41,36 @@ namespace Prism
         /// </summary>
         protected IPlatformInitializer PlatformInitializer { get; }
 
-        protected PrismApplicationBase(IPlatformInitializer initializer = null)
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplicationBase" /> using the default constructor
+        /// </summary>
+        protected PrismApplicationBase() : this(null, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplicationBase" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        protected PrismApplicationBase(IPlatformInitializer platformInitializer) : this(platformInitializer, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplicationBase" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// Also determines whether to set the <see cref="DependencyResolver" /> for resolving Renderers and Platform Effects.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        /// <param name="setFormsDependencyResolver">Should <see cref="PrismApplication" /> set the <see cref="DependencyResolver" />.</param>
+        protected PrismApplicationBase(IPlatformInitializer platformInitializer, bool setFormsDependencyResolver)
         {
             base.ModalPopping += PrismApplicationBase_ModalPopping;
             base.ModalPopped += PrismApplicationBase_ModalPopped;
+            _setFormsDependencyResolver = setFormsDependencyResolver;
 
-            PlatformInitializer = initializer;
+            PlatformInitializer = platformInitializer;
             InitializeInternal();
         }
 
@@ -80,7 +105,9 @@ namespace Prism
             PlatformInitializer?.RegisterTypes(_containerExtension);
             RegisterTypes(_containerExtension);
             _containerExtension.FinalizeExtension();
-            SetDependencyResolver(_containerExtension);
+
+            if(_setFormsDependencyResolver)
+                SetDependencyResolver(_containerExtension);
 
             _moduleCatalog = Container.Resolve<IModuleCatalog>();
             ConfigureModuleCatalog(_moduleCatalog);

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.550168-pre3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid71</TargetFrameworks>
     <Title>Unity for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Unity extensions for Prism for Xamarin.Forms.</Summary>-->

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -1,5 +1,6 @@
 ﻿using Prism.Ioc;
 using Unity;
+using System.Collections.Generic;
 #if __ANDROID__
 using System;
 using Prism.Logging;
@@ -45,26 +46,22 @@ namespace Prism.Unity
             DependencyResolver.ResolveUsing((Type type, object[] dependencies) =>
             {
                 var container = containerProvider.GetContainer();
-                ParameterOverrides overrides = null;
+                List<ResolverOverride> overrides = new List<ResolverOverride>();
 
                 foreach(var dependency in dependencies)
                 {
-                    if(dependency is Android.Content.Context context)
+                    if (dependency is Android.Content.Context context)
                     {
-                        if (overrides != null)
-                            container.Resolve<ILoggerFacade>().Log($"An Android.Content.Context has already been provided to resolve {type.Name}", Category.Warn, Priority.High);
-                        overrides = new ParameterOverrides()
-                        {
-                            { "context", context }
-                        };
+                        overrides.Add(new DependencyOverride(typeof(Android.Content.Context), context));
                     }
                     else
                     {
                         container.Resolve<ILoggerFacade>().Log($"Resolving an unknown type {dependency.GetType().Name}", Category.Warn, Priority.High);
+                        overrides.Add(new DependencyOverride(dependency.GetType(), dependency));
                     }
                 }
 
-                return container.Resolve(type, overrides);
+                return container.Resolve(type, overrides.ToArray());
             });
         }
 #endif

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -1,12 +1,73 @@
 ﻿using Prism.Ioc;
 using Unity;
+#if __ANDROID__
+using System;
+using Prism.Logging;
+using Unity.Resolution;
+using Xamarin.Forms.Internals;
+#endif
 
 namespace Prism.Unity
 {
     public abstract class PrismApplication : PrismApplicationBase
     {
-        public PrismApplication(IPlatformInitializer initializer = null) 
-            : base (initializer) { }
+        /// <summary>
+        /// Initializes a new instance of PrismApplication using the default constructor
+        /// </summary>
+        protected PrismApplication() 
+            : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplication" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        protected PrismApplication(IPlatformInitializer platformInitializer)
+            : base(platformInitializer) { }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="PrismApplication" /> with a <see cref="IPlatformInitializer" />.
+        /// Used when there are specific types that need to be registered on the platform.
+        /// Also determines whether to set the <see cref="DependencyResolver" /> for resolving Renderers and Platform Effects.
+        /// </summary>
+        /// <param name="platformInitializer">The <see cref="IPlatformInitializer"/>.</param>
+        /// <param name="setFormsDependencyResolver">Should <see cref="PrismApplication" /> set the <see cref="DependencyResolver" />.</param>
+        protected PrismApplication(IPlatformInitializer platformInitializer, bool setFormsDependencyResolver)
+            : base(platformInitializer, setFormsDependencyResolver) { }
+
+#if __ANDROID__
+        /// <summary>
+        /// Sets the <see cref="DependencyResolver" /> to use the App Container for resolving types
+        /// </summary>
+        protected override void SetDependencyResolver(IContainerProvider containerProvider)
+        {
+            base.SetDependencyResolver(containerProvider);
+            DependencyResolver.ResolveUsing((Type type, object[] dependencies) =>
+            {
+                var container = containerProvider.GetContainer();
+                ParameterOverrides overrides = null;
+
+                foreach(var dependency in dependencies)
+                {
+                    if(dependency is Android.Content.Context context)
+                    {
+                        if (overrides != null)
+                            container.Resolve<ILoggerFacade>().Log($"An Android.Content.Context has already been provided to resolve {type.Name}", Category.Warn, Priority.High);
+                        overrides = new ParameterOverrides()
+                        {
+                            { "context", context }
+                        };
+                    }
+                    else
+                    {
+                        container.Resolve<ILoggerFacade>().Log($"Resolving an unknown type {dependency.GetType().Name}", Category.Warn, Priority.High);
+                    }
+                }
+
+                return container.Resolve(type, overrides);
+            });
+        }
+#endif
 
         protected override IContainerExtension CreateContainerExtension()
         {

--- a/Source/build/Prism.Autofac.Wpf.nuspec
+++ b/Source/build/Prism.Autofac.Wpf.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
 
       <group targetFramework=".NETFramework4.5">
-        <dependency id="Autofac" version="4.6.2" />
+        <dependency id="Autofac" version="4.8.1" />
         <dependency id="Prism.Wpf" version="$wpfVersion$" />
       </group>
 

--- a/Source/build/Prism.DryIoc.Wpf.nuspec
+++ b/Source/build/Prism.DryIoc.Wpf.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       
       <group targetFramework=".NETFramework4.5">
-        <dependency id="DryIoc.dll" version="2.12.8" />
+        <dependency id="DryIoc.dll" version="2.12.10" />
         <dependency id="Prism.Wpf" version="$wpfVersion$" />
       </group>
       

--- a/Source/build/Prism.Unity.Wpf.nuspec
+++ b/Source/build/Prism.Unity.Wpf.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       
       <group targetFramework=".NETFramework4.5">
-        <dependency id="Unity.Container" version="5.8.3" />
+        <dependency id="Unity.Container" version="5.8.6" />
         <dependency id="Prism.Wpf" version="$wpfVersion$" />
       </group>
 

--- a/Source/global.json
+++ b/Source/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "MSBuild.Sdk.Extras": "1.5.4"
+    }
+}


### PR DESCRIPTION
﻿### Description of Change ###

Updates to directly reference MSBuild.SDK.Extras as the SDK type to generally cleanup the project files and centrally control the referenced version. Updates all dependencies. Adds Android target on the DI Projects for Forms to handle Context required for Android Renderers. Updates the base PrismApplication(Base) to now have 3 ctors allowing the option of enabling the Xamarin.Forms DependencyResolver without breaking existing apps. 

There are no specific tests included in this PR as the only relevant tests would have to be done on Android and we do not currently have Integration tests.

### Bugs Fixed ###

- fixes #1443, Android specific target now provides the ability to handle injecting a specific Android.Content.Context that is passed into the DependencyResolver.

### API Changes ###

The constructor in PrismApplication no longer has an optional IPlatformInitializer. Instead there are now three constructor options:

Removed:

- PrismApplication(IPlatformInitializer = null)

Added:

- PrismApplication()
- PrismApplication(IPlatformInitializer)
- PrismApplication(IPlatformInitializer, bool)

This ensures backwards compatibility while migrating the functionality to the new ctor signature allowing optional control of whether Prism should set the Xamarin.Forms DependencyResolver. 

### Behavioral Changes ###

Platform Renderers and Effects will no longer be resolved by the container by default. This is now an Opt-In feature.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard