### PR TITLE
Fixed NullException in EventToCommand for derived properties

### DIFF
--- a/Source/Xamarin/Prism.Forms/Behaviors/EventToCommandBehavior.cs
+++ b/Source/Xamarin/Prism.Forms/Behaviors/EventToCommandBehavior.cs
@@ -183,7 +183,10 @@ namespace Prism.Behaviors
                 object propertyValue = eventArgs;
                 foreach (var propertyPathPart in propertyPathParts)
                 {
-                    var propInfo = propertyValue.GetType().GetTypeInfo().GetDeclaredProperty(propertyPathPart);
+                    var propInfo = propertyValue.GetType().GetRuntimeProperty(propertyPathPart);
+                    if (propInfo == null)
+                        throw new MissingMemberException($"Unable to find {EventArgsParameterPath}");
+
                     propertyValue = propInfo.GetValue(propertyValue);
                     if (propertyValue == null)
                     {


### PR DESCRIPTION
﻿### Description of Change ###

Replaced GetDeclaredProperty with GetRuntimeProperty

### Bugs Fixed ###

- #1549 

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard