### PR TITLE
added support to control DialogWindow propertes from style

### DIFF
--- a/Sandbox/Wpf/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/App.xaml.cs
@@ -21,7 +21,7 @@ namespace HelloWorld
             containerRegistry.RegisterDialog<ConfirmationDialog, ConfirmationDialogViewModel>();
 
             //register a custom window host
-            containerRegistry.RegisterDialogWindow<CustomDialogWindow>();
+            //containerRegistry.RegisterDialogWindow<CustomDialogWindow>();
         }
     }
 }

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/ConfirmationDialog.xaml
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/ConfirmationDialog.xaml
@@ -4,6 +4,15 @@
              xmlns:prism="http://prismlibrary.com/"
              prism:ViewModelLocator.AutoWireViewModel="True"
              Width="300" Height="150">
+
+    <prism:DialogService.DialogWindowStyle>
+        <Style TargetType="Window">
+            <Setter Property="ResizeMode" Value="NoResize"/>
+            <Setter Property="ShowInTaskbar" Value="False"/>
+            <Setter Property="SizeToContent" Value="WidthAndHeight"/>
+        </Style>
+    </prism:DialogService.DialogWindowStyle>
+    
     <Grid x:Name="LayoutRoot" Margin="5">
         <Grid.RowDefinitions>
             <RowDefinition />

--- a/Source/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
@@ -9,6 +9,17 @@ namespace Prism.Ioc
         /// Registers an object to be used as a dialog in the IDialogService.
         /// </summary>
         /// <typeparam name="TView">The Type of object to register as the dialog</typeparam>
+        /// <param name="containerRegistry"></param>
+        /// <param name="name">The unique name to register with the dialog.</param>
+        public static void RegisterDialog<TView>(this IContainerRegistry containerRegistry, string name = null)
+        {
+            containerRegistry.RegisterForNavigation<TView>(name);
+        }
+
+        /// <summary>
+        /// Registers an object to be used as a dialog in the IDialogService.
+        /// </summary>
+        /// <typeparam name="TView">The Type of object to register as the dialog</typeparam>
         /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the dialog</typeparam>
         /// <param name="containerRegistry"></param>
         /// <param name="name">The unique name to register with the dialog.</param>

--- a/Source/Wpf/Prism.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.Wpf/Properties/AssemblyInfo.cs
@@ -23,5 +23,6 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Mvvm")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Interactivity")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Interactivity.InteractionRequest")]
+[assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Services.Dialogs")]
 
 

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DefaultDialogs/DialogWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DefaultDialogs/DialogWindow.xaml
@@ -2,6 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="{Binding Title}" Icon="{Binding IconSource}"
-        WindowStartupLocation="CenterOwner" SizeToContent="WidthAndHeight">
-    
+        WindowStartupLocation="CenterOwner">
+    <Window.Style>
+        <Style TargetType="{x:Type Window}" >
+            <Setter Property="SizeToContent" Value="WidthAndHeight" />
+        </Style>
+    </Window.Style>
+
 </Window>

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogWindow.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogWindow.cs
@@ -25,5 +25,7 @@ namespace Prism.Services.Dialogs
         event CancelEventHandler Closing;
 
         IDialogResult Result { get; set; }
+
+        Style Style { get; set; }
     }
 }


### PR DESCRIPTION
﻿### Description of Change ###

You can now control the properties of the DialogWindow by using a style via an attaxched property on the Dialog UserControl

```
    <prism:DialogService.DialogWindowStyle>
        <Style TargetType="Window">
            <Setter Property="ResizeMode" Value="NoResize"/>
            <Setter Property="ShowInTaskbar" Value="False"/>
            <Setter Property="SizeToContent" Value="WidthAndHeight"/>
        </Style>
    </prism:DialogService.DialogWindowStyle>
```

_NOTE_ I'm not real happy with the location of the attached property and it may be moved to a different class.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - DialogService.DialogWindowStyle attached property
 - Added IDialogWindow.Style property

### PR Checklist ###

- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard