### PR TITLE
WIP: Prune automatically, but on a delay

### DIFF
--- a/Source/Prism/Events/EventBase.cs
+++ b/Source/Prism/Events/EventBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Prism.Events
 {
@@ -13,7 +14,8 @@ namespace Prism.Events
     ///</summary>
     public abstract class EventBase
     {
-        private readonly List<IEventSubscription> _subscriptions = new List<IEventSubscription>();
+        private int _pruneGuard;
+        private readonly LinkedList<IEventSubscription> _subscriptions = new LinkedList<IEventSubscription>();
 
         /// <summary>
         /// Allows the SynchronizationContext to be set by the EventAggregator for UI Thread Dispatching
@@ -28,6 +30,13 @@ namespace Prism.Events
         {
             get { return _subscriptions; }
         }
+
+        /// <summary>
+        /// To limit memory consumption with a rare Publish, the subscriptions
+        /// are automatically cleaned up during subscribe, but only as often as
+        /// this delay.
+        /// </summary>
+        protected virtual TimeSpan AutoPruneDelay => TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Adds the specified <see cref="IEventSubscription"/> to the subscribers' collection.
@@ -45,10 +54,12 @@ namespace Prism.Events
 
             lock (Subscriptions)
             {
-                Prune();
+                autoPrune();
                 Subscriptions.Add(eventSubscription);
             }
             return eventSubscription.SubscriptionToken;
+
+            async void autoPrune() => await PruneAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -97,26 +108,45 @@ namespace Prism.Events
             }
         }
 
-        private void Prune()
+        /// <summary>
+        /// Prunes Subscriptions list, throttled according to <see cref="AutoPruneDelay"/>.
+        /// </summary>
+        /// <returns>A task for when this operation is completed.</returns>
+        protected virtual async Task PruneAsync()
         {
-            lock (Subscriptions)
+            if (Interlocked.CompareExchange(ref _pruneGuard, 1, 0) == 1)
+                return;
+
+            try
             {
-                for (var i = Subscriptions.Count - 1; i >= 0; i--)
-                {
-                    if (_subscriptions[i].GetExecutionStrategy() == null)
-                    {
-                        _subscriptions.RemoveAt(i);
-                    }
-                }
-            }
+                await Task.Delay(AutoPruneDelay).ConfigureAwait(false);
+                PruneAndReturnStrategies();
+            } finally { Interlocked.Exchange(ref _pruneGuard, 0); }
         }
 
         private List<Action<object[]>> PruneAndReturnStrategies()
         {
-            lock (Subscriptions)
+            lock (_subscriptions)
             {
-                Prune();
-                return _subscriptions.Select(x => x.GetExecutionStrategy()).ToList();
+                return strategies().ToList();
+            }
+
+            IEnumerable<Action<object[]>> strategies()
+            {
+                LinkedListNode<IEventSubscription> node = _subscriptions.Last;
+                while (node != null)
+                {
+                    var previous = node.Previous;
+                    IEventSubscription sub = node.Value;
+                    Action<object[]> listItem =  sub?.GetExecutionStrategy();
+
+                    if (listItem != null)
+                        yield return listItem;
+                    else
+                        _subscriptions.Remove(node);
+
+                    node = previous;
+                }
             }
         }
     }


### PR DESCRIPTION
﻿### Description of Change ###

A previous fix carried with it O(n<sup>2</sup>) performance on event subscriptions. This aims to undo that, without losing the memory cleanup that fix enabled. (While `EventBase` maintains weak references, the array of the event subscriptions themselves would grow without bound unless `Publish` is called.)

### Bugs Fixed ###

- https://github.com/PrismLibrary/Prism/issues/1505

### API Changes ###

Added:
 - protected virtual TimeSpan AutoPruneDelay { get; }
 - protected virtual Task EventBase.PruneAsync();

### Behavioral Changes ###

In general, this should behave transparently to a user. It is _possible_ that the delayed `PruneAsync` could run while the event is publishing or being subscribed to, but this shouldn't carry any behavioral difference over the existing code, which locks on `Subscriptions`.

### PR Checklist ###
(will get to this tomorrow, but wanted to get this thought out and share for discussion)
- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard