### PR TITLE
API Enhancements

### DIFF
--- a/Source/Windows10/Prism.Windows/Navigation/INavigationServiceExtensions.cs
+++ b/Source/Windows10/Prism.Windows/Navigation/INavigationServiceExtensions.cs
@@ -53,5 +53,30 @@ namespace Prism.Navigation
 
         public static Task<INavigationResult> NavigateAsync(this INavigationService service, Uri path, INavigationParameters parameter, NavigationTransitionInfo infoOverride)
             => (service as IPlatformNavigationService).NavigateAsync(path, parameter, infoOverride);
+
+        public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService, params (string Key, object Value)[] parameters)
+        {
+            return navigationService.GoBackAsync(GetNavigationParameters(parameters));
+        }
+
+        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, params (string Key, object Value)[] parameters)
+        {
+            return navigationService.NavigateAsync(name, GetNavigationParameters(parameters));
+        }
+
+        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri, params (string Key, object Value)[] parameters)
+        {
+            return navigationService.NavigateAsync(uri, GetNavigationParameters(parameters));
+        }
+
+        private static INavigationParameters GetNavigationParameters((string Key, object Value)[] parameters)
+        {
+            var navParams = new NavigationParameters();
+            foreach (var (Key, Value) in parameters)
+            {
+                navParams.Add(Key, Value);
+            }
+            return navParams;
+        }
     }
 }

--- a/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
@@ -18,6 +18,22 @@ namespace Prism.Forms.Tests.Services
         }
 
         [Fact]
+        public void CancelActionSheetButton_WithNoAction_DoNotThrowException()
+        {
+            var cancel = ActionSheetButton.CreateCancelButton("Foo");
+            var ex = Record.Exception(() => cancel.PressButton());
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void DestroyActionSheetButton_WithNoAction_DoNotThrowException()
+        {
+            var destroy = ActionSheetButton.CreateDestroyButton("Foo");
+            var ex = Record.Exception(() => destroy.PressButton());
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public async Task DisplayActionSheetNoButtons_ShouldThrowException()
         {
             var service = new PageDialogServiceMock("cancel", _applicationProvider);

--- a/Source/Xamarin/Prism.Forms/Navigation/INavigationServiceExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/INavigationServiceExtensions.cs
@@ -16,7 +16,7 @@ namespace Prism.Navigation
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
         public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService, INavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             return ((IPlatformNavigationService)navigationService).GoBackAsync(parameters, useModalNavigation, animated);
@@ -27,6 +27,7 @@ namespace Prism.Navigation
         /// </summary>
         /// <param name="navigationService">The INavigatinService instance</param>
         /// <param name="parameters">The navigation parameters</param>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
         /// <remarks>Only works when called from a View within a NavigationPage</remarks>
         public static Task<INavigationResult> GoBackToRootAsync(this INavigationService navigationService, INavigationParameters parameters = null)
         {
@@ -40,6 +41,7 @@ namespace Prism.Navigation
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PushModalAsync, if <c>false</c> uses PushAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
         public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, INavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
             return ((IPlatformNavigationService)navigationService).NavigateAsync(name, parameters, useModalNavigation, animated);
@@ -52,9 +54,10 @@ namespace Prism.Navigation
         /// <param name="parameters">The navigation parameters</param>
         /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
         /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
         /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
         /// <example>
-        /// Navigate(new Uri("MainPage?id=3&name=brian", UriKind.RelativeSource), parameters);
+        /// NavigateAsync(new Uri("MainPage?id=3&name=brian", UriKind.RelativeSource), parameters);
         /// </example>
         public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri, INavigationParameters parameters = null, bool? useModalNavigation = null, bool animated = true)
         {
@@ -81,10 +84,59 @@ namespace Prism.Navigation
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+        /// </summary>
+        /// <param name="parameters">The navigation parameters</param>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+        public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService, params (string Key, object Value)[] parameters)
+        {
+            return navigationService.GoBackAsync(GetNavigationParameters(parameters));
+        }
+
+        /// <summary>
+        /// Initiates navigation to the target specified by the <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The Uri to navigate to</param>
+        /// <param name="parameters">The navigation parameters</param>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+        /// <example>
+        /// NavigateAsync("MainPage?id=3&name=dan", ("person", person), ("foo", bar));
+        /// </example>
+        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, params (string Key, object Value)[] parameters)
+        {
+            return navigationService.NavigateAsync(name, GetNavigationParameters(parameters));
+        }
+
+        /// <summary>
+        /// Initiates navigation to the target specified by the <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The Uri to navigate to</param>
+        /// <param name="parameters">The navigation parameters</param>
+        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+        /// <example>
+        /// NavigateAsync(new Uri("MainPage?id=3&name=dan", UriKind.RelativeSource), ("person", person), ("foo", bar));
+        /// </example>
+        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri, params (string Key, object Value)[] parameters)
+        {
+            return navigationService.NavigateAsync(uri, GetNavigationParameters(parameters));
+        }
+
+        private static INavigationParameters GetNavigationParameters((string Key, object Value)[] parameters)
+        {
+            var navParams = new NavigationParameters();
+            foreach(var (Key, Value) in parameters)
+            {
+                navParams.Add(Key, Value);
+            }
+            return navParams;
+        }
+
         private static void ProcessNavigationPath(Page page, Stack<string> stack)
         {
-            var parent = page.Parent as Page;
-            if (parent != null)
+            if (page.Parent is Page parent)
             {
                 if (parent is NavigationPage)
                 {
@@ -203,8 +255,7 @@ namespace Prism.Navigation
             var currentPageKeyInfo = PageNavigationRegistry.GetPageNavigationInfo(page.GetType());
             string currentSegment = $"{currentPageKeyInfo.Name}";
 
-            var parent = page.Parent as Page;
-            if (parent != null)
+            if (page.Parent is Page parent)
             {
                 var parentKeyInfo = PageNavigationRegistry.GetPageNavigationInfo(parent.GetType());
 

--- a/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButton.cs
+++ b/Source/Xamarin/Prism.Forms/Services/PageDialogService/ActionSheetButton.cs
@@ -47,6 +47,13 @@ namespace Prism.Services
         /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
         /// </summary>
         /// <param name="text">Button text</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateCancelButton(string text) => CreateCancelButton(text, default(Action));
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+        /// </summary>
+        /// <param name="text">Button text</param>
         /// <param name="action">Action to execute when button pressed</param>
         /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
         public static IActionSheetButton CreateCancelButton(string text, Action action)
@@ -92,6 +99,13 @@ namespace Prism.Services
         {
             return CreateButtonInternal(text, null, isDestroy: true, command: command);
         }
+
+        /// <summary>
+        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+        /// </summary>
+        /// <param name="text">Button text</param>
+        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+        public static IActionSheetButton CreateDestroyButton(string text) => CreateDestroyButton(text, default(Action));
 
         /// <summary>
         /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"


### PR DESCRIPTION
﻿### Description of Change ###

The included changes provide a little syntactic sugar to the existing APIs 

### Bugs Fixed ###

n/a

### API Changes ###

ActionSheetButton - eliminate the requirement to pass in either an Action or Command for Cancel/Destroy buttons where the intent may simply be to dismiss the dialog.

Added:
 - static IActionSheetButton CreateCancelButton(string)
 - static IActionSheetButton CreateDestroyButton(string)

INavigationService - now that we're making use of Tuples across the board with IContainerProvider, adding extension methods to allow simply passing in Tuples rather than having to explicitly create new NavigationParameters. Added for both Prism.Windows and Prism.Forms

- Task<INavigationResult> NavigateAsync(string, params (string, object)[])
- Task<INavigationResult> NavigateAsync(Uri, params (string, object)[])
- Task<INavigationResult> GoBackAsync(params (string, object)[])

### Behavioral Changes ###

none

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard