### PR TITLE
Expand IoC abstractions

### DIFF
--- a/Source/Prism/Ioc/IContainerProvider.cs
+++ b/Source/Prism/Ioc/IContainerProvider.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Prism.Ioc
 {
     public interface IContainerProvider
     {
         object Resolve(Type type);
+
+        object Resolve(Type type, IDictionary<Type, object> parameters);
 
         object Resolve(Type type, string name);
     }

--- a/Source/Prism/Ioc/IContainerProviderExtensions.cs
+++ b/Source/Prism/Ioc/IContainerProviderExtensions.cs
@@ -1,10 +1,18 @@
-﻿namespace Prism.Ioc
+﻿using System;
+using System.Collections.Generic;
+
+namespace Prism.Ioc
 {
     public static class IContainerProviderExtensions
     {
         public static T Resolve<T>(this IContainerProvider provider)
         {
             return (T)provider.Resolve(typeof(T));
+        }
+
+        public static T Resolve<T>(this IContainerProvider provider, IDictionary<Type, object> parameters)
+        {
+            return (T)provider.Resolve(typeof(T), parameters);
         }
 
         public static T Resolve<T>(this IContainerProvider provider, string name)

--- a/Source/Prism/Ioc/IContainerRegistry.cs
+++ b/Source/Prism/Ioc/IContainerRegistry.cs
@@ -11,5 +11,11 @@ namespace Prism.Ioc
         void Register(Type from, Type to);
 
         void Register(Type from, Type to, string name);
+
+        void RegisterMany(Type implementingType);
+
+        bool IsRegistered(Type type);
+
+        bool IsRegistered(Type type, string name);
     }
 }

--- a/Source/Prism/Ioc/IContainerRegistry.cs
+++ b/Source/Prism/Ioc/IContainerRegistry.cs
@@ -6,7 +6,11 @@ namespace Prism.Ioc
     {
         void RegisterInstance(Type type, object instance);
 
+        void RegisterInstance(Type type, object instance, string name);
+
         void RegisterSingleton(Type from, Type to);
+
+        void RegisterSingleton(Type from, Type to, string name);
 
         void Register(Type from, Type to);
 

--- a/Source/Prism/Ioc/IContainerRegistryExtensions.cs
+++ b/Source/Prism/Ioc/IContainerRegistryExtensions.cs
@@ -9,6 +9,11 @@ namespace Prism.Ioc
             containerRegistry.RegisterInstance(typeof(TInterface), instance);
         }
 
+        public static void RegisterInstance<TInterface>(this IContainerRegistry containerRegistry, TInterface instance, string name)
+        {
+            containerRegistry.RegisterInstance(typeof(TInterface), instance, name);
+        }
+
         public static void RegisterSingleton(this IContainerRegistry containerRegistry, Type type)
         {
             containerRegistry.RegisterSingleton(type, type);
@@ -17,6 +22,11 @@ namespace Prism.Ioc
         public static void RegisterSingleton<TFrom, TTo>(this IContainerRegistry containerRegistry) where TTo : TFrom
         {
             containerRegistry.RegisterSingleton(typeof(TFrom), typeof(TTo));
+        }
+
+        public static void RegisterSingleton<TFrom, TTo>(this IContainerRegistry containerRegistry, string name) where TTo : TFrom
+        {
+            containerRegistry.RegisterSingleton(typeof(TFrom), typeof(TTo), name);
         }
 
         public static void RegisterSingleton<T>(this IContainerRegistry containerRegistry)

--- a/Source/Prism/Ioc/IContainerRegistryExtensions.cs
+++ b/Source/Prism/Ioc/IContainerRegistryExtensions.cs
@@ -53,5 +53,20 @@ namespace Prism.Ioc
         {
             containerRegistry.Register(typeof(TFrom), typeof(TTo), name);
         }
+
+        public static void RegisterMany<T>(this IContainerRegistry containerRegistry)
+        {
+            containerRegistry.RegisterMany(typeof(T));
+        }
+
+        public static bool IsRegistered<T>(this IContainerRegistry containerRegistry)
+        {
+            return containerRegistry.IsRegistered(typeof(T));
+        }
+
+        public static bool IsRegistered<T>(this IContainerRegistry containerRegistry, string name)
+        {
+            return containerRegistry.IsRegistered(typeof(T), name);
+        }
     }
 }

--- a/Source/Windows10/Prism.DryIoc.Windows/DryIocContainerExtension.cs
+++ b/Source/Windows10/Prism.DryIoc.Windows/DryIocContainerExtension.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using DryIoc;
 using Prism.Ioc;
 using Prism.Navigation;
@@ -57,6 +59,26 @@ namespace Prism.DryIoc
                 return Instance.Resolve(viewModelType, new[] { service });
             }
             return Instance.Resolve(viewModelType);
+        }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            return Instance.Resolve(type, args: parameters.Select(p => p.Value).ToArray());
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            Instance.RegisterMany(new Type[] { implementingType }, Reuse.Singleton, serviceTypeCondition: t => implementingType.ImplementsServiceType(t));
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            return Instance.IsRegistered(type);
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            return Instance.IsRegistered(type, name);
         }
     }
 }

--- a/Source/Windows10/Prism.DryIoc.Windows/DryIocContainerExtension.cs
+++ b/Source/Windows10/Prism.DryIoc.Windows/DryIocContainerExtension.cs
@@ -26,9 +26,19 @@ namespace Prism.DryIoc
             Instance.UseInstance(type, instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.UseInstance(type, instance, serviceKey: name);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.Register(from, to, Reuse.Singleton);
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.Register(from, to, Reuse.Singleton, serviceKey: name);
         }
 
         public void Register(Type from, Type to)

--- a/Source/Windows10/Prism.Unity.Windows/UnityContainerExtension.cs
+++ b/Source/Windows10/Prism.Unity.Windows/UnityContainerExtension.cs
@@ -26,9 +26,19 @@ namespace Prism.Unity
             Instance.RegisterInstance(type, instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.RegisterInstance(type, name, instance);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.RegisterSingleton(from, to);
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.RegisterSingleton(from, to, name);
         }
 
         public void Register(Type from, Type to)

--- a/Source/Windows10/Prism.Unity.Windows/UnityContainerExtension.cs
+++ b/Source/Windows10/Prism.Unity.Windows/UnityContainerExtension.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Prism.Ioc;
 using Prism.Navigation;
 using Unity;
+using Unity.Injection;
 using Unity.Resolution;
 using Windows.UI.Xaml.Controls;
 
@@ -67,6 +71,31 @@ namespace Prism.Unity
             {
                 return Instance.Resolve(viewModelType);
             }
+        }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            var overrides = parameters.Select(p => new DependencyOverride(p.Key, p.Value)).ToArray();
+            return Instance.Resolve(type, overrides);
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            Instance.RegisterSingleton(implementingType);
+            foreach (var serviceType in implementingType.GetInterfaces())
+            {
+                Instance.RegisterType(serviceType, new InjectionFactory(x => x.Resolve(implementingType)));
+            }
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            return Instance.IsRegistered(type);
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            return Instance.IsRegistered(type, name);
         }
     }
 }

--- a/Source/Wpf/Prism.DryIoc.Wpf/Ioc/DryIocContainerExtension.cs
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Ioc/DryIocContainerExtension.cs
@@ -24,9 +24,19 @@ namespace Prism.DryIoc.Ioc
             Instance.UseInstance(type, instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.UseInstance(type, instance, serviceKey: name);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.Register(from, to, Reuse.Singleton);
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.Register(from, to, Reuse.Singleton, serviceKey: name);
         }
 
         public void Register(Type from, Type to)

--- a/Source/Wpf/Prism.DryIoc.Wpf/Ioc/DryIocContainerExtension.cs
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Ioc/DryIocContainerExtension.cs
@@ -1,6 +1,8 @@
-﻿using DryIoc;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DryIoc;
 using Prism.Ioc;
-using System;
 
 namespace Prism.DryIoc.Ioc
 {
@@ -50,6 +52,26 @@ namespace Prism.DryIoc.Ioc
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
             return Instance.Resolve(viewModelType);
+        }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            return Instance.Resolve(type, args: parameters.Select(p => p.Value).ToArray());
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            Instance.RegisterMany(new Type[] { implementingType }, Reuse.Singleton, serviceTypeCondition: t => implementingType.ImplementsServiceType(t));
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            return Instance.IsRegistered(type);
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            return Instance.IsRegistered(type, name);
         }
     }
 }

--- a/Source/Wpf/Prism.Ninject.Wpf/Ioc/NinjectContainerExtension.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/Ioc/NinjectContainerExtension.cs
@@ -1,6 +1,9 @@
 ﻿using Ninject;
+using Ninject.Parameters;
 using Prism.Ioc;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Prism.Ninject.Ioc
 {
@@ -53,6 +56,27 @@ namespace Prism.Ninject.Ioc
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
             return Instance.Get(viewModelType);
+        }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            var overrides = parameters.Select(p => new TypeMatchingConstructorArgument(p.Key, (c,t) => p.Value)).ToArray();
+            return Instance.Get(type, overrides);
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            Instance.Bind(implementingType.GetInterfaces().ToArray()).To(implementingType).InSingletonScope();
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            return IsRegistered(type);
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            return Instance.IsRegistered(type);
         }
     }
 }

--- a/Source/Wpf/Prism.Ninject.Wpf/Ioc/NinjectContainerExtension.cs
+++ b/Source/Wpf/Prism.Ninject.Wpf/Ioc/NinjectContainerExtension.cs
@@ -28,9 +28,19 @@ namespace Prism.Ninject.Ioc
             Instance.Bind(type).ToConstant(instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.Bind(type).ToConstant(instance).Named(name);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.Bind(from).To(to).InSingletonScope();
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.Bind(from).To(to).InSingletonScope().Named(name);
         }
 
         public void Register(Type from, Type to)

--- a/Source/Wpf/Prism.Unity.Wpf/Ioc/UnityContainerExtension.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/Ioc/UnityContainerExtension.cs
@@ -25,9 +25,19 @@ namespace Prism.Unity.Ioc
             Instance.RegisterInstance(type, instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.RegisterInstance(type, name, instance);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.RegisterSingleton(from, to);
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.RegisterSingleton(from, to, name);
         }
 
         public void Register(Type from, Type to)

--- a/Source/Wpf/Prism.Unity.Wpf/Ioc/UnityContainerExtension.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/Ioc/UnityContainerExtension.cs
@@ -1,6 +1,10 @@
-﻿using Prism.Ioc;
-using System;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Prism.Ioc;
 using Unity;
+using Unity.Injection;
+using Unity.Resolution;
 
 namespace Prism.Unity.Ioc
 {
@@ -49,6 +53,31 @@ namespace Prism.Unity.Ioc
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
             return Instance.Resolve(viewModelType);
+        }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            var overrides = parameters.Select(p => new DependencyOverride(p.Key, p.Value)).ToArray();
+            return Instance.Resolve(type, overrides);
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            Instance.RegisterSingleton(implementingType);
+            foreach (var serviceType in implementingType.GetInterfaces())
+            {
+                Instance.RegisterType(serviceType, new InjectionFactory(x => x.Resolve(implementingType)));
+            }
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            return Instance.IsRegistered(type);
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            return Instance.IsRegistered(type, name);
         }
     }
 }

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
@@ -40,12 +40,22 @@ namespace Prism.Wpf.Tests.Mocks
             throw new NotImplementedException();
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RegisterMany(Type implementingType)
         {
             throw new NotImplementedException();
         }
 
         public void RegisterSingleton(Type from, Type to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
         {
             throw new NotImplementedException();
         }

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
@@ -15,6 +15,16 @@ namespace Prism.Wpf.Tests.Mocks
             
         }
 
+        public bool IsRegistered(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            throw new NotImplementedException();
+        }
+
         public void Register(Type from, Type to)
         {
             throw new NotImplementedException();
@@ -26,6 +36,11 @@ namespace Prism.Wpf.Tests.Mocks
         }
 
         public void RegisterInstance(Type type, object instance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RegisterMany(Type implementingType)
         {
             throw new NotImplementedException();
         }

--- a/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Mocks/MockContainerAdapter.cs
@@ -81,6 +81,11 @@ namespace Prism.Wpf.Tests.Mocks
             throw new NotImplementedException();
         }
 
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            throw new NotImplementedException();
+        }
+
         public object ResolveViewModelForView(object view, Type viewModelType)
         {
             throw new NotImplementedException();

--- a/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
+++ b/Source/Xamarin/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
@@ -28,12 +28,8 @@ using Xamarin.Forms;
 using Xunit;
 using Xunit.Abstractions;
 
-#if Autofac
-namespace Prism.Autofac.Forms.Tests.Fixtures
-#elif DryIoc
+#if DryIoc
 namespace Prism.DryIoc.Forms.Tests.Fixtures
-#elif Ninject
-namespace Prism.Ninject.Forms.Tests.Fixtures
 #elif Unity
 namespace Prism.Unity.Forms.Tests.Fixtures
 #endif
@@ -294,8 +290,6 @@ namespace Prism.Unity.Forms.Tests.Fixtures
             Assert.IsType<XamlViewMockA>(navigationPage.RootPage);
             Assert.IsType<XamlViewMockA>(navigationPage.CurrentPage);
         }
-
-        
 
         private static INavigationService ResolveAndSetRootPage(PrismApplicationMock app)
         {

--- a/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
@@ -26,9 +26,19 @@ namespace Prism.DryIoc
             Instance.UseInstance(type, instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.UseInstance(type, instance, serviceKey: name);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.Register(from, to, Reuse.Singleton);
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.Register(from, to, Reuse.Singleton, serviceKey: name);
         }
 
         public void Register(Type from, Type to)

--- a/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/DryIocContainerExtension.cs
@@ -1,8 +1,10 @@
-﻿using Prism.Ioc;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using DryIoc;
-using System;
-using Xamarin.Forms;
+using Prism.Ioc;
 using Prism.Mvvm;
+using Xamarin.Forms;
 
 namespace Prism.DryIoc
 {
@@ -49,7 +51,7 @@ namespace Prism.DryIoc
             return Instance.Resolve(type, serviceKey: name);
         }
 
-        public object ResolveViewModelForView(object view, Type viewModelType)
+        public virtual object ResolveViewModelForView(object view, Type viewModelType)
         {
             switch (view)
             {
@@ -57,8 +59,7 @@ namespace Prism.DryIoc
                     var getVM = Instance.Resolve<Func<Page, object>>(viewModelType);
                     return getVM(page);
                 case BindableObject bindable:
-                    var attachedPage = bindable.GetValue(ViewModelLocator.AutowirePartialViewProperty) as Page;
-                    if (attachedPage != null)
+                    if (bindable.GetValue(ViewModelLocator.AutowirePartialViewProperty) is Page attachedPage)
                     {
                         var getVMForPartial = Instance.Resolve<Func<Page, object>>(viewModelType);
                         return getVMForPartial(attachedPage);
@@ -67,6 +68,26 @@ namespace Prism.DryIoc
             }
 
             return Instance.Resolve(viewModelType);
+        }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            return Instance.Resolve(type, args: parameters.Select(p => p.Value).ToArray());
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            Instance.RegisterMany(new Type[] { implementingType }, Reuse.Singleton, serviceTypeCondition: t => implementingType.ImplementsServiceType(t));
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            return Instance.IsRegistered(type);
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            return Instance.IsRegistered(type, name);
         }
     }
 }

--- a/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid71</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid80</TargetFrameworks>
     <Title>DryIoc for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>DryIoc extensions for Prism for Xamarin.Forms.</Summary>-->

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationContainerMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationContainerMock.cs
@@ -110,5 +110,15 @@ namespace Prism.Forms.Tests.Mocks
         {
             throw new NotImplementedException();
         }
+
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationContainerMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/PageNavigationContainerMock.cs
@@ -90,5 +90,25 @@ namespace Prism.Forms.Tests.Mocks
         {
             throw new NotImplementedException();
         }
+
+        public object Resolve(Type type, IDictionary<Type, object> parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RegisterMany(Type implementingType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid71</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;MonoAndroid80</TargetFrameworks>
     <Title>Unity for Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Unity extensions for Prism for Xamarin.Forms.</Summary>-->

--- a/Source/Xamarin/Prism.Unity.Forms/UnityContainerExtension.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/UnityContainerExtension.cs
@@ -26,9 +26,19 @@ namespace Prism.Unity
             Instance.RegisterInstance(type, instance);
         }
 
+        public void RegisterInstance(Type type, object instance, string name)
+        {
+            Instance.RegisterInstance(type, name, instance);
+        }
+
         public void RegisterSingleton(Type from, Type to)
         {
             Instance.RegisterSingleton(from, to);
+        }
+
+        public void RegisterSingleton(Type from, Type to, string name)
+        {
+            Instance.RegisterSingleton(from, to, name);
         }
 
         public void Register(Type from, Type to)


### PR DESCRIPTION
﻿### Description of Change ###

Expanding IContainerProvider to allow resolving with specified instances. This will be helpful in UWP as well as in Prism.Forms for resolving Renderers with parameters specified by Xamarin.Forms.

Expanding IContainerRegistry to allow Instances and Singletons to be named instances. Adding new API's to allow checking if a service is currently registered, and to register a concrete type for all implemented interfaces. 

### API Changes ###

Added:
 - void IContainerRegistry.RegisterInstance(Type type, object instance, string name);
 - void IContainerRegistry.RegisterSingleton(Type from, Type to, string name);
 - void IContainerRegistry.RegisterMany(Type implementingType);
 - bool IContainerRegistry.IsRegistered(Type type);
 - bool IContainerRegistry.IsRegistered(Type type, string name);
 - object IContainerProvider.Resolve(Type type, IDictionary<Type, object> parameters);

also added generic equivalent for each API

### Behavioral Changes ###

n/a

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard