### PR TITLE
added SelectTab extension method for tabbedpages

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Android/HelloWorld.Android.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.Android/HelloWorld.Android.csproj
@@ -48,7 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2.1" />

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.UWP/HelloWorld.UWP.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.UWP/HelloWorld.UWP.csproj
@@ -143,7 +143,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/HelloWorld.iOS.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld.iOS/HelloWorld.iOS.csproj
@@ -149,7 +149,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/App.xaml.cs
@@ -60,7 +60,7 @@ namespace HelloWorld
             //NavigationService.NavigateAsync($"ViewA/ViewB/MyMasterDetail/NavigationPage/ViewA/ViewB?{KnownNavigationParameters.UseModalNavigation}=true/ViewA/ViewC");
             //NavigationService.NavigateAsync($"MyMasterDetail/NavigationPage/MyTabbedPage?{KnownNavigationParameters.SelectedTab}=ViewC");            
 
-            NavigationService.NavigateAsync($"MyMasterDetail/MyNavigationPage/ViewA");
+            NavigationService.NavigateAsync($"MyMasterDetail/MyTabbedPage");
         }
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleA.csproj
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ModuleA.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.2.0.839982" />
+    <PackageReference Include="Xamarin.Forms" Version="3.3.0.967583" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -5,6 +5,7 @@ using Prism.Navigation;
 using Prism;
 using Prism.AppModel;
 using System.Diagnostics;
+using Prism.Navigation.TabbedPages;
 
 namespace ModuleA.ViewModels
 {
@@ -73,7 +74,7 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.NavigateAsync($"ViewB/ViewC");
+            await _navigationService.SelectTab("ViewC");
             CanNavigate = true;
         }
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewBViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewBViewModel.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System;
 using Prism;
 using Prism.AppModel;
+using Prism.Navigation.TabbedPages;
 
 namespace ModuleA.ViewModels
 {
@@ -64,7 +65,10 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.NavigateAsync("ViewA");
+            //await _navigationService.NavigateAsync("ViewA");
+
+            await _navigationService.SelectTab("ViewA");
+
             CanNavigate = true;
         }
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System;
 using Prism.AppModel;
+using Prism.Navigation.TabbedPages;
 
 namespace ModuleA.ViewModels
 {
@@ -36,11 +37,13 @@ namespace ModuleA.ViewModels
 
                 //Debug.WriteLine("After _navigationService.NavigateAsync(ViewB) ...");
 
-                var result = await _navigationService.NavigateAsync("../../");
-                if (!result.Success)
-                {
+                //var result = await _navigationService.NavigateAsync("../../");
+                //if (!result.Success)
+                //{
 
-                }
+                //}
+
+                await _navigationService.SelectTab("ViewB?id=3");
             }
             catch(Exception ex)
             {

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyTabbedPage.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/MyTabbedPage.xaml
@@ -12,13 +12,13 @@
         <ToolbarItem Text="Reset" Command="{Binding ApplicationCommands.ResetCommand}"/>
     </TabbedPage.ToolbarItems>
 
-    <!--<NavigationPage Title="View A">
+    <NavigationPage Title="View A">
         <x:Arguments>
 			<local:ViewA Title="View A" />
 		</x:Arguments>
 	</NavigationPage>
 
-    <NavigationPage Title="View B">
+    <!--<NavigationPage Title="View B">
         <x:Arguments>
 			<local:ViewB Title="View B" />
 		</x:Arguments>
@@ -26,7 +26,7 @@
 
 	<local:ViewC Title="View C" />-->
 
-    <local:ViewA Title="View A" />
+    <!--<local:ViewA Title="View A" />-->
     <local:ViewB Title="View B"/>
     <local:ViewC Title="View C"/>
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/ViewB.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/ViewB.xaml
@@ -13,11 +13,11 @@
         </OnPlatform>
     </ContentPage.Padding>
 
-    <local:PartialViewB prism:ViewModelLocator.AutowirePartialView="{x:Reference viewB}" />
-    <!--<StackLayout>
+    <!--<local:PartialViewB prism:ViewModelLocator.AutowirePartialView="{x:Reference viewB}" />-->
+    <StackLayout>
         <Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
         <Label Text="{Binding IsActive}" />
         <Button Command="{Binding NavigateCommand}" Text="Navigate" />
-    </StackLayout>-->
+    </StackLayout>
 
 </ContentPage>

--- a/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
@@ -1,0 +1,68 @@
+﻿using Prism.Common;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace Prism.Navigation.TabbedPages
+{
+    public static class INavigationServiceExtensions
+    {
+        /// <summary>
+        /// Selects a Tab of the TabbedPage parent.
+        /// </summary>
+        /// <param name="name">The name of the tab to select</param>
+        /// <param name="parameters">The navigation parameters</param>
+        public static async Task SelectTab(this INavigationService navigationService, string name, INavigationParameters parameters = null)
+        {
+            var currentPage = ((IPageAware)navigationService).Page;
+
+            var canNavigate = await PageUtilities.CanNavigateAsync(currentPage, parameters);
+            if (!canNavigate)
+                return;
+
+            TabbedPage tabbedPage = null;
+
+            if (currentPage.Parent is TabbedPage parent)
+            {
+                tabbedPage = parent;
+            }
+            else if (currentPage.Parent is NavigationPage navPage)
+            {
+                if (navPage.Parent != null && navPage.Parent is TabbedPage parent2)
+                {
+                    tabbedPage = parent2;
+                }
+            }
+
+            if (tabbedPage == null)
+                return;
+
+            var tabToSelectedType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(name));
+
+            Page target = null;
+            foreach (var child in tabbedPage.Children)
+            {
+                if (child.GetType() == tabToSelectedType)
+                {
+                    target = child;
+                    break;
+                }
+
+                if (child is NavigationPage)
+                {
+                    if (((NavigationPage)child).CurrentPage.GetType() == tabToSelectedType)
+                    {
+                        target = child;
+                        break;
+                    }
+                }
+            }
+
+            var tabParameters = UriParsingHelper.GetSegmentParameters(name, parameters);
+
+            PageUtilities.OnNavigatingTo(target, tabParameters);
+            tabbedPage.CurrentPage = target;
+            PageUtilities.OnNavigatedFrom(currentPage, tabParameters);
+            PageUtilities.OnNavigatedTo(target, tabParameters);
+        }
+    }
+}


### PR DESCRIPTION
﻿### Description of Change ###

Added a new extension method to `INavigationService` that allows a developer to select a tab from within the same TabbedPage instance.

### API Changes ###

Added:
 - void INavigationService.SelectTab(name, parameters);

To use the new extension method, add the `Prism.Navigation.TabbedPages` namespace to your ViewModel.

`IConfirmNavigation` and `INavigationAware` interfaces are respected. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard