### PR TITLE
fixed #1589

### DIFF
--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -607,6 +607,9 @@ namespace Prism.Navigation
                 await ProcessNavigation(newDetail, segments, parameters, newDetail is NavigationPage ? false : true, animated);
                 await DoNavigateAction(detail, nextSegment, newDetail, parameters, onNavigationActionCompleted: () =>
                 {
+                    if (detailIsNavPage)
+                        OnNavigatedFrom(((NavigationPage)detail).CurrentPage, parameters);
+
                     currentPage.IsPresented = isPresented;
                     currentPage.Detail = newDetail;
                     PageUtilities.DestroyPage(detail);


### PR DESCRIPTION
﻿### Description of Change ###

if the current detail is a navPage, we need to call OnNavigatedFrom on the navage.CurrentPage

### Bugs Fixed ###

- #1589 

### API Changes ###

none

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard