### PR TITLE
Load modules without a shell in WPF applications (#1601)

### DIFF
--- a/Source/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/Source/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -195,7 +195,7 @@ namespace Prism
         /// </summary>
         protected virtual void OnInitialized()
         {
-            MainWindow.Show();
+            MainWindow?.Show();
         }
 
         /// <summary>

--- a/Source/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/Source/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -86,8 +86,9 @@ namespace Prism
                 RegionManager.SetRegionManager(shell, _containerExtension.Resolve<IRegionManager>());
                 RegionManager.UpdateRegions();
                 InitializeShell(shell);
-                InitializeModules();
             }
+			
+            InitializeModules();
         }
 
         /// <summary>


### PR DESCRIPTION
﻿### Description of Change ###

This always loads the modules even when no shell was created.
It also makes sure to not crash afterwards when MainWindow is null.

### Bugs Fixed ###

https://github.com/PrismLibrary/Prism/issues/1601

### API Changes ###

None

### Behavioral Changes ###

InitializeModules() is called for WPF application even when there's no shell created in CreateShell()

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard