### PR TITLE
Optimize WeakDelegateReference by introducing TargetEquals, which tak…

### DIFF
--- a/Source/Prism.Tests/Events/DelegateReferenceFixture.cs
+++ b/Source/Prism.Tests/Events/DelegateReferenceFixture.cs
@@ -104,6 +104,53 @@ namespace Prism.Tests.Events
             Assert.NotNull(action.Target);
         }
 
+        [Fact]
+        public void TargetEqualsActionShouldReturnTrue()
+        {
+            var classHandler = new SomeClassHandler();
+            Action<string> myAction = new Action<string>(classHandler.MyAction);
+
+            var weakAction = new DelegateReference(myAction, false);
+
+            Assert.True(weakAction.TargetEquals(new Action<string>(classHandler.MyAction)));
+        }
+
+        [Fact]
+        public void TargetEqualsNullShouldReturnTrueIfTargetNotAlive()
+        {
+            SomeClassHandler handler = new SomeClassHandler();
+            var weakHandlerRef = new WeakReference(handler);
+
+            var action = new DelegateReference((Action<string>)handler.DoEvent, false);
+
+            handler = null;
+            GC.Collect();
+            Assert.False(weakHandlerRef.IsAlive);
+
+            Assert.True(action.TargetEquals(null));
+        }
+
+        [Fact]
+        public void TargetEqualsNullShouldReturnFalseIfTargetAlive()
+        {
+            SomeClassHandler handler = new SomeClassHandler();
+            var weakHandlerRef = new WeakReference(handler);
+
+            var action = new DelegateReference((Action<string>)handler.DoEvent, false);
+
+            Assert.False(action.TargetEquals(null));
+            Assert.True(weakHandlerRef.IsAlive);
+            GC.KeepAlive(handler);
+        }
+        
+        [Fact]
+        public void TargetEqualsWorksWithStaticMethodDelegates()
+        {
+            var action = new DelegateReference((Action)SomeClassHandler.StaticMethod, false);
+
+            Assert.True(action.TargetEquals((Action)SomeClassHandler.StaticMethod));
+        }
+
         //todo: fix
         //[Fact]
         //public void NullDelegateThrows()

--- a/Source/Prism/Events/DelegateReference.cs
+++ b/Source/Prism/Events/DelegateReference.cs
@@ -40,7 +40,7 @@ namespace Prism.Events
                 _delegateType = @delegate.GetType();
             }
         }
-
+        
         /// <summary>
         /// Gets the <see cref="Delegate" /> (the target) referenced by the current <see cref="DelegateReference"/> object.
         /// </summary>
@@ -59,7 +59,26 @@ namespace Prism.Events
                 }
             }
         }
-
+        
+        /// <summary>
+        /// Checks if the <see cref="Delegate" /> (the target) referenced by the current <see cref="DelegateReference"/> object are equal to another <see cref="Delegate" />.
+        /// This is equivalent with comparing <see cref="Target"/> with <paramref name="delegate"/>, only more efficient.
+        /// </summary>
+        /// <param name="delegate">The other delegate to compare with.</param>
+        /// <returns>True if the target referenced by the current object are equal to <paramref name="delegate"/>.</returns>
+        public bool TargetEquals(Delegate @delegate)
+        {
+            if (_delegate != null)
+            {
+                return _delegate == @delegate;
+            }
+            if (@delegate == null)
+            {
+                return !_method.IsStatic && !this._weakReference.IsAlive;
+            }
+            return _weakReference.Target == @delegate.Target && Equals(this._method, @delegate.GetMethodInfo());
+        }
+        
         private Delegate TryGetDelegate()
         {
             if (_method.IsStatic)

--- a/Source/Prism/Events/DelegateReference.cs
+++ b/Source/Prism/Events/DelegateReference.cs
@@ -74,9 +74,9 @@ namespace Prism.Events
             }
             if (@delegate == null)
             {
-                return !_method.IsStatic && !this._weakReference.IsAlive;
+                return !_method.IsStatic && !_weakReference.IsAlive;
             }
-            return _weakReference.Target == @delegate.Target && Equals(this._method, @delegate.GetMethodInfo());
+            return _weakReference.Target == @delegate.Target && Equals(_method, @delegate.GetMethodInfo());
         }
         
         private Delegate TryGetDelegate()

--- a/Source/Wpf/Prism.Wpf/Events/WeakDelegatesManager.cs
+++ b/Source/Wpf/Prism.Wpf/Events/WeakDelegatesManager.cs
@@ -17,19 +17,15 @@ namespace Prism.Events
 
         public void RemoveListener(Delegate listener)
         {
-            this.listeners.RemoveAll(reference =>
-            {
-                //Remove the listener, and prune collected listeners
-                Delegate target = reference.Target;
-                return listener.Equals(target) || target == null;
-            });
+            //Remove the listener, and prune collected listeners
+            this.listeners.RemoveAll(reference => reference.TargetEquals(null) || reference.TargetEquals(listener));
         }
 
         public void Raise(params object[] args)
         {
-            this.listeners.RemoveAll(listener => listener.Target == null);
+            this.listeners.RemoveAll(listener => listener.TargetEquals(null));
 
-            foreach (Delegate handler in this.listeners.ToList().Select(listener => listener.Target).Where(listener => listener != null))
+            foreach (Delegate handler in this.listeners.Select(listener => listener.Target).Where(listener => listener != null).ToList())
             {
                 handler.DynamicInvoke(args);
             }


### PR DESCRIPTION
…es 60% less time than comparing with Target if it's still alive, and makes WeakDelegateManager.RemoveListener take 90% less time in normal usage.

﻿### Description of Change ###

In our application, we saw a lot of time being spent inside WeakDelegateManager.RemoveListener when injecting a view with many subviews (around 100 in total). This was due to WeakDelegateManager creating temporary Delegates for each DelegateReference in the list just to do comparisions. By introducing TargetEquals method, you can now test equality without actually using. Testing the fix locally showed that time spent in WeakDelegateManager.RemoveListener got reduced with 90% and made our view injection almost 3 seconds faster!

### Bugs Fixed ###

#1796 

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - bool DelegateReference.TargetEquals(Delegate);

### Behavioral Changes ###

None

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard