### PR TITLE
Tabbed Switching Refactoring

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -74,7 +74,7 @@ namespace ModuleA.ViewModels
         async void Navigate()
         {
             CanNavigate = false;
-            await _navigationService.SelectTab("ViewC");
+            await _navigationService.SelectTabAsync("ViewC");
             CanNavigate = true;
         }
 

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewBViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewBViewModel.cs
@@ -67,7 +67,7 @@ namespace ModuleA.ViewModels
             CanNavigate = false;
             //await _navigationService.NavigateAsync("ViewA");
 
-            await _navigationService.SelectTab("ViewA");
+            await _navigationService.SelectTabAsync("ViewA");
 
             CanNavigate = true;
         }

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewCViewModel.cs
@@ -43,7 +43,7 @@ namespace ModuleA.ViewModels
 
                 //}
 
-                await _navigationService.SelectTab("ViewB?id=3");
+                await _navigationService.SelectTabAsync("ViewB?id=3");
             }
             catch(Exception ex)
             {

--- a/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Prism.Common;
+using System;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 
@@ -11,58 +12,78 @@ namespace Prism.Navigation.TabbedPages
         /// </summary>
         /// <param name="name">The name of the tab to select</param>
         /// <param name="parameters">The navigation parameters</param>
-        public static async Task SelectTab(this INavigationService navigationService, string name, INavigationParameters parameters = null)
+        public static async Task<INavigationResult> SelectTabAsync(this INavigationService navigationService, string name, INavigationParameters parameters = null)
         {
-            var currentPage = ((IPageAware)navigationService).Page;
-
-            var canNavigate = await PageUtilities.CanNavigateAsync(currentPage, parameters);
-            if (!canNavigate)
-                return;
-
-            TabbedPage tabbedPage = null;
-
-            if (currentPage.Parent is TabbedPage parent)
+            try
             {
-                tabbedPage = parent;
-            }
-            else if (currentPage.Parent is NavigationPage navPage)
-            {
-                if (navPage.Parent != null && navPage.Parent is TabbedPage parent2)
+                var currentPage = ((IPageAware)navigationService).Page;
+
+                var canNavigate = await PageUtilities.CanNavigateAsync(currentPage, parameters);
+                if (!canNavigate)
+                    throw new Exception($"IConfirmNavigation for {currentPage} returned false");
+
+                TabbedPage tabbedPage = null;
+
+                if (currentPage.Parent is TabbedPage parent)
                 {
-                    tabbedPage = parent2;
+                    tabbedPage = parent;
                 }
-            }
-
-            if (tabbedPage == null)
-                return;
-
-            var tabToSelectedType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(name));
-
-            Page target = null;
-            foreach (var child in tabbedPage.Children)
-            {
-                if (child.GetType() == tabToSelectedType)
+                else if (currentPage.Parent is NavigationPage navPage)
                 {
-                    target = child;
-                    break;
+                    if (navPage.Parent != null && navPage.Parent is TabbedPage parent2)
+                    {
+                        tabbedPage = parent2;
+                    }
                 }
 
-                if (child is NavigationPage)
+                if (tabbedPage == null)
+                    throw new Exception("No parent TabbedPage could be found");
+
+                var tabToSelectedType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(name));
+                if (tabToSelectedType is null)
+                    throw new Exception($"No View Type has been registered for '{name}'");
+
+                Page target = null;
+                foreach (var child in tabbedPage.Children)
                 {
-                    if (((NavigationPage)child).CurrentPage.GetType() == tabToSelectedType)
+                    if (child.GetType() == tabToSelectedType)
                     {
                         target = child;
                         break;
                     }
+
+                    if (child is NavigationPage childNavPage)
+                    {
+                        if (childNavPage.CurrentPage.GetType() == tabToSelectedType)
+                        {
+                            target = child;
+                            break;
+                        }
+                        else if(childNavPage.RootPage.GetType() == tabToSelectedType)
+                        {
+                            await childNavPage.PopToRootAsync();
+                            target = child;
+                            break;
+                        }
+                    }
                 }
+
+                if (target is null)
+                    throw new Exception($"Could not find a Child Tab for '{name}'");
+
+                var tabParameters = UriParsingHelper.GetSegmentParameters(name, parameters);
+
+                PageUtilities.OnNavigatingTo(target, tabParameters);
+                tabbedPage.CurrentPage = target;
+                PageUtilities.OnNavigatedFrom(currentPage, tabParameters);
+                PageUtilities.OnNavigatedTo(target, tabParameters);
+            }
+            catch(Exception ex)
+            {
+                return new NavigationResult { Exception = ex };
             }
 
-            var tabParameters = UriParsingHelper.GetSegmentParameters(name, parameters);
-
-            PageUtilities.OnNavigatingTo(target, tabParameters);
-            tabbedPage.CurrentPage = target;
-            PageUtilities.OnNavigatedFrom(currentPage, tabParameters);
-            PageUtilities.OnNavigatedTo(target, tabParameters);
+            return new NavigationResult { Success = true };
         }
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
@@ -54,14 +54,9 @@ namespace Prism.Navigation.TabbedPages
 
                     if (child is NavigationPage childNavPage)
                     {
-                        if (childNavPage.CurrentPage.GetType() == tabToSelectedType)
+                        if (childNavPage.CurrentPage.GetType() == tabToSelectedType || 
+                            childNavPage.RootPage.GetType() == tabToSelectedType)
                         {
-                            target = child;
-                            break;
-                        }
-                        else if(childNavPage.RootPage.GetType() == tabToSelectedType)
-                        {
-                            await childNavPage.PopToRootAsync();
                             target = child;
                             break;
                         }


### PR DESCRIPTION
﻿### Description of Change ###

Normalizes the API to match other Navigation methods with INavigationResult. Adds check of the NavigationPage Root Page when determining which tab to switch to. 

#### NOTE

Tabs containing a NavigationPage will switch whether you know the root or current page within the navigation stack. However no actual navigation will occur within the NavigationPage.

### API Changes ###

Changed:
 - Task INavigationService.SelectTab> => Task<INavigationResult> INavigationService.SelectTabAsync

### Behavioral Changes ###

- Tab Selection will now take into account both the Current and Root Page of tabs containing a Navigation Page.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard