### PR TITLE
Cleanup of subscriptions with a time based delay.

### DIFF
--- a/Source/Prism.Tests/Events/MockDelegateReference.cs
+++ b/Source/Prism.Tests/Events/MockDelegateReference.cs
@@ -9,6 +9,7 @@ namespace Prism.Tests.Events
     class MockDelegateReference : IDelegateReference
     {
         public Delegate Target { get; set; }
+        public bool IsAlive => true;
 
         public MockDelegateReference()
         {

--- a/Source/Prism/Events/DelegateReference.cs
+++ b/Source/Prism/Events/DelegateReference.cs
@@ -60,6 +60,8 @@ namespace Prism.Events
             }
         }
 
+        public bool IsAlive => _delegate != null || _weakReference.IsAlive;
+
         private Delegate TryGetDelegate()
         {
             if (_method.IsStatic)

--- a/Source/Prism/Events/EventSubscription.cs
+++ b/Source/Prism/Events/EventSubscription.cs
@@ -43,6 +43,8 @@ namespace Prism.Events
         /// <value>A token that identifies this <see cref="IEventSubscription"/>.</value>
         public SubscriptionToken SubscriptionToken { get; set; }
 
+        public bool IsAlive => _actionReference.IsAlive;
+
         /// <summary>
         /// Gets the execution strategy to publish this event.
         /// </summary>

--- a/Source/Prism/Events/IDelegateReference.cs
+++ b/Source/Prism/Events/IDelegateReference.cs
@@ -15,5 +15,7 @@ namespace Prism.Events
         /// </summary>
         /// <value>A <see cref="Delegate"/> instance if the target is valid; otherwise <see langword="null"/>.</value>
         Delegate Target { get; }
+
+        bool IsAlive { get; }
     }
 }

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/MockDelegateReference.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/MockDelegateReference.cs
@@ -8,7 +8,7 @@ namespace Prism.Wpf.Tests.Mocks
     class MockDelegateReference : IDelegateReference
     {
         public Delegate Target { get; set; }
-
+        public bool IsAlive => true;
         public MockDelegateReference()
         {
 


### PR DESCRIPTION
﻿### Description of Change ###

Because the current situation has a performance problem, if someone is registering a high amount of events on the EventAggregator, the adapted code is improving the situation. Now it will check at the moment someone is registering, when the last prune run has been. If it was more than 1 minute ago, it will prune the list otherwise not.

### Bugs Fixed ###

- https://github.com/PrismLibrary/Prism/issues/1505

### API Changes ###

Added:
 - protected TimeSpan PruneInterval { get; set; }

### Behavioral Changes ###

Speed++;
