### PR TITLE
Automatic View Registration

### DIFF
--- a/Source/Xamarin/Prism.Forms/AppModel/RuntimePlatform.cs
+++ b/Source/Xamarin/Prism.Forms/AppModel/RuntimePlatform.cs
@@ -1,18 +1,18 @@
 ﻿namespace Prism.AppModel
 {
-	/// <summary>
-	/// Represents the Platform (OS) that the application is running on.
-	/// </summary>
-	/// <remarks>This enum acts as a wrapper around the Device.RuntimePlatform string-based options</remarks>
-	public enum RuntimePlatform
-	{
-		Android,
-		iOS,
-		macOS,
-		Tizen,
-		UWP,
-		WinPhone,
-		WinRT,
-		Unknown
-	}
+    /// <summary>
+    /// Represents the Platform (OS) that the application is running on.
+    /// </summary>
+    /// <remarks>This enum acts as a wrapper around the Device.RuntimePlatform string-based options</remarks>
+    public enum RuntimePlatform
+    {
+        Android,
+        iOS,
+        macOS,
+        Tizen,
+        UWP,
+        WinPhone,
+        WinRT,
+        Unknown
+    }
 }

--- a/Source/Xamarin/Prism.Forms/Ioc/AutoRegisterForNavigationAttribute.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/AutoRegisterForNavigationAttribute.cs
@@ -3,7 +3,7 @@
 namespace Prism.Ioc
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-    public class RegisterByConventionAttribute : Attribute
+    public class AutoRegisterForNavigationAttribute : Attribute
     {
         public bool Automatic { get; set; }
     }

--- a/Source/Xamarin/Prism.Forms/Ioc/RegisterByConventionAttribute.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/RegisterByConventionAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Prism.Ioc
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class RegisterByConventionAttribute : Attribute
+    {
+        public bool Automatic { get; set; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Ioc/RegisterForNavigationAttribute.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/RegisterForNavigationAttribute.cs
@@ -1,0 +1,14 @@
+﻿using Prism.AppModel;
+using System;
+
+namespace Prism.Ioc
+{
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class, AllowMultiple = true)]
+    public class RegisterForNavigationAttribute : Attribute
+    {
+        public Type ViewType { get; set; }
+        public Type ViewModelType { get; set; }
+        public string Name { get; set; }
+        public RuntimePlatform? RuntimePlatform { get; set; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Ioc/TypeAutoLoadExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/TypeAutoLoadExtensions.cs
@@ -11,9 +11,9 @@ namespace Prism.Ioc
     {
         public static void AutoRegisterViews(this Type type, IContainerRegistry containerRegistry)
         {
-            if (!type.GetCustomAttributes().Any(a => a is RegisterByConventionAttribute)) return;
+            if (!type.GetCustomAttributes().Any(a => a is AutoRegisterForNavigationAttribute)) return;
 
-            var regAttr = type.GetCustomAttribute<RegisterByConventionAttribute>();
+            var regAttr = type.GetCustomAttribute<AutoRegisterForNavigationAttribute>();
             var assembly = type.Assembly;
 
             if (regAttr.Automatic)

--- a/Source/Xamarin/Prism.Forms/Ioc/TypeAutoLoadExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/TypeAutoLoadExtensions.cs
@@ -1,0 +1,88 @@
+﻿using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xamarin.Forms;
+
+namespace Prism.Ioc
+{
+    internal static class IContainerRegistryAutoLoadExtensions
+    {
+        public static void AutoRegisterViews(this Type type, IContainerRegistry containerRegistry)
+        {
+            if (!type.GetCustomAttributes().Any(a => a is RegisterByConventionAttribute)) return;
+
+            var regAttr = type.GetCustomAttribute<RegisterByConventionAttribute>();
+            var assembly = type.Assembly;
+
+            if (regAttr.Automatic)
+            {
+                var viewTypes = assembly.ExportedTypes.Where(t => t.IsSubclassOf(typeof(Page)));
+                RegisterViewsAutomatically(containerRegistry, viewTypes);
+            }
+            else
+            {
+                RegisterViewsByAttribute(containerRegistry, assembly);
+            }
+        }
+
+        private static void RegisterViewsAutomatically(IContainerRegistry containerRegistry, IEnumerable<Type> viewTypes)
+        {
+            foreach (var viewType in viewTypes)
+            {
+                containerRegistry.RegisterForNavigation(viewType, viewType.Name);
+            }
+
+            if (!containerRegistry.IsRegistered<object>(nameof(NavigationPage)))
+            {
+                containerRegistry.RegisterForNavigation<NavigationPage>();
+            }
+
+            if (!containerRegistry.IsRegistered<object>(nameof(TabbedPage)))
+            {
+                containerRegistry.RegisterForNavigation<TabbedPage>();
+            }
+        }
+
+        private static void RegisterViewsByAttribute(IContainerRegistry containerRegistry, Assembly assembly)
+        {
+            var attrs = assembly.GetCustomAttributes<RegisterForNavigationAttribute>();
+            foreach (var attr in attrs)
+            {
+                RegisterViewByAttribute(containerRegistry, attr);
+            }
+
+            var viewTypes = assembly.ExportedTypes.Where(t => t.IsSubclassOf(typeof(Page))
+                && t.GetCustomAttributes<RegisterForNavigationAttribute>().Any());
+            foreach (var viewType in viewTypes)
+            {
+                var attr = viewType.GetCustomAttributes<RegisterForNavigationAttribute>()
+                    .FirstOrDefault(a => a.RuntimePlatform.ToString() == Device.RuntimePlatform || a.RuntimePlatform is null);
+                attr.ViewType = viewType;
+                RegisterViewByAttribute(containerRegistry, attr);
+            }
+        }
+
+        private static void RegisterViewByAttribute(IContainerRegistry containerRegistry, RegisterForNavigationAttribute attr)
+        {
+            if (attr.ViewType is null)
+                throw new Exception($"Cannot auto register View. No ViewType was specified. Name: '{attr.Name}'. ViewModelType: '{attr.ViewModelType?.Name}'");
+
+            if (attr.RuntimePlatform != null && attr.RuntimePlatform.ToString() != Device.RuntimePlatform) return;
+
+            var name = attr.Name;
+            if (string.IsNullOrEmpty(name))
+            {
+                name = attr.ViewType.Name;
+            }
+
+            containerRegistry.RegisterForNavigation(attr.ViewType, name);
+
+            if (attr.ViewModelType != null)
+            {
+                ViewModelLocationProvider.Register(attr.ViewType.Name, attr.ViewModelType);
+            }
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Modularity/ModuleInitializer.cs
+++ b/Source/Xamarin/Prism.Forms/Modularity/ModuleInitializer.cs
@@ -18,6 +18,7 @@ namespace Prism.Modularity
             if (module != null)
             {
                 module.RegisterTypes(_container);
+                module.GetType().AutoRegisterViews(_container);
                 module.OnInitialized(_container);
             }
         }

--- a/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
+++ b/Source/Xamarin/Prism.Forms/PrismApplicationBase.cs
@@ -130,6 +130,7 @@ namespace Prism
             RegisterRequiredTypes(_containerExtension);
             PlatformInitializer?.RegisterTypes(_containerExtension);
             RegisterTypes(_containerExtension);
+            GetType().AutoRegisterViews(_containerExtension);
             _containerExtension.FinalizeExtension();
 
             if(_setFormsDependencyResolver)


### PR DESCRIPTION
﻿### Description of Change ###

Adds support for registration Views either through Attributes or automatically for all pages in the Assembly. This will register Views in the same assembly as the Prism Application or Module

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - AutoRegisterForNavigationAttribute 

```cs
[AutoRegisterForNavigation]
public partial class App : PrismApplication
{
}

[AutoRegisterForNavigation(Automatic = true)]
public class ModuleA : IModule
{
}
```

 - RegisterForNavigationAttribute 

The RegisterForNavigationAttribute can be added either at an assembly level or at the class level to any Page. Note that if added to a Page the Type of the Page it's added to will override anything you manually add. The ViewType is required when adding the attribute at the assembly level.

```cs
[assembly: RegisterForNavigation(ViewType = typeof(ViewA))]
[assembly: RegisterForNavigation(ViewType = typeof(ViewB), Name = "viewB")]
[assembly: RegisterForNavigation(ViewType = typeof(ViewC), Name = "platformSpecific", RuntimePlatform = RuntimePlatform.iOS)]
[assembly: RegisterForNavigation(ViewType = typeof(ViewD), Name = "platformSpecific", RuntimePlatform = RuntimePlatform.Android)]
```

Or By Page

```cs
[RegisterForNavigation]
public class ViewA : ContentPage { }

[RegisterForNavigation(Name = "viewB")]
public class ViewB : ContentPage { }

// Ignored if no attribute exists at the assembly or class level
// Only registered if RegisterByConventionAttribute.Automatic is true
public class ViewC : ContentPage { }

// Only Registered on iOS
[RegisterForNavigation(RuntimePlatform = RuntimePlatform.iOS)]
public class ViewD : ContentPage { }
```

### Behavioral Changes ###

Will check for RegisterByConventionAttribute on implementing PrismApplication and Modules. If the attribute exists additional lookups will occur to register Views either automatically or by attribute.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard