### PR TITLE
#1505 [EventAggregator] Memory problem with EventAggregator and never…

### DIFF
--- a/Source/Prism.Tests/Events/PubSubEventFixture.cs
+++ b/Source/Prism.Tests/Events/PubSubEventFixture.cs
@@ -11,6 +11,41 @@ namespace Prism.Tests.Events
     public class PubSubEventFixture
     {
         [Fact]
+        public void EnsureSubscriptionListIsEmptyAfterPublishingAMessage()
+        {
+            var pubSubEvent = new TestablePubSubEvent<string>();
+            SubscribeExternalActionWithoutReference(pubSubEvent);
+            GC.Collect();
+            pubSubEvent.Publish("testPayload");
+            Assert.True(pubSubEvent.BaseSubscriptions.Count == 0, "Subscriptionlist is not empty");
+        }
+
+        [Fact]
+        public void EnsureSubscriptionListIsNotEmptyWithoutPublishOrSubscribe()
+        {
+            var pubSubEvent = new TestablePubSubEvent<string>();
+            SubscribeExternalActionWithoutReference(pubSubEvent);
+            GC.Collect();
+            Assert.True(pubSubEvent.BaseSubscriptions.Count == 1, "Subscriptionlist is empty");
+        }
+
+        [Fact]
+        public void EnsureSubscriptionListIsEmptyAfterSubscribeAgainAMessage()
+        {
+            var pubSubEvent = new TestablePubSubEvent<string>();
+            SubscribeExternalActionWithoutReference(pubSubEvent);
+            GC.Collect();
+            SubscribeExternalActionWithoutReference(pubSubEvent);
+            Assert.True(pubSubEvent.BaseSubscriptions.Count == 1, "Subscriptionlist is empty");
+        }
+
+        private static void SubscribeExternalActionWithoutReference(TestablePubSubEvent<string> pubSubEvent)
+        {
+            pubSubEvent.Subscribe(new ExternalAction().ExecuteAction);
+        }
+
+
+        [Fact]
         public void CanSubscribeAndRaiseEvent()
         {
             TestablePubSubEvent<string> pubSubEvent = new TestablePubSubEvent<string>();

--- a/Source/Prism/Events/EventBase.cs
+++ b/Source/Prism/Events/EventBase.cs
@@ -45,6 +45,7 @@ namespace Prism.Events
 
             lock (Subscriptions)
             {
+                Prune();
                 Subscriptions.Add(eventSubscription);
             }
             return eventSubscription.SubscriptionToken;
@@ -96,30 +97,27 @@ namespace Prism.Events
             }
         }
 
-        private List<Action<object[]>> PruneAndReturnStrategies()
+        private void Prune()
         {
-            List<Action<object[]>> returnList = new List<Action<object[]>>();
-
             lock (Subscriptions)
             {
                 for (var i = Subscriptions.Count - 1; i >= 0; i--)
                 {
-                    Action<object[]> listItem =
-                        _subscriptions[i].GetExecutionStrategy();
-
-                    if (listItem == null)
+                    if (_subscriptions[i].GetExecutionStrategy() == null)
                     {
-                        // Prune from main list. Log?
                         _subscriptions.RemoveAt(i);
-                    }
-                    else
-                    {
-                        returnList.Add(listItem);
                     }
                 }
             }
+        }
 
-            return returnList;
+        private List<Action<object[]>> PruneAndReturnStrategies()
+        {
+            lock (Subscriptions)
+            {
+                Prune();
+                return _subscriptions.Select(x => x.GetExecutionStrategy()).ToList();
+            }
         }
     }
 }


### PR DESCRIPTION
﻿### Description of Change ###

* If someone is subscribing a handler to an EventAggregator, the internal subscription list is getting cleared on `Subscribe` and `Publish`

### Bugs Fixed ###

- https://github.com/PrismLibrary/Prism/issues/1505

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ x ] Has tests (if omitted, state reason in description)
- [ x ] Rebased on top of master at time of PR
- [ x ] Changes adhere to coding standard