### PR TITLE
Refactored DialogWindow attached properties

### DIFF
--- a/Sandbox/Wpf/HelloWorld/HelloWorld.sln
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorld", "HelloWorld\HelloWorld.csproj", "{B03C14CC-8DE9-40EE-9562-12B976E4CEE8}"
 EndProject
@@ -10,8 +10,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Prism Library", "Prism Library", "{15CF1FE1-D78E-4E3D-A9F8-FA0FCC56A83A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Wpf", "..\..\..\Source\Wpf\Prism.Wpf\Prism.Wpf.csproj", "{AA8ED3D6-A708-4187-8FAC-00F56E063AD7}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Ninject.Wpf", "..\..\..\Source\Wpf\Prism.Ninject.Wpf\Prism.Ninject.Wpf.csproj", "{5263604A-39EC-4E7B-82DD-8F52C838A77A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Wpf", "..\..\..\Source\Wpf\Prism.DryIoc.Wpf\Prism.DryIoc.Wpf.csproj", "{A0842858-BFD5-41AE-BDE7-CBD870BC9900}"
 EndProject
@@ -35,10 +33,6 @@ Global
 		{AA8ED3D6-A708-4187-8FAC-00F56E063AD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA8ED3D6-A708-4187-8FAC-00F56E063AD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA8ED3D6-A708-4187-8FAC-00F56E063AD7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5263604A-39EC-4E7B-82DD-8F52C838A77A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5263604A-39EC-4E7B-82DD-8F52C838A77A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5263604A-39EC-4E7B-82DD-8F52C838A77A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5263604A-39EC-4E7B-82DD-8F52C838A77A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A0842858-BFD5-41AE-BDE7-CBD870BC9900}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A0842858-BFD5-41AE-BDE7-CBD870BC9900}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0842858-BFD5-41AE-BDE7-CBD870BC9900}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -54,7 +48,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{457AA668-72BB-4701-9A4E-FA86B0C412DE} = {15CF1FE1-D78E-4E3D-A9F8-FA0FCC56A83A}
 		{AA8ED3D6-A708-4187-8FAC-00F56E063AD7} = {15CF1FE1-D78E-4E3D-A9F8-FA0FCC56A83A}
-		{5263604A-39EC-4E7B-82DD-8F52C838A77A} = {15CF1FE1-D78E-4E3D-A9F8-FA0FCC56A83A}
 		{A0842858-BFD5-41AE-BDE7-CBD870BC9900} = {15CF1FE1-D78E-4E3D-A9F8-FA0FCC56A83A}
 		{DEBADAAB-5C78-444E-AA77-336A43B49EC3} = {15CF1FE1-D78E-4E3D-A9F8-FA0FCC56A83A}
 	EndGlobalSection

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/ConfirmationDialog.xaml
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/ConfirmationDialog.xaml
@@ -5,14 +5,15 @@
              prism:ViewModelLocator.AutoWireViewModel="True"
              Width="300" Height="150">
 
-    <prism:DialogService.DialogWindowStyle>
+    <prism:Dialog.WindowStyle>
         <Style TargetType="Window">
+            <Setter Property="prism:Dialog.WindowStartupLocation" Value="CenterScreen" />
             <Setter Property="ResizeMode" Value="NoResize"/>
             <Setter Property="ShowInTaskbar" Value="False"/>
             <Setter Property="SizeToContent" Value="WidthAndHeight"/>
         </Style>
-    </prism:DialogService.DialogWindowStyle>
-    
+    </prism:Dialog.WindowStyle>
+
     <Grid x:Name="LayoutRoot" Margin="5">
         <Grid.RowDefinitions>
             <RowDefinition />

--- a/Source/Wpf/Prism.DryIoc.Wpf/Legacy/DryIocBootstrapper.cs
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Legacy/DryIocBootstrapper.cs
@@ -154,7 +154,7 @@ namespace Prism.DryIoc
             if (_useDefaultConfiguration)
             {
                 RegisterTypeIfMissing<IDialogService, DialogService>(true);
-                RegisterTypeIfMissing<IDialogWindow, Services.Dialogs.DefaultDialogs.DialogWindow>(false);
+                RegisterTypeIfMissing<IDialogWindow, DialogWindow>(false);
 
                 RegisterTypeIfMissing<IModuleInitializer, ModuleInitializer>(true);
                 RegisterTypeIfMissing<IModuleManager, ModuleManager>(true);

--- a/Source/Wpf/Prism.Unity.Wpf/Legacy/UnityBootstrapper.cs
+++ b/Source/Wpf/Prism.Unity.Wpf/Legacy/UnityBootstrapper.cs
@@ -150,7 +150,7 @@ namespace Prism.Unity
             if (useDefaultConfiguration)
             {
                 RegisterTypeIfMissing(typeof(IDialogService), typeof(DialogService), true);
-                RegisterTypeIfMissing(typeof(IDialogWindow), typeof(Services.Dialogs.DefaultDialogs.DialogWindow), false);
+                RegisterTypeIfMissing(typeof(IDialogWindow), typeof(DialogWindow), false);
 
                 RegisterTypeIfMissing(typeof(IServiceLocator), typeof(UnityServiceLocatorAdapter), true);
                 RegisterTypeIfMissing(typeof(IModuleInitializer), typeof(ModuleInitializer), true);

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -15,6 +15,10 @@ Prism.Wpf helps you more easily design and build rich, flexible, and easy to mai
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Services\Dialogs\DialogWindow.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Condition=" '$(TargetFramework)' == 'net45' " Include="System.Configuration" />
     <Reference Include="System.Windows.Interactivity">
       <HintPath>..\System.Windows.Interactivity.dll</HintPath>

--- a/Source/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/Source/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -129,7 +129,7 @@ namespace Prism
             containerRegistry.Register<IRegionNavigationJournalEntry, RegionNavigationJournalEntry>();
             containerRegistry.Register<IRegionNavigationJournal, RegionNavigationJournal>();
             containerRegistry.Register<IRegionNavigationService, RegionNavigationService>();
-            containerRegistry.Register<IDialogWindow, Services.Dialogs.DefaultDialogs.DialogWindow>(); //default dialog host
+            containerRegistry.Register<IDialogWindow, DialogWindow>(); //default dialog host
         }
 
         /// <summary>

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/Dialog.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/Dialog.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Windows;
+
+namespace Prism.Services.Dialogs
+{
+    public class Dialog
+    {
+        public static readonly DependencyProperty WindowStyleProperty =
+            DependencyProperty.RegisterAttached("WindowStyle", typeof(Style), typeof(Dialog), new PropertyMetadata(null));
+
+        public static Style GetWindowStyle(DependencyObject obj)
+        {
+            return (Style)obj.GetValue(WindowStyleProperty);
+        }
+
+        public static void SetWindowStyle(DependencyObject obj, Style value)
+        {
+            obj.SetValue(WindowStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty WindowStartupLocationProperty =
+            DependencyProperty.RegisterAttached("WindowStartupLocation", typeof(WindowStartupLocation), typeof(Dialog), new UIPropertyMetadata(WindowStartupLocation.CenterOwner, OnWindowStartupLocationChanged));
+
+        public static WindowStartupLocation GetWindowStartupLocation(DependencyObject obj)
+        {
+            return (WindowStartupLocation)obj.GetValue(WindowStartupLocationProperty);
+        }
+
+        public static void SetWindowStartupLocation(DependencyObject obj, WindowStartupLocation value)
+        {
+            obj.SetValue(WindowStartupLocationProperty, value);
+        }
+
+        private static void OnWindowStartupLocationChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is Window window)
+                window.WindowStartupLocation = (WindowStartupLocation)e.NewValue;
+        }
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
@@ -11,19 +11,6 @@ namespace Prism.Services.Dialogs
     {
         private readonly IContainerExtension _containerExtension;
 
-        public static readonly DependencyProperty DialogWindowStyleProperty =
-            DependencyProperty.RegisterAttached("DialogWindowStyle", typeof(Style), typeof(DialogService), new PropertyMetadata(null));
-
-        public static Style GetDialogWindowStyle(DependencyObject obj)
-        {
-            return (Style)obj.GetValue(DialogWindowStyleProperty);
-        }
-
-        public static void SetDialogWindowStyle(DependencyObject obj, Style value)
-        {
-            obj.SetValue(DialogWindowStyleProperty, value);
-        }
-
         public DialogService(IContainerExtension containerExtension)
         {
             _containerExtension = containerExtension;
@@ -119,7 +106,7 @@ namespace Prism.Services.Dialogs
 
         void ConfigureDialogWindowProperties(IDialogWindow window, FrameworkElement dialogContent, IDialogAware viewModel)
         {
-            var windowStyle = DialogService.GetDialogWindowStyle(dialogContent);
+            var windowStyle = Dialog.GetWindowStyle(dialogContent);
             if (windowStyle != null)
                 window.Style = windowStyle;
 
@@ -128,8 +115,6 @@ namespace Prism.Services.Dialogs
 
             //TODO: is there a better way to set the owner
             window.Owner = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
-
-            //TODO: is the a good way to control the WindowStartupPosition (not a dependency property and can't be set in a style)
         }
     }
 }

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogWindow.xaml
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Prism.Services.Dialogs.DefaultDialogs.DialogWindow"
+﻿<Window x:Class="Prism.Services.Dialogs.DialogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="{Binding Title}"

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogWindow.xaml.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogWindow.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows;
 
-namespace Prism.Services.Dialogs.DefaultDialogs
+namespace Prism.Services.Dialogs
 {
     /// <summary>
     /// Interaction logic for DialogWindow.xaml


### PR DESCRIPTION
﻿### Description of Change ###

Renamed the DialogWindowStyle attached property and added a new WindowStartupLocation attached property in order to control the startup position of the dialog window.

### API Changes ###

Added:
 - Dialog.WindowStartupLocation

Changed:
 - DialogService.DialogWindowStyle => Dialog.WindowStyle

Example:
```
    <prism:Dialog.WindowStyle>
        <Style TargetType="Window">
            <Setter Property="prism:Dialog.WindowStartupLocation" Value="CenterScreen" />
            <Setter Property="ResizeMode" Value="NoResize"/>
            <Setter Property="ShowInTaskbar" Value="False"/>
            <Setter Property="SizeToContent" Value="WidthAndHeight"/>
        </Style>
    </prism:Dialog.WindowStyle>
```

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard