### PR TITLE
Allow Search Pattern to be specified with DirectoryModuleCatalog

### DIFF
--- a/Source/Wpf/Prism.Wpf.Tests/Modularity/DirectoryModuleCatalogFixture.Desktop.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Modularity/DirectoryModuleCatalogFixture.Desktop.cs
@@ -70,6 +70,30 @@ namespace Prism.Wpf.Tests.Modularity
         }
 
         [TestMethod]
+        public void NonExistentSearchPathDefaults()
+        {
+            DirectoryModuleCatalog catalog = new DirectoryModuleCatalog
+            {
+                ModulePath = ModulesDirectory1
+            };
+            catalog.Load();
+
+            Assert.AreEqual("*.dll", catalog.SearchPattern);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void IncorrectSearchPathSuffixThrows()
+        {
+            DirectoryModuleCatalog catalog = new DirectoryModuleCatalog
+            {
+                ModulePath = ModulesDirectory1,
+                SearchPattern = "*.dl"
+            };
+            catalog.Load();
+        }
+
+        [TestMethod]
         public void ShouldReturnAListOfModuleInfo()
         {
             CompilerHelper.CompileFile(@"Prism.Wpf.Tests.Mocks.Modules.MockModuleA.cs",

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -38,5 +38,20 @@ Prism.Wpf helps you more easily design and build rich, flexible, and easy to mai
   <ItemGroup>
     <Content Include="..\System.Windows.Interactivity.dll" Pack="true" PackagePath="lib\net45" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/Source/Wpf/Prism.Wpf/Properties/Resources.Designer.cs
+++ b/Source/Wpf/Prism.Wpf/Properties/Resources.Designer.cs
@@ -469,6 +469,7 @@ namespace Prism.Properties {
         /// </summary>
         internal static string StringCannotBeNullOrEmpty {
             get {
+                return ResourceManager.GetString("StringCannotBeNullOrEmpty", resourceCulture);
             }
         }
         

--- a/Source/Wpf/Prism.Wpf/Properties/Resources.Designer.cs
+++ b/Source/Wpf/Prism.Wpf/Properties/Resources.Designer.cs
@@ -456,20 +456,19 @@ namespace Prism.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The provided String argument {0} must not be null or empty..
+        ///   Looks up a localized string similar to The Search Pattern must end with .dll.
         /// </summary>
-        internal static string StringCannotBeNullOrEmpty {
+        internal static string SearchPatternMustEndWithDll {
             get {
-                return ResourceManager.GetString("StringCannotBeNullOrEmpty", resourceCulture);
+                return ResourceManager.GetString("SearchPatternMustEndWithDll", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The provided String argument {0} must not be null or empty..
         /// </summary>
-        internal static string StringCannotBeNullOrEmpty1 {
+        internal static string StringCannotBeNullOrEmpty {
             get {
-                return ResourceManager.GetString("StringCannotBeNullOrEmpty1", resourceCulture);
             }
         }
         

--- a/Source/Wpf/Prism.Wpf/Properties/Resources.resx
+++ b/Source/Wpf/Prism.Wpf/Properties/Resources.resx
@@ -254,9 +254,6 @@
   <data name="StringCannotBeNullOrEmpty" xml:space="preserve">
     <value>The provided String argument {0} must not be null or empty.</value>
   </data>
-  <data name="StringCannotBeNullOrEmpty1" xml:space="preserve">
-    <value>The provided String argument {0} must not be null or empty.</value>
-  </data>
   <data name="TypeWithKeyNotRegistered" xml:space="preserve">
     <value>No BehaviorType with key '{0}' was registered.</value>
   </data>
@@ -276,5 +273,8 @@
   </data>
   <data name="MustBeModuleGroupCatalog" xml:space="preserve">
     <value>The ModuleCatalog must implement IModuleGroupCatalog to add groups</value>
+  </data>
+  <data name="SearchPatternMustEndWithDll" xml:space="preserve">
+    <value>The Search Pattern must end with .dll</value>
   </data>
 </root>


### PR DESCRIPTION
﻿### Description of Change ###

When using DirectoryModuleCatalog with ModulePath of ".", I was experiencing issues similar to #1329. This issue / PR was closed because the solution did not guarantee a regression. The proposed solution is not extremely flexible but allows the use of ModulePath "." with SearchPattern "CompanyName*.dll" to load applicable modules and avoid errors.

### Bugs Fixed ###

#1329

### API Changes ###

No external APIs changed.

### Behavioral Changes ###

No behavioral changes.

### PR Checklist ###

- [X] Has tests (if omitted, state reason in description)
- [ note sure ] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard