### PR TITLE
Allow registering View Model with name in order the reuse a single view with different view models

### DIFF
--- a/Source/Prism/Mvvm/ViewModelLocationProvider.cs
+++ b/Source/Prism/Mvvm/ViewModelLocationProvider.cs
@@ -184,5 +184,22 @@ namespace Prism.Mvvm
         {
             _typeFactories[viewTypeName] = viewModelType;
         }
+
+        public static object GetViewModelForKey(string viewKey, object view)
+        {
+            if (_typeFactories.TryGetValue(viewKey, out var viewModelType))
+            {
+                return GetViewModelForType(viewModelType, view);
+            }
+
+            return null;
+        }
+
+        private static object GetViewModelForType(Type viewModelType, object view)
+        {
+            return _defaultViewModelFactoryWithViewParameter != null ?
+                _defaultViewModelFactoryWithViewParameter(view, viewModelType) : 
+                _defaultViewModelFactory(viewModelType);
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Ioc/IContainerRegistryExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/IContainerRegistryExtensions.cs
@@ -49,6 +49,13 @@ namespace Prism.Ioc
             containerRegistry.RegisterForNavigationWithViewModel<TViewModel>(typeof(TView), name);
         }
 
+        public static void RegisterForNavigationNamed<TView, TViewModel>(this IContainerRegistry containerRegistry, string name = null)
+            where TView : Page
+            where TViewModel : class
+        {
+            containerRegistry.RegisterForNavigationWithViewModelNamed<TViewModel>(typeof(TView), name);
+        }
+
         /// <summary>
         /// Registers a Page for navigation based on the current Device OS using a shared ViewModel
         /// </summary>
@@ -177,6 +184,17 @@ namespace Prism.Ioc
                 name = viewType.Name;
 
             ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
+
+            containerRegistry.RegisterForNavigation(viewType, name);
+        }
+
+        private static void RegisterForNavigationWithViewModelNamed<TViewModel>(this IContainerRegistry containerRegistry, Type viewType, string name)
+            where TViewModel : class
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                name = viewType.Name;
+
+            ViewModelLocationProvider.Register(name, typeof(TViewModel));
 
             containerRegistry.RegisterForNavigation(viewType, name);
         }

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Prism.Mvvm;
 using Xamarin.Forms;
 
 namespace Prism.Navigation
@@ -722,7 +723,12 @@ namespace Prism.Navigation
                 if (page == null)
                     throw new NullReferenceException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
 
-                PageUtilities.SetAutowireViewModelOnPage(page);
+                var viewModel = ViewModelLocationProvider.GetViewModelForKey(segment, page);
+                if (viewModel != null)
+                    page.BindingContext = viewModel;
+                else
+                    PageUtilities.SetAutowireViewModelOnPage(page);
+
                 _pageBehaviorFactory.ApplyPageBehaviors(page);
                 ConfigurePages(page, segment);
 


### PR DESCRIPTION
﻿### Description of Change ###

Motivation was to be able to register a view to a view model with a custom name.
Goal is to navigate to different paths, using the same view, but different view models.
At the moment you can register a view to a view model using a name.
Registering the same view with a different view model and name does just override the previous registered view.
So I changed the key used to register the view from view.GetType().ToString() to the name that was passed in when registering the view -->

```
containerRegistry.RegisterForNavigation<DetailView, DetailViewModel1>("DetailView1");
containerRegistry.RegisterForNavigation<DetailView, DetailViewModel2>("DetailView2");
```

_Navigate to DetailView, using view model DetailViewModel**1**_
`NavigationService.NavigateAsync("DetailView1");`

_Navigate to DetailView, using view model DetailViewModel**2**_
`NavigationService.NavigateAsync("DetailView2");`


### API Changes ###

Added:
`void IContainerRegistryExtensions.RegisterForNavigationNamed<TView, TViewModel>(this IContainerRegistry containerRegistry, string name = null)`

`object ViewModelLocationProvider.GetViewModelForKey(string viewKey, object view)`