### PR TITLE
Xaml nav

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <MasterDetailPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                   xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
-              prism:ViewModelLocator.AutowireViewModel="True"
-             x:Class="HelloWorld.Views.MyMasterDetail">
+                  xmlns:nav="clr-namespace:Prism.Navigation.Xaml;assembly=Prism.Forms"
+                  prism:ViewModelLocator.AutowireViewModel="True"
+                  x:Class="HelloWorld.Views.MyMasterDetail">
 
     <MasterDetailPage.Master>
         <ContentPage Title="Default">
@@ -12,6 +13,7 @@
                 <Button Text="ViewA" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewA" />
                 <Button Text="ViewB" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewB" />
                 <Button Text="ViewC" Command="{Binding NavigateCommand}" CommandParameter="MyNavigationPage/ViewC" />
+                <Button Text="XamlNav" Command="{nav:NavigateTo 'MyNavigationPage/ViewA'}" />
             </StackLayout>
         </ContentPage>
     </MasterDetailPage.Master>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml.cs
@@ -1,24 +1,17 @@
 ﻿using Prism.Navigation;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
 
 namespace HelloWorld.Views
 {
-    public partial class MyMasterDetail : MasterDetailPage, IMasterDetailPageOptions
+    [XamlCompilation(XamlCompilationOptions.Skip)]
+    public partial class MyMasterDetail : IMasterDetailPageOptions
     {
         public MyMasterDetail()
         {
             InitializeComponent();
         }
 
-        public bool IsPresentedAfterNavigation
-        {
-            get { return Device.Idiom != TargetIdiom.Phone; }
-        }
+        public bool IsPresentedAfterNavigation => Device.Idiom != TargetIdiom.Phone;
     }
 }

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/XamlNavigationFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/XamlNavigationFixture.cs
@@ -1,0 +1,138 @@
+using Xunit;
+using Xunit.Abstractions;
+using Prism.DI.Forms.Tests.Fixtures;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Xaml.Internals;
+using Prism.DI.Forms.Tests.Mocks.Internals;
+using Xamarin.Forms.Internals;
+using Prism.Navigation.Xaml;
+using System.Windows.Input;
+using System;
+using System.Threading.Tasks;
+using Prism.DI.Forms.Tests.Mocks.Views;
+
+#if Autofac
+namespace Prism.Autofac.Forms.Tests.Fixtures
+#elif DryIoc
+namespace Prism.DryIoc.Forms.Tests.Fixtures
+#elif Ninject
+namespace Prism.Ninject.Forms.Tests.Fixtures
+#elif Unity
+namespace Prism.Unity.Forms.Tests.Fixtures
+#endif
+{
+    public class XamlNavigationFixture : FixtureBase
+    {
+        public XamlNavigationFixture(ITestOutputHelper testOutputHelper) 
+            : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public void RequiresServiceProvider()
+        {
+            var navigateExtension = new NavigateToExtension();
+            var ex = Record.Exception(() => navigateExtension.ProvideValue(null));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Fact]
+        public void ProvidesCommand()
+        {
+            var serviceProvider = new XamlServiceProvider();
+            var navigateExtension = new NavigateToExtension();
+
+            object providedValue = null;
+            var ex = Record.Exception(() => providedValue = navigateExtension.ProvideValue(serviceProvider));
+
+            Assert.Null(ex);
+            Assert.NotNull(providedValue);
+            Assert.IsAssignableFrom<ICommand>(providedValue);
+        }
+
+        [Fact]
+        public async Task ResolvesParentPage()
+        {
+            var app = CreateMockApplication();
+
+            Log.Listeners.Clear();
+            var logObserver = new FormsLogObserver();
+            Log.Listeners.Add(logObserver);
+
+            var layout = new Button();
+            var serviceProvider = new XamlServiceProvider();
+            serviceProvider.Add(typeof(IProvideValueTarget), new XamlValueTargetProvider(layout, "Command"));
+
+            var navigateExtension = new NavigateToExtension()
+            {
+                Name = "/AutowireView"
+            };
+            navigateExtension.ProvideValue(serviceProvider);
+
+            app.MainPage = new NavigationPage(new ContentPage
+            {
+                Content = layout
+            });
+
+            Assert.NotNull(layout.Parent);
+            Assert.IsType<ContentPage>(layout.Parent);
+
+            Assert.NotNull(navigateExtension.SourcePage);
+            Assert.True(navigateExtension.CanExecute(null));
+            var ex = await Record.ExceptionAsync(async () =>
+            {
+                navigateExtension.Execute(null);
+                if (navigateExtension.IsNavigating)
+                    await Task.Delay(100);
+            });
+            Assert.Null(ex);
+            Assert.Empty(logObserver.Logs);
+
+            Assert.IsType<AutowireView>(app.MainPage);
+        }
+
+        [Fact]
+        public async Task LogsNavigationErrors_WithoutThrowingException()
+        {
+            var app = CreateMockApplication();
+
+            Log.Listeners.Clear();
+            var logObserver = new FormsLogObserver();
+            Log.Listeners.Add(logObserver);
+
+            var layout = new Button();
+            var serviceProvider = new XamlServiceProvider();
+            serviceProvider.Add(typeof(IProvideValueTarget), new XamlValueTargetProvider(layout, "Command"));
+
+            var navigateExtension = new NavigateToExtension()
+            {
+                Name = "/NonExistentPage"
+            };
+            navigateExtension.ProvideValue(serviceProvider);
+
+            app.MainPage = new NavigationPage(new ContentPage
+            {
+                Content = layout
+            });
+
+            Assert.NotNull(layout.Parent);
+            Assert.IsType<ContentPage>(layout.Parent);
+
+            Assert.NotNull(navigateExtension.SourcePage);
+            Assert.True(navigateExtension.CanExecute(null));
+            var ex = await Record.ExceptionAsync(async () =>
+            {
+                navigateExtension.Execute(null);
+                if (navigateExtension.IsNavigating)
+                    await Task.Delay(100);
+            });
+            Assert.Null(ex);
+            Assert.NotEmpty(logObserver.Logs);
+
+            Assert.IsType<NavigationPage>(app.MainPage);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/XamlNavigationFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/XamlNavigationFixture.cs
@@ -134,5 +134,37 @@ namespace Prism.Unity.Forms.Tests.Fixtures
 
             Assert.IsType<NavigationPage>(app.MainPage);
         }
+
+        [Fact]
+        public void UsesMasterDetailPage_WhenParentIsMaster()
+        {
+            var app = CreateMockApplication();
+
+            var layout = new Button();
+            var serviceProvider = new XamlServiceProvider();
+            serviceProvider.Add(typeof(IProvideValueTarget), new XamlValueTargetProvider(layout, "Command"));
+
+            var navigateExtension = new NavigateToExtension()
+            {
+                Name = "SomeOtherView"
+            };
+            navigateExtension.ProvideValue(serviceProvider);
+
+            app.MainPage = new MasterDetailPage
+            {
+                Master = new ContentPage
+                {
+                    Title = "Test",
+                    Content = layout
+                },
+                Detail = new NavigationPage(new ContentPage())
+            };
+
+            Assert.NotNull(layout.Parent);
+            Assert.IsType<ContentPage>(layout.Parent);
+
+            Assert.NotNull(navigateExtension.SourcePage);
+            Assert.IsType<MasterDetailPage>(navigateExtension.SourcePage);
+        }
     }
 }

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Internals/FormsLogObserver.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Internals/FormsLogObserver.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+
+namespace Prism.DI.Forms.Tests.Mocks.Internals
+{
+    public class FormsLogObserver : LogListener
+    {
+        private List<(string category, string message)> _logs { get; }
+
+        public FormsLogObserver()
+        {
+            _logs = new List<(string category, string message)>();
+        }
+
+        public IReadOnlyList<(string category, string message)> Logs => _logs;
+
+        public override void Warning(string category, string message) =>
+            _logs.Add((category, message));
+    }
+}

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Internals/XamlValueTargetProvider.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Mocks/Internals/XamlValueTargetProvider.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Prism.DI.Forms.Tests.Mocks.Internals
+{
+    class XamlValueTargetProvider : IProvideValueTarget
+    {
+        public XamlValueTargetProvider(object targetObject, object targetProperty)
+        {
+            TargetObject = targetObject;
+            TargetProperty = targetProperty;
+        }
+
+        public object TargetObject { get; }
+        public object TargetProperty { get; }
+
+        public IEnumerable<object> ParentObjects => GetBindableStack();
+
+        private IEnumerable<object> GetBindableStack()
+        {
+            var stack = new List<object>();
+            if(TargetObject is Element element)
+            {
+                stack.Add(element);
+                while(element.Parent != null)
+                {
+                    element = element.Parent;
+                    stack.Add(element);
+                }
+            }
+
+            return stack;
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/GoBackExtension.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/GoBackExtension.cs
@@ -10,10 +10,14 @@ namespace Prism.Navigation.Xaml
 
         protected override async Task HandleNavigation(INavigationParameters parameters, INavigationService navigationService)
         {
-            if (GoBackType == GoBackType.ToRoot)
-                await navigationService.GoBackToRootAsync(parameters);
-            else
+            var result = GoBackType == GoBackType.ToRoot ?
+                await navigationService.GoBackToRootAsync(parameters) :
                 await navigationService.GoBackAsync(parameters);
+
+            if (result.Exception != null)
+            {
+                Log(result.Exception);
+            }
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigateToExtension.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigateToExtension.cs
@@ -10,7 +10,11 @@ namespace Prism.Navigation.Xaml
 
         protected override async Task HandleNavigation(INavigationParameters parameters, INavigationService navigationService)
         {
-            await navigationService.NavigateAsync(Name, parameters);
+            var result = await navigationService.NavigateAsync(Name, parameters);
+            if(result.Exception != null)
+            {
+                Log(result.Exception);
+            }
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/Navigation.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/Navigation.cs
@@ -32,6 +32,8 @@ namespace Prism.Navigation.Xaml
 
         internal static INavigationService GetNavigationService(Page page)
         {
+            if(page == null) throw new ArgumentNullException(nameof(page));
+
             var navigationService = (INavigationService) page.GetValue(NavigationServiceProperty);
             if (navigationService == null) page.SetValue(NavigationServiceProperty, navigationService = CreateNavigationService(page));
 

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationExtensionBase.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationExtensionBase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -14,35 +13,35 @@ namespace Prism.Navigation.Xaml
     {
         private IServiceProvider ServiceProvider;
 
-        private Element targetElement;
+        private Element _targetElement;
         protected Element TargetElement
         {
             get
             {
-                if (targetElement == null)
+                if (_targetElement == null)
                 {
                     Initialize();
                 }
-                return targetElement;
+                return _targetElement;
             }
-            set => targetElement = value;
+            set => _targetElement = value;
         }
 
         protected internal bool IsNavigating;
 
-        private Page sourcePage;
+        private Page _sourcePage;
         public Page SourcePage
         {
             protected internal get
             {
-                if(sourcePage == null)
+                if(_sourcePage == null)
                 {
                     Initialize();
                 }
 
-                return sourcePage;
+                return _sourcePage;
             }
-            set => sourcePage = value;
+            set => _sourcePage = value;
         }
 
         public bool CanExecute(object parameter) => !IsNavigating;
@@ -111,7 +110,7 @@ namespace Prism.Navigation.Xaml
                                                                        .GetTypeInfo()
                                                                        .IsSubclassOf(typeof(Page)));
 
-            if (sourcePage is null && parentPage != null)
+            if (_sourcePage is null && parentPage != null)
             {
                 SourcePage = parentPage;
 


### PR DESCRIPTION
﻿### Description of Change ###

Refactors the lookup logic for the Xaml Navigation Extension to delay the lookup of the Target object and parent Page. Adds unit tests and exception logging.

### Bugs Fixed ###

- fixes #1572 

### API Changes ###

API is unchanged.

### Behavioral Changes ###

- XAML Navigation Extensions no longer return false if the parent Page cannot be found.
- The SourcePage is only set in the event it has not been specified by the developer
- In the event that the Parent Page is set as the Master of a MasterDetailPage, the SourcePage will be set to the MasterDetailPage
- A new virtual method has been added to Log exceptions. By default this uses the Xamarin.Forms Log which is the same mechanism used for Binding and other XF XAML Extensions

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard