### PR TITLE
IDialogService updates, Used P/Invoke to get active window + Created attached property for WindowStartupLocation

### DIFF
--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/ConfirmationDialog.xaml
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/ConfirmationDialog.xaml
@@ -7,6 +7,7 @@
 
     <prism:DialogService.DialogWindowStyle>
         <Style TargetType="Window">
+            <Setter Property="prism:WindowStartupLocationBehavior.WindowStartupLocation" Value="CenterOwner"/>
             <Setter Property="ResizeMode" Value="NoResize"/>
             <Setter Property="ShowInTaskbar" Value="False"/>
             <Setter Property="SizeToContent" Value="WidthAndHeight"/>

--- a/Source/Wpf/Prism.Wpf/Common/WindowStartupLocationBehavior.cs
+++ b/Source/Wpf/Prism.Wpf/Common/WindowStartupLocationBehavior.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows;
+
+namespace Prism.Common
+{
+    public static class WindowStartupLocationBehavior
+    {
+        public static readonly DependencyProperty WindowStartupLocationProperty;
+
+        public static WindowStartupLocation GetWindowStartupLocation(DependencyObject obj)
+        {
+            return (WindowStartupLocation)obj.GetValue(WindowStartupLocationProperty);
+        }
+
+        public static void SetWindowStartupLocation(DependencyObject obj, WindowStartupLocation value)
+        {
+            obj.SetValue(WindowStartupLocationProperty, value);
+        }
+
+        static WindowStartupLocationBehavior()
+        {
+            WindowStartupLocationProperty = DependencyProperty.RegisterAttached("WindowStartupLocation", typeof(WindowStartupLocation), typeof(WindowStartupLocationBehavior), new UIPropertyMetadata(WindowStartupLocation.CenterOwner, OnWindowStartupLocationChanged));
+        }
+
+        private static void OnWindowStartupLocationChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is Window window)
+                window.WindowStartupLocation = GetWindowStartupLocation(window);
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Extensions/ApplicationExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Extensions/ApplicationExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Prism.Extensions
+{
+    public static class ApplicationExtensions
+    {
+        [DllImport("user32.dll")]
+        static extern IntPtr GetActiveWindow();
+
+        public static Window GetActiveWindow(this Application application)
+        {
+            return application.Windows.OfType<Window>().SingleOrDefault(window => new WindowInteropHelper(window).Handle == GetActiveWindow());
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Properties/AssemblyInfo.cs
+++ b/Source/Wpf/Prism.Wpf/Properties/AssemblyInfo.cs
@@ -24,5 +24,6 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Interactivity")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Interactivity.InteractionRequest")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Services.Dialogs")]
+[assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Common")]
 
 

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
@@ -4,6 +4,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
+using Prism.Extensions;
 
 namespace Prism.Services.Dialogs
 {
@@ -126,10 +127,14 @@ namespace Prism.Services.Dialogs
             window.Content = dialogContent;
             window.DataContext = viewModel; //we want the host window and the dialog to share the same data contex
 
-            //TODO: is there a better way to set the owner
-            window.Owner = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
+            window.Owner = Application.Current?.GetActiveWindow(); // Application may be null if IsInDesignMode.
 
-            //TODO: is the a good way to control the WindowStartupPosition (not a dependency property and can't be set in a style)
+            // We set windows's WindowStartupLocation CLR property by using the 
+            // WindowStartupLocationBehavior.WindowStartupLocationProperty attached property,
+            // which we set in DialogWindowStyle. 
+            // If owner is null, we user CenterScreen as fallback value.
+            if (window.Owner == null && window is Window win)
+                win.WindowStartupLocation = WindowStartupLocation.CenterScreen;
         }
     }
 }


### PR DESCRIPTION
﻿### Description of Change ###

I used the IDialogService for WPF and i faced the "issue" with the WindowStartupLocation. So this is my first pull request on github! 

Actually i completed two TODOs that @brianlagunas created with #1721. 

Firstly, i created an application extension that uses p/invoke in order to get the active Application window and i made it public in order for everyone to have access and use it.

Also, you can now  control the WindowStartupLocation of the DialogWindow by using the  WindowStartupLocationBehavior.WindowStartupLocation attached property inside DialogWindowStyle.

```
 <prism:DialogService.DialogWindowStyle>
    <Style TargetType="Window">
        <Setter Property="prism:WindowStartupLocationBehavior.WindowStartupLocation" Value="CenterOwner"/>
    </Style>
</prism:DialogService.DialogWindowStyle>
```

### API Changes ###

Added:
 * WindowStartupLocationBehavior.WindowStartupLocation attached property
 * Application.GetActiveWindow() extension

### Behavioral Changes ###

From now on WindowStartupLocation property of IDialogWindow will have CenterScreen fallback value if IDialogWindow.Owner is null. (Previously value was CenterOwner)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard