### PR TITLE
Fix typo in documentation of DelegateCommand<T>

### DIFF
--- a/Source/Prism/Commands/DelegateCommand{T}.cs
+++ b/Source/Prism/Commands/DelegateCommand{T}.cs
@@ -50,7 +50,7 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="executeMethod">Delegate to execute when Execute is called on the command. This can be null to just hook up a CanExecute delegate.</param>
         /// <param name="canExecuteMethod">Delegate to execute when CanExecute is called on the command. This can be null.</param>
-        /// <exception cref="ArgumentNullException">When both <paramref name="executeMethod"/> and <paramref name="canExecuteMethod"/> ar <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">When both <paramref name="executeMethod"/> and <paramref name="canExecuteMethod"/> are <see langword="null" />.</exception>
         public DelegateCommand(Action<T> executeMethod, Func<T, bool> canExecuteMethod)
             : base()
         {


### PR DESCRIPTION
Just fixed a small typo.

Before:
`When both executeMethod and canExecuteMethod ar null.`

After:
`When both executeMethod and canExecuteMethod are null.`