### PR TITLE
add Linker Preserve Attribute

### DIFF
--- a/Source/Xamarin/Prism.Forms/Properties/AssemblyInfo.cs
+++ b/Source/Xamarin/Prism.Forms/Properties/AssemblyInfo.cs
@@ -4,3 +4,5 @@
 [assembly: InternalsVisibleTo("Prism.Autofac.Forms.Tests")]
 [assembly: InternalsVisibleTo("Prism.DryIoc.Forms.Tests")]
 [assembly: InternalsVisibleTo("Prism.Unity.Forms.Tests")]
+
+[assembly: Xamarin.Forms.Internals.Preserve(AllMembers = true)]


### PR DESCRIPTION
﻿### Description of Change ###

Adding linker Preserve Attribute to Prism.Forms

### Bugs Fixed ###

N/A

### API Changes ###

N/A

### Behavioral Changes ###

Linking Xamarin.iOS projects will now leave Prism.Forms alone reducing issues in which the Linker removes references to Prism implementations.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard