### PR TITLE
[Xamarin Forms] App Links Service

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/AppLinkServiceMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/AppLinkServiceMock.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Prism.Services;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Mocks
+{
+    public class AppLinkServiceMock : IAppLinkService
+    {
+        public List<IAppLinkEntry> Entries { get; set; } = new List<IAppLinkEntry>();
+
+        public void RegisterLink(IAppLinkEntry entry)
+        {
+            this.Entries.Add(entry);
+        }
+
+        public void DeregisterLink(IAppLinkEntry entry)
+        {
+            this.Entries.Remove(entry);
+        }
+
+        public void DeregisterLink(Uri uri)
+        {
+            var link = this.Entries.FirstOrDefault(x => x.AppLinkUri.Equals(uri));
+            if (link != null)
+                this.Entries.Remove(link);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -143,6 +143,7 @@ namespace Prism
             containerRegistry.RegisterSingleton<IEventAggregator, EventAggregator>();
             containerRegistry.RegisterSingleton<IDependencyService, DependencyService>();
             containerRegistry.RegisterSingleton<IPageDialogService, PageDialogService>();
+            containerRegistry.RegisterSingleton<IAppLinkService, AppLinkService>();
             containerRegistry.RegisterSingleton<IDeviceService, DeviceService>();
             containerRegistry.RegisterSingleton<IPageBehaviorFactory, PageBehaviorFactory>();
             containerRegistry.RegisterSingleton<IModuleCatalog, ModuleCatalog>();

--- a/Source/Xamarin/Prism.Forms/Services/AppLinkService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/AppLinkService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Prism.Services
+{
+    public class AppLinkService : IAppLinkService
+    {
+        public void RegisterLink(IAppLinkEntry entry)
+        {
+            Application.Current.AppLinks.RegisterLink(entry);
+        }
+
+        public void DeregisterLink(IAppLinkEntry entry)
+        {
+            Application.Current.AppLinks.DeregisterLink(entry);
+        }
+
+        public void DeregisterLink(Uri uri)
+        {
+            Application.Current.AppLinks.DeregisterLink(uri);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Services/IAppLinkService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/IAppLinkService.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Prism.Services
+{
+    public interface IAppLinkService
+    {
+        /// <summary>
+        /// Add the provided application link to the application index
+        /// </summary>
+        /// <param name="entry">Application link details</param>
+        void RegisterLink(IAppLinkEntry entry);
+
+        /// <summary>
+        /// Removes the provided application link from the application index
+        /// </summary>
+        /// <param name="entry">Application link details</param>
+        void DeregisterLink(IAppLinkEntry entry);
+
+        /// <summary>
+        /// Removes the provided application link from the application index
+        /// </summary>
+        /// <param name="uri">The URI of your registered application link</param>
+        void DeregisterLink(Uri uri);
+    }
+}


### PR DESCRIPTION
﻿### Description of Change ###

Adds the ability to properly inject (and therefore mock) the AppLinks registry within Xamarin.Forms

### Bugs Fixed ###

N/A

### API Changes ###

No changes to existing API surface.  There is the question of if you want the IApplicationProvider updated and injected into the service implementation.

### Behavioral Changes ###

Adds a new required registration to container registry in PrismApplicationBase

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
   * API is pretty routine - compared it with DeviceService which didn't seem to have them either
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard