### PR TITLE
Bumping minimum UWP version

### DIFF
--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net45;uap10.0.15063;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net45;uap10.0.16299;uap10.0.17134;uap10.0.17763</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Prism</AssemblyName>
     <PackageId>Prism.Core</PackageId>

--- a/Source/Windows10/Prism.DryIoc.Windows/Prism.DryIoc.Windows.csproj
+++ b/Source/Windows10/Prism.DryIoc.Windows/Prism.DryIoc.Windows.csproj
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.15063;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>uap10.0.16299;uap10.0.17134;uap10.0.17763</TargetFrameworks>
     <Title>DryIoc for Prism for UWP</Title>
     <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->

--- a/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
+++ b/Source/Windows10/Prism.Unity.Windows/Prism.Unity.Windows.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.15063;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>uap10.0.16299;uap10.0.17134;uap10.0.17763</TargetFrameworks>
     <Title>Unity for Prism for UWP</Title>
     <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->

--- a/Source/Windows10/Prism.Windows/Prism.Windows.csproj
+++ b/Source/Windows10/Prism.Windows/Prism.Windows.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.15063;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>uap10.0.16299;uap10.0.17134;uap10.0.17763</TargetFrameworks>
     <RootNamespace>Prism</RootNamespace>
     <Title>Prism for UWP</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->


### PR DESCRIPTION
﻿### Description of Change ###

Applying Microsoft's N-1 support. Already adding newest SDK, so temporarily 3 SDKs.

Also:

> Projects using .NET Standard 2.0 must have a Minimum Version of Build 16299 or later.

Source: https://docs.microsoft.com/en-us/windows/uwp/updates-and-versions/choose-a-uwp-version
