### PR TITLE
Support Partial Views in Xamarin Forms

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Android/HelloWorld.Android.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Android/HelloWorld.Android.csproj
@@ -105,6 +105,10 @@
       <Project>{152da85c-13f4-4427-850c-052cbbcdd4b0}</Project>
       <Name>Prism.Forms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\ModuleA\ModuleA.csproj">
+      <Project>{f0d7441b-d48a-4f58-91fb-45fa441b0434}</Project>
+      <Name>ModuleA</Name>
+    </ProjectReference>
     <ProjectReference Include="..\HelloWorld\HelloWorld.csproj">
       <Project>{DCC0DE3D-297A-4CE1-A002-81AEE3CA0AE4}</Project>
       <Name>HelloWorld</Name>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.UWP/HelloWorld.UWP.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.UWP/HelloWorld.UWP.csproj
@@ -159,6 +159,10 @@
       <Project>{152da85c-13f4-4427-850c-052cbbcdd4b0}</Project>
       <Name>Prism.Forms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\ModuleA\ModuleA.csproj">
+      <Project>{f0d7441b-d48a-4f58-91fb-45fa441b0434}</Project>
+      <Name>ModuleA</Name>
+    </ProjectReference>
     <ProjectReference Include="..\HelloWorld\HelloWorld.csproj">
       <Project>{DCC0DE3D-297A-4CE1-A002-81AEE3CA0AE4}</Project>
       <Name>HelloWorld</Name>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/HelloWorld.iOS.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/HelloWorld.iOS.csproj
@@ -165,6 +165,10 @@
       <Project>{152da85c-13f4-4427-850c-052cbbcdd4b0}</Project>
       <Name>Prism.Forms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\ModuleA\ModuleA.csproj">
+      <Project>{f0d7441b-d48a-4f58-91fb-45fa441b0434}</Project>
+      <Name>ModuleA</Name>
+    </ProjectReference>
     <ProjectReference Include="..\HelloWorld\HelloWorld.csproj">
       <Project>{DCC0DE3D-297A-4CE1-A002-81AEE3CA0AE4}</Project>
       <Name>HelloWorld</Name>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.xaml.cs
@@ -1,7 +1,6 @@
 using System;
 using HelloWorld.Views;
 using Prism;
-using Prism.DryIoc;
 using Prism.Ioc;
 using Prism.Modularity;
 using Xamarin.Forms;
@@ -10,7 +9,7 @@ using Xamarin.Forms.Xaml;
 [assembly: XamlCompilation (XamlCompilationOptions.Compile)]
 namespace HelloWorld
 {
-    public partial class App : PrismApplication
+    public sealed partial class App
     {
         public App() 
             : this(null)
@@ -87,11 +86,17 @@ namespace HelloWorld
 
         protected override void OnSleep ()
         {
+            // Support IApplicationLifecycleAware
+            base.OnSleep();
+
             // Handle when your app sleeps
         }
 
         protected override void OnResume ()
         {
+            // Support IApplicationLifecycleAware
+            base.OnResume();
+
             // Handle when your app resumes
         }
     }

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/PartialViewBViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/PartialViewBViewModel.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Diagnostics;
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Navigation;
+
+namespace ModuleA.ViewModels
+{
+    public class PartialViewBViewModel : BindableBase
+    {
+        private INavigationService _navigationService { get; }
+
+        public PartialViewBViewModel(INavigationService navigationService, IApplicationCommands applicationCommands)
+        {
+            _navigationService = navigationService;
+            NavigateCommand = new DelegateCommand(Navigate).ObservesCanExecute(() => CanNavigate);
+            SaveCommand = new DelegateCommand(Save);
+            ResetCommand = new DelegateCommand(Reset);
+
+            applicationCommands.SaveCommand.RegisterCommand(SaveCommand);
+            applicationCommands.ResetCommand.RegisterCommand(ResetCommand);
+        }
+
+        private string _title = "View B";
+        public string Title
+        {
+            get { return _title; }
+            set { SetProperty(ref _title, value); }
+        }
+
+        private bool _canNavigate = true;
+        public bool CanNavigate
+        {
+            get { return _canNavigate; }
+            set { SetProperty(ref _canNavigate, value); }
+        }
+
+        public event EventHandler IsActiveChanged;
+
+        private bool _isActive;
+        public bool IsActive
+        {
+            get { return _isActive; }
+            set
+            {
+                SetProperty(ref _isActive, value);
+                OnActiveChanged();
+            }
+        }
+
+        public DelegateCommand NavigateCommand { get; }
+
+        public DelegateCommand SaveCommand { get; }
+
+        public DelegateCommand ResetCommand { get; }
+
+        private void Reset()
+        {
+            Title = "View B";
+        }
+
+        async void Navigate()
+        {
+            CanNavigate = false;
+            await _navigationService.NavigateAsync("ViewA");
+            CanNavigate = true;
+        }
+
+        private void Save()
+        {
+            Title = "Saved";
+        }
+
+        void OnActiveChanged()
+        {
+            IsActiveChanged?.Invoke(this, EventArgs.Empty);
+            SaveCommand.IsActive = IsActive;
+        }
+
+        public void OnNavigatedFrom(INavigationParameters parameters)
+        {
+
+        }
+
+        public void OnNavigatedTo(INavigationParameters parameters)
+        {
+            Debug.WriteLine("Navigated to ViewB");
+        }
+
+        public void OnNavigatingTo(INavigationParameters parameters)
+        {
+
+        }
+
+        public void OnAppearing()
+        {
+            Debug.WriteLine("ViewB is appearing");
+        }
+
+        public void OnDisappearing()
+        {
+            Debug.WriteLine("ViewB is disappearing");
+        }
+    }
+}

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/PartialViewB.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/PartialViewB.xaml
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <StackLayout xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
-             prism:ViewModelLocator.AutowireViewModel="True"
              x:Class="ModuleA.Views.PartialViewB">
     <Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
     <Label Text="{Binding IsActive}" />

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/PartialViewB.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/PartialViewB.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<StackLayout xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
+             prism:ViewModelLocator.AutowireViewModel="True"
+             x:Class="ModuleA.Views.PartialViewB">
+    <Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
+    <Label Text="{Binding IsActive}" />
+    <Button Command="{Binding NavigateCommand}" Text="Navigate" />
+</StackLayout>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/PartialViewB.xaml.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/PartialViewB.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms.Xaml;
+
+namespace ModuleA.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class PartialViewB
+    {
+        public PartialViewB ()
+        {
+            InitializeComponent ();
+        }
+    }
+}

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/ViewB.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/ViewB.xaml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:ModuleA.Views"
              xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
              prism:ViewModelLocator.AutowireViewModel="True"
              x:Class="ModuleA.Views.ViewB"
+             x:Name="viewB"
              Title="View B">
     <ContentPage.Padding>
         <OnPlatform x:TypeArguments="Thickness">
@@ -11,10 +13,11 @@
         </OnPlatform>
     </ContentPage.Padding>
 
-	<StackLayout>
-		<Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
-		<Label Text="{Binding IsActive}" />
-		<Button Command="{Binding NavigateCommand}" Text="Navigate" />
-	</StackLayout>
+    <local:PartialViewB prism:ViewModelLocator.AutowirePartialView="{x:Reference viewB}" />
+    <!--<StackLayout>
+        <Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
+        <Label Text="{Binding IsActive}" />
+        <Button Command="{Binding NavigateCommand}" Text="Navigate" />
+    </StackLayout>-->
 
 </ContentPage>

--- a/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Autofac.Forms.Tests/Prism.Autofac.Forms.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Autofac.Forms/AutofacContainerExtension.cs
+++ b/Source/Xamarin/Prism.Autofac.Forms/AutofacContainerExtension.cs
@@ -2,6 +2,7 @@
 using Autofac.Core;
 using Autofac.Features.ResolveAnything;
 using Prism.Ioc;
+using Prism.Mvvm;
 using Prism.Navigation;
 using System;
 using Xamarin.Forms;
@@ -61,9 +62,18 @@ namespace Prism.Autofac
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
             Parameter parameter = null;
-            if (view is Page page)
+            switch(view)
             {
-                parameter = new TypedParameter(typeof(INavigationService), this.CreateNavigationService(page));
+                case Page page:
+                    parameter = new TypedParameter(typeof(INavigationService), this.CreateNavigationService(page));
+                    break;
+                case BindableObject bindable:
+                    var attachedPage = bindable.GetValue(ViewModelLocator.AutowirePartialViewProperty) as Page;
+                    if(attachedPage != null)
+                    {
+                        parameter = new TypedParameter(typeof(INavigationService), this.CreateNavigationService(attachedPage));
+                    }
+                    break;
             }
 
             return Instance.Resolve(viewModelType, parameter);

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/FixtureBase.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/FixtureBase.cs
@@ -1,0 +1,24 @@
+using Prism.DI.Forms.Tests.Mocks;
+using Xamarin.Forms;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Prism.DI.Forms.Tests.Fixtures
+{
+    public abstract class FixtureBase
+    {
+        protected ITestOutputHelper _testOutputHelper { get; }
+
+        public FixtureBase(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            Xamarin.Forms.Mocks.MockForms.Init();
+        }
+
+        protected PrismApplicationMock CreateMockApplication(Page view = null)
+        {
+            var initializer = new XunitPlatformInitializer(_testOutputHelper);
+            return view == null ? new PrismApplicationMock(initializer) : new PrismApplicationMock(initializer, view);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PartialViewFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PartialViewFixture.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+#if Autofac
+using Autofac.Core.Registration;
+#elif DryIoc
+using DryIoc;
+#elif Ninject
+using Ninject;
+#endif
+using Prism.DI.Forms.Tests.Fixtures;
+using Prism.DI.Forms.Tests.Mocks.ViewModels;
+using Prism.DI.Forms.Tests.Mocks.Views;
+using Prism.Mvvm;
+using Xamarin.Forms;
+using Xunit;
+using Xunit.Abstractions;
+
+#if Autofac
+namespace Prism.Autofac.Forms.Tests.Fixtures
+#elif DryIoc
+namespace Prism.DryIoc.Forms.Tests.Fixtures
+#elif Ninject
+namespace Prism.Ninject.Forms.Tests.Fixtures
+#elif Unity
+namespace Prism.Unity.Forms.Tests.Fixtures
+#endif
+{
+    public class PartialViewFixture : FixtureBase
+    {
+        public PartialViewFixture(ITestOutputHelper testOutputHelper) 
+            : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public async Task PartialView_LocatesViewModel()
+        {
+            var app = CreateMockApplication();
+            await app.NavigationService.NavigateAsync("/XamlViewMock?text=Test");
+            Assert.NotNull(app.MainPage);
+            Assert.IsType<XamlViewMock>(app.MainPage);
+            var page = (XamlViewMock)app.MainPage;
+            var layout = (StackLayout)page.Content;
+            Assert.NotNull(layout);
+            var partialView = (PartialView)layout.Children.FirstOrDefault(c => c is PartialView);
+            Assert.NotNull(partialView);
+            Assert.NotNull(partialView.BindingContext);
+            Assert.True(ViewModelLocator.GetAutowireViewModel(partialView));
+            Assert.IsType<PartialViewModel>(partialView.BindingContext);
+        }
+
+        [Fact]
+        public async Task PartialView_AddedToPageRegistry()
+        {
+            var app = CreateMockApplication();
+            await app.NavigationService.NavigateAsync("/XamlViewMock?text=Test");
+            var page = (XamlViewMock)app.MainPage;
+            var partialViews = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty);
+
+            Assert.Single(partialViews);
+        }
+
+        [Fact]
+        public async Task PartialViewSupportsINavigationAwareInterfaces()
+        {
+            var app = CreateMockApplication();
+            await app.NavigationService.NavigateAsync("/XamlViewMock?text=Test");
+            var page = (XamlViewMock)app.MainPage;
+            var layout = (StackLayout)page.Content;
+            var partialView = (PartialView)layout.Children.FirstOrDefault(c => c is PartialView);
+            var vm = (PartialViewModel)partialView.BindingContext;
+            Assert.Equal(1, vm.OnNavigatingToCalled);
+            Assert.Equal(1, vm.OnNavigatedToCalled);
+            Assert.Equal(0, vm.OnNavigatedFromCalled);
+            Assert.Equal("Test", vm.SomeText);
+
+            var partialViews = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty);
+            Assert.Single(partialViews);
+
+            partialView.Navigate();
+
+            Assert.Equal(1, vm.OnNavigatedFromCalled);
+        }
+
+        [Fact]
+        public async Task PartialViewModel_InjectsINavigationService()
+        {
+            var app = CreateMockApplication();
+            await app.NavigationService.NavigateAsync("/XamlViewMock?text=Test");
+            var page = (XamlViewMock)app.MainPage;
+            var layout = (StackLayout)page.Content;
+            var partialView = (PartialView)layout.Children.FirstOrDefault(c => c is PartialView);
+            var vm = (PartialViewModel)partialView.BindingContext;
+
+            partialView.Navigate();
+            Assert.IsType<AutowireView>(app.MainPage);
+        }
+
+        [Fact]
+        public async Task PartialView_DoesNotResultInMemoryLeak()
+        {
+            var app = CreateMockApplication();
+            await app.NavigationService.NavigateAsync("NavigationPage/XamlViewMock?text=Test");
+            var navPage = (NavigationPage)app.MainPage;
+            Assert.Single((List<BindableObject>)navPage.CurrentPage.GetValue(ViewModelLocator.PartialViewsProperty));
+
+            await app.NavigationService.NavigateAsync("/AutowireView");
+
+            Assert.Null(app.MainPage.GetValue(ViewModelLocator.PartialViewsProperty));
+
+            await app.NavigationService.NavigateAsync("/XamlViewMock");
+            Assert.Single((List<BindableObject>)app.MainPage.GetValue(ViewModelLocator.PartialViewsProperty));
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
@@ -301,6 +301,27 @@ namespace Prism.Unity.Forms.Tests.Fixtures
             Assert.IsType<XamlViewMockA>(navigationPage.CurrentPage);
         }
 
+        [Fact]
+        public async Task PartialViewSupport()
+        {
+            var app = CreateMockApplication();
+            await app.NavigationService.NavigateAsync("/XamlViewMock?text=Test");
+            Assert.NotNull(app.MainPage);
+            Assert.IsType<XamlViewMock>(app.MainPage);
+            var page = (XamlViewMock)app.MainPage;
+            var layout = (StackLayout)page.Content;
+            Assert.NotNull(layout);
+            var partialView = (PartialView)layout.Children.FirstOrDefault(c => c is PartialView);
+            Assert.NotNull(partialView);
+            Assert.NotNull(partialView.BindingContext);
+
+            var vm = (PartialViewModel)partialView.BindingContext;
+            Assert.True(vm.OnNavigatingToCalled);
+            Assert.True(vm.OnNavigatedToCalled);
+            Assert.False(vm.OnNavigatedFromCalled);
+            Assert.Equal("Test", vm.SomeText);
+        }
+
         private static INavigationService ResolveAndSetRootPage(PrismApplicationMock app)
         {
             var navigationService = app.NavigationService;

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationMock.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/PrismApplicationMock.cs
@@ -8,6 +8,7 @@ using Prism.Navigation;
 using Xamarin.Forms;
 using Prism.Logging;
 using Prism.Forms.Tests.Mocks.Logging;
+using Prism.Mvvm;
 #if Autofac
 using Prism.Autofac;
 using Autofac;
@@ -66,6 +67,7 @@ namespace Prism.DI.Forms.Tests
             containerRegistry.RegisterForNavigation<XamlViewMockA,XamlViewMockAViewModel>();
 
             DependencyService.Register<IDependencyServiceMock, DependencyServiceMock>();
+            ViewModelLocationProvider.Register<PartialView, PartialViewModel>();
         }
 
         protected override void ConfigureModuleCatalog(IModuleCatalog moduleCatalog)

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/PartialViewModel.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/PartialViewModel.cs
@@ -23,11 +23,11 @@ namespace Prism.DI.Forms.Tests.Mocks.ViewModels
 
         public DelegateCommand NavigateCommand { get; }
 
-        public bool OnNavigatingToCalled { get; private set; }
+        public int OnNavigatingToCalled { get; private set; }
 
-        public bool OnNavigatedToCalled { get; private set; }
+        public int OnNavigatedToCalled { get; private set; }
 
-        public bool OnNavigatedFromCalled { get; private set; }
+        public int OnNavigatedFromCalled { get; private set; }
 
         private async void OnNavigateCommandExecuted()
         {
@@ -37,17 +37,17 @@ namespace Prism.DI.Forms.Tests.Mocks.ViewModels
         public void OnNavigatingTo(INavigationParameters parameters)
         {
             SomeText = parameters.GetValue<string>("text");
-            OnNavigatingToCalled = true;
+            OnNavigatingToCalled++;
         }
 
         public void OnNavigatedTo(INavigationParameters parameters)
         {
-            OnNavigatedToCalled = true;
+            OnNavigatedToCalled++;
         }
 
         public void OnNavigatedFrom(INavigationParameters parameters)
         {
-            OnNavigatedFromCalled = true;
+            OnNavigatedFromCalled++;
         }
     }
 }

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/PartialViewModel.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/ViewModels/PartialViewModel.cs
@@ -1,0 +1,53 @@
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Navigation;
+
+namespace Prism.DI.Forms.Tests.Mocks.ViewModels
+{
+    public class PartialViewModel : BindableBase, INavigationAware
+    {
+        private INavigationService _navigationService { get; }
+
+        public PartialViewModel(INavigationService navigationService)
+        {
+            _navigationService = navigationService;
+            NavigateCommand = new DelegateCommand(OnNavigateCommandExecuted);
+        }
+
+        private string _someText;
+        public string SomeText
+        {
+            get => _someText;
+            set => SetProperty(ref _someText, value);
+        }
+
+        public DelegateCommand NavigateCommand { get; }
+
+        public bool OnNavigatingToCalled { get; private set; }
+
+        public bool OnNavigatedToCalled { get; private set; }
+
+        public bool OnNavigatedFromCalled { get; private set; }
+
+        private async void OnNavigateCommandExecuted()
+        {
+            await _navigationService.NavigateAsync("/AutowireView");
+        }
+
+        public void OnNavigatingTo(INavigationParameters parameters)
+        {
+            SomeText = parameters.GetValue<string>("text");
+            OnNavigatingToCalled = true;
+        }
+
+        public void OnNavigatedTo(INavigationParameters parameters)
+        {
+            OnNavigatedToCalled = true;
+        }
+
+        public void OnNavigatedFrom(INavigationParameters parameters)
+        {
+            OnNavigatedFromCalled = true;
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/PartialView.xaml
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/PartialView.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentView
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Prism.DI.Forms.Tests.Mocks.Views.PartialView">
+    <StackLayout>
+        <Label Text="{Binding SomeText}" />
+        <Button Command="{Binding NavigateCommand}"
+                x:Name="navigateButton" />
+    </StackLayout>
+</ContentView>

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/PartialView.xaml.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/PartialView.xaml.cs
@@ -1,0 +1,16 @@
+using Xamarin.Forms.Xaml;
+
+namespace Prism.DI.Forms.Tests.Mocks.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class PartialView
+    {
+        public PartialView()
+        {
+            InitializeComponent();
+        }
+
+        public void Navigate() =>
+            navigateButton.SendClicked();
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/XamlViewMock.xaml
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Views/XamlViewMock.xaml
@@ -2,15 +2,22 @@
 <ContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Prism.DI.Forms.Tests.Mocks.Views"
     xmlns:prism="clr-namespace:Prism.Ioc;assembly=Prism.Forms"
+    xmlns:mvvm="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
     xmlns:converters="using:Prism.Forms.Tests.Mocks.Converters"
     Title="{Binding Title}"
+    x:Name="xamlViewMock"
     x:Class="Prism.DI.Forms.Tests.Mocks.Views.XamlViewMock">
     <ContentPage.Resources>
         <ResourceDictionary>
             <prism:ContainerProvider x:TypeArguments="converters:MockValueConverter" x:Key="mockValueConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
-    <Entry x:Name="testEntry"
+    <StackLayout>
+        <local:PartialView mvvm:ViewModelLocator.AutowirePartialView="{x:Reference xamlViewMock}" />
+        <Entry x:Name="testEntry"
            Text="{Binding Test,Converter={StaticResource mockValueConverter}}" />
+    </StackLayout>
+    
 </ContentPage>

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
@@ -2,6 +2,7 @@
 using DryIoc;
 using System;
 using Xamarin.Forms;
+using Prism.Mvvm;
 
 namespace Prism.DryIoc
 {
@@ -55,9 +56,17 @@ namespace Prism.DryIoc
                 case Page page:
                     var getVM = Instance.Resolve<Func<Page, object>>(viewModelType);
                     return getVM(page);
-                default:
-                    return Instance.Resolve(viewModelType);
+                case BindableObject bindable:
+                    var attachedPage = bindable.GetValue(ViewModelLocator.AutowirePartialViewProperty) as Page;
+                    if (attachedPage != null)
+                    {
+                        var getVMForPartial = Instance.Resolve<Func<Page, object>>(viewModelType);
+                        return getVMForPartial(attachedPage);
+                    }
+                    break;
             }
+
+            return Instance.Resolve(viewModelType);
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Navigation;
+﻿using Prism.Mvvm;
+using Prism.Navigation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,17 +13,23 @@ namespace Prism.Common
     {
         public static void InvokeViewAndViewModelAction<T>(object view, Action<T> action) where T : class
         {
-            T viewAsT = view as T;
-            if (viewAsT != null)
+            if (view is T viewAsT)
                 action(viewAsT);
 
-            var element = view as BindableObject;
-            if (element != null)
+            if (view is BindableObject element)
             {
-                var viewModelAsT = element.BindingContext as T;
-                if (viewModelAsT != null)
+                if (element.BindingContext is T viewModelAsT)
                 {
                     action(viewModelAsT);
+                }
+            }
+
+            if(view is Page page && 
+              (page.GetValue(ViewModelLocator.AutowirePartialViewProperty) as List<BindableObject>).Any())
+            {
+                foreach(var partial in (page.GetValue(ViewModelLocator.AutowirePartialViewProperty) as List<BindableObject>))
+                {
+                    InvokeViewAndViewModelAction(partial, action);
                 }
             }
         }
@@ -51,25 +58,22 @@ namespace Prism.Common
                 DestroyPage(((MasterDetailPage)page).Master);
                 DestroyPage(((MasterDetailPage)page).Detail);
             }
-            else if (page is TabbedPage)
+            else if (page is TabbedPage tabbedPage)
             {
-                var tabbedPage = (TabbedPage)page;
                 foreach (var item in tabbedPage.Children.Reverse())
                 {
                     DestroyPage(item);
                 }
             }
-            else if (page is CarouselPage)
+            else if (page is CarouselPage carouselPage)
             {
-                var carouselPage = (CarouselPage)page;
                 foreach (var item in carouselPage.Children.Reverse())
                 {
                     DestroyPage(item);
                 }
             }
-            else if (page is NavigationPage)
+            else if (page is NavigationPage navigationPage)
             {
-                var navigationPage = (NavigationPage)page;
                 foreach (var item in navigationPage.Navigation.NavigationStack.Reverse())
                 {
                     DestroyPage(item);
@@ -89,15 +93,12 @@ namespace Prism.Common
 
         public static Task<bool> CanNavigateAsync(object page, INavigationParameters parameters)
         {
-            var confirmNavigationItem = page as IConfirmNavigationAsync;
-            if (confirmNavigationItem != null)
+            if (page is IConfirmNavigationAsync confirmNavigationItem)
                 return confirmNavigationItem.CanNavigateAsync(parameters);
 
-            var bindableObject = page as BindableObject;
-            if (bindableObject != null)
+            if (page is BindableObject bindableObject)
             {
-                var confirmNavigationBindingContext = bindableObject.BindingContext as IConfirmNavigationAsync;
-                if (confirmNavigationBindingContext != null)
+                if (bindableObject.BindingContext is IConfirmNavigationAsync confirmNavigationBindingContext)
                     return confirmNavigationBindingContext.CanNavigateAsync(parameters);
             }
 
@@ -106,15 +107,12 @@ namespace Prism.Common
 
         public static bool CanNavigate(object page, INavigationParameters parameters)
         {
-            var confirmNavigationItem = page as IConfirmNavigation;
-            if (confirmNavigationItem != null)
+            if (page is IConfirmNavigation confirmNavigationItem)
                 return confirmNavigationItem.CanNavigate(parameters);
 
-            var bindableObject = page as BindableObject;
-            if (bindableObject != null)
+            if (page is BindableObject bindableObject)
             {
-                var confirmNavigationBindingContext = bindableObject.BindingContext as IConfirmNavigation;
-                if (confirmNavigationBindingContext != null)
+                if (bindableObject.BindingContext is IConfirmNavigation confirmNavigationBindingContext)
                     return confirmNavigationBindingContext.CanNavigate(parameters);
             }
 

--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -24,10 +24,10 @@ namespace Prism.Common
                 }
             }
 
-            if(view is Page page && 
-              (page.GetValue(ViewModelLocator.AutowirePartialViewProperty) as List<BindableObject>).Any())
+            if(view is Page page)
             {
-                foreach(var partial in (page.GetValue(ViewModelLocator.AutowirePartialViewProperty) as List<BindableObject>))
+                var partials = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty);
+                foreach(var partial in partials)
                 {
                     InvokeViewAndViewModelAction(partial, action);
                 }

--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -26,7 +26,7 @@ namespace Prism.Common
 
             if(view is Page page)
             {
-                var partials = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty);
+                var partials = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty) ?? new List<BindableObject>();
                 foreach(var partial in partials)
                 {
                     InvokeViewAndViewModelAction(partial, action);

--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -14,6 +14,9 @@ namespace Prism.Mvvm
         public static readonly BindableProperty AutowireViewModelProperty =
             BindableProperty.CreateAttached("AutowireViewModel", typeof(bool?), typeof(ViewModelLocator), null, propertyChanged: OnAutowireViewModelChanged);
 
+        /// <summary>
+        /// Instructs Prism to use a given page as the parent for a Partial View
+        /// </summary>
         public static readonly BindableProperty AutowirePartialViewProperty =
             BindableProperty.CreateAttached("AutowirePartialView", typeof(Page), typeof(ViewModelLocator), null, propertyChanged: OnAutowirePartialViewChanged);
 
@@ -38,6 +41,16 @@ namespace Prism.Mvvm
         public static void SetAutowireViewModel(BindableObject bindable, bool? value)
         {
             bindable.SetValue(ViewModelLocator.AutowireViewModelProperty, value);
+        }
+
+        public static Page GetAutowirePartialView(BindableObject bindable)
+        {
+            return (Page)bindable.GetValue(AutowirePartialViewProperty);
+        }
+
+        public static void SetAutowirePartialView(BindableObject bindable, Page page)
+        {
+            bindable.SetValue(AutowirePartialViewProperty, page);
         }
 
         private static void OnAutowireViewModelChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -86,7 +86,10 @@ namespace Prism.Mvvm
 
                 partialViews.Add(bindable);
                 // Set Autowire Property
-                bindable.SetValue(AutowireViewModelProperty, true);
+                if(bindable.GetValue(AutowireViewModelProperty) == null)
+                {
+                    bindable.SetValue(AutowireViewModelProperty, true);
+                }
             }
         }
 

--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System.Collections.Generic;
+using Xamarin.Forms;
 
 namespace Prism.Mvvm
 {
@@ -12,6 +13,12 @@ namespace Prism.Mvvm
         /// </summary>
         public static readonly BindableProperty AutowireViewModelProperty =
             BindableProperty.CreateAttached("AutowireViewModel", typeof(bool?), typeof(ViewModelLocator), null, propertyChanged: OnAutowireViewModelChanged);
+
+        public static readonly BindableProperty AutowirePartialViewProperty =
+            BindableProperty.CreateAttached("AutowirePartialView", typeof(Page), typeof(ViewModelLocator), null, propertyChanged: OnAutowirePartialViewChanged);
+
+        internal static readonly BindableProperty PartialViewsProperty =
+            BindableProperty.CreateAttached("PrismPartialViews", typeof(List<BindableObject>), typeof(ViewModelLocator), new List<Page>());
 
         /// <summary>
         /// Gets the AutowireViewModel property value.
@@ -40,15 +47,29 @@ namespace Prism.Mvvm
                 ViewModelLocationProvider.AutoWireViewModelChanged(bindable, Bind);
         }
 
+        private static void OnAutowirePartialViewChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (oldValue == newValue)
+                return;
+
+            if(newValue != null && newValue is Page page)
+            {
+                // Add View to Views Collection for Page.
+                var partialViews = page.GetValue(PartialViewsProperty) as List<BindableObject>;
+                partialViews.Add(bindable);
+                // Set Autowire Property
+                bindable.SetValue(AutowireViewModelProperty, true);
+            }
+        }
+
         /// <summary>
         /// Sets the <see cref="Xamarin.Forms.BindableObject.BindingContext"/> of a View
         /// </summary>
         /// <param name="view">The View to set the <see cref="Xamarin.Forms.BindableObject.BindingContext"/> on</param>
         /// <param name="viewModel">The object to use as the <see cref="Xamarin.Forms.BindableObject.BindingContext"/> for the View</param>
-        static void Bind(object view, object viewModel)
+        private static void Bind(object view, object viewModel)
         {
-            BindableObject element = view as BindableObject;
-            if (element != null)
+            if (view is BindableObject element)
                 element.BindingContext = viewModel;
         }
     }

--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -18,7 +18,7 @@ namespace Prism.Mvvm
             BindableProperty.CreateAttached("AutowirePartialView", typeof(Page), typeof(ViewModelLocator), null, propertyChanged: OnAutowirePartialViewChanged);
 
         internal static readonly BindableProperty PartialViewsProperty =
-            BindableProperty.CreateAttached("PrismPartialViews", typeof(List<BindableObject>), typeof(ViewModelLocator), new List<Page>());
+            BindableProperty.CreateAttached("PrismPartialViews", typeof(List<BindableObject>), typeof(ViewModelLocator), new List<BindableObject>());
 
         /// <summary>
         /// Gets the AutowireViewModel property value.

--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -21,7 +21,7 @@ namespace Prism.Mvvm
             BindableProperty.CreateAttached("AutowirePartialView", typeof(Page), typeof(ViewModelLocator), null, propertyChanged: OnAutowirePartialViewChanged);
 
         internal static readonly BindableProperty PartialViewsProperty =
-            BindableProperty.CreateAttached("PrismPartialViews", typeof(List<BindableObject>), typeof(ViewModelLocator), new List<BindableObject>());
+            BindableProperty.CreateAttached("PrismPartialViews", typeof(List<BindableObject>), typeof(ViewModelLocator), null);
 
         /// <summary>
         /// Gets the AutowireViewModel property value.
@@ -65,10 +65,25 @@ namespace Prism.Mvvm
             if (oldValue == newValue)
                 return;
 
-            if(newValue != null && newValue is Page page)
+            if(oldValue is Page oldPage)
+            {
+                var oldPartials = (List<BindableObject>)oldPage.GetValue(PartialViewsProperty);
+                oldPartials?.Clear();
+                oldPage.SetValue(PartialViewsProperty, null);
+            }
+
+            List<BindableObject> partialViews = null;
+            if (newValue != null && newValue is Page page)
             {
                 // Add View to Views Collection for Page.
-                var partialViews = page.GetValue(PartialViewsProperty) as List<BindableObject>;
+                partialViews = page.GetValue(PartialViewsProperty) as List<BindableObject>;
+
+                if(partialViews == null)
+                {
+                    partialViews = new List<BindableObject>();
+                    page.SetValue(PartialViewsProperty, partialViews);
+                }
+
                 partialViews.Add(bindable);
                 // Set Autowire Property
                 bindable.SetValue(AutowireViewModelProperty, true);

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Xamarin/Prism.Forms/Properties/AssemblyInfo.cs
+++ b/Source/Xamarin/Prism.Forms/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Prism.Forms.Tests")]
+[assembly: InternalsVisibleTo("Prism.Autofac.Forms.Tests")]
+[assembly: InternalsVisibleTo("Prism.DryIoc.Forms.Tests")]
+[assembly: InternalsVisibleTo("Prism.Unity.Forms.Tests")]

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Source/Xamarin/Prism.Unity.Forms/UnityContainerExtension.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityContainerExtension.cs
@@ -1,7 +1,9 @@
 ﻿using Prism.Ioc;
+using Prism.Mvvm;
 using System;
 using Unity;
 using Unity.Resolution;
+using Xamarin.Forms;
 
 namespace Prism.Unity
 {
@@ -49,15 +51,30 @@ namespace Prism.Unity
         {
             ResolverOverride[] overrides = null;
 
-            if(view is Xamarin.Forms.Page page)
+            switch (view)
             {
-                overrides = new ResolverOverride[]
-                {
-                    new DependencyOverride(
-                        typeof(Navigation.INavigationService),
-                        this.CreateNavigationService(page)
-                    )
-                };
+                case Page page:
+                    overrides = new ResolverOverride[]
+                    {
+                        new DependencyOverride(
+                            typeof(Navigation.INavigationService),
+                            this.CreateNavigationService(page)
+                        )
+                    };
+                    break;
+                case BindableObject bindable:
+                    var attachedPage = bindable.GetValue(ViewModelLocator.AutowirePartialViewProperty) as Page;
+                    if (attachedPage != null)
+                    {
+                        overrides = new ResolverOverride[]
+                        {
+                            new DependencyOverride(
+                                typeof(Navigation.INavigationService),
+                                this.CreateNavigationService(attachedPage)
+                            )
+                        };
+                    }
+                    break;
             }
 
             return Instance.Resolve(viewModelType, overrides);

--- a/Source/global.json
+++ b/Source/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.52"
+        "MSBuild.Sdk.Extras": "1.6.55"
     }
 }


### PR DESCRIPTION
﻿### Description of Change ###

Adds an ability to support Partial Views that have their own ViewModel which can be reused across multiple Pages in a single application. This sets the AutowireViewModel property behind the scenes and updates the ResolveViewModelForView in each of the Container projects to look for an associated Page if the View is not a Page.

#### Example

```xml
<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
                xmlns:local="using:AwesomeProject.Views"
                x:Name="page"
                x:Class="AwesomeProject.Views.ViewA">
  <local:MyCustomView prism:ViewModelLocator.AutowirePartialView="{x:Reference page}" />
</ContentPage>
```

```cs
public class MyCustomViewModel : BindableBase
{
    public MyCustomViewModel(INavigationService navigationService)
    {
        // The navigationService can now be used....
    }
}
```

### API Changes ###

Added:
 - BindableProperty `ViewModelLocator.AutowirePartialView`. This takes a reference to the associated Page
    - This allows us to make minimal changes and not need to wait and recurse the Element.Parent, as ViewModelLocator.AutowireViewModel is set prior to the Parent being set on the Element.

### Behavioral Changes ###

- void PageUtilities.InvokeViewAndViewModelAction => Added check to see if  view is Xamarin.Forms.Page and if it has any PartialViews. If it does the InvokeAction is called for each Partial View.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard