### PR TITLE
Attached RegionManager to dialog by default

### DIFF
--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
@@ -1,5 +1,6 @@
 ﻿using Prism.Common;
 using Prism.Ioc;
+using Prism.Regions;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -10,10 +11,12 @@ namespace Prism.Services.Dialogs
     public class DialogService : IDialogService
     {
         private readonly IContainerExtension _containerExtension;
+        private readonly IRegionManager _regionManager;
 
-        public DialogService(IContainerExtension containerExtension)
+        public DialogService(IContainerExtension containerExtension, IRegionManager regionManager)
         {
             _containerExtension = containerExtension;
+            _regionManager = regionManager;
         }
 
         public void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback)
@@ -29,6 +32,7 @@ namespace Prism.Services.Dialogs
         void ShowDialogInternal(string name, IDialogParameters parameters, Action<IDialogResult> callback, bool isModal)
         {
             IDialogWindow dialogWindow = CreateDialogWindow();
+            RegionManager.SetRegionManager((DependencyObject)dialogWindow, _regionManager);
             ConfigureDialogWindowEvents(dialogWindow, callback);
             ConfigureDialogWindowContent(name, dialogWindow, parameters);
 
@@ -56,7 +60,7 @@ namespace Prism.Services.Dialogs
 
             ConfigureDialogWindowProperties(window, dialogContent, viewModel);
 
-            MvvmHelpers.ViewAndViewModelAction<IDialogAware>(viewModel, d => d.OnDialogOpened(parameters));            
+            MvvmHelpers.ViewAndViewModelAction<IDialogAware>(viewModel, d => d.OnDialogOpened(parameters));
         }
 
         void ConfigureDialogWindowEvents(IDialogWindow dialogWindow, Action<IDialogResult> callback)


### PR DESCRIPTION
﻿### Description of Change ###

If you create and show a new Window in Prism and then try to navigate within regions, it will fail because there is no RegionManager associated with the new Window object.

The IDialogService has been modified to automatcally assign the application's RegionManager to eacvh dialog window instance so that region navigation will work out of the box

### Bugs Fixed ###

- #1805 

### API Changes ###

None

### Behavioral Changes ###

Region navigation will now function properly when navigating within the IDialogService

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard