### PR TITLE
Properly resolve viewmodels for particular views in UWP

### DIFF
--- a/Source/Windows10/Prism.DryIoc.Windows/DryIocContainerExtension.cs
+++ b/Source/Windows10/Prism.DryIoc.Windows/DryIocContainerExtension.cs
@@ -51,7 +51,7 @@ namespace Prism.DryIoc
 
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
-            if (view is Page page)
+            if (view is Page page && page.Frame != null)
             {
                 var service = NavigationService.Instances[page.Frame];
                 return Instance.Resolve(viewModelType, new[] { service });

--- a/Source/Windows10/Prism.Unity.Windows/UnityContainerExtension.cs
+++ b/Source/Windows10/Prism.Unity.Windows/UnityContainerExtension.cs
@@ -49,7 +49,7 @@ namespace Prism.Unity
 
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
-            if (view is Page page)
+            if (view is Page page && page.Frame != null)
             {
                 var service = NavigationService.Instances[page.Frame];
                 ResolverOverride[] overrides = null;


### PR DESCRIPTION
﻿### Description of Change ###

Changed the behaviour of {Unity|DryIoc}ContainerExtension.ResolveViewModelForView() to be able to resolve VM for a view that is a page, but doesn't have its frame associated.


### Bugs Fixed ###

#1628 

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###
None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard