### PR TITLE
Removes FastExpressionCompiler from DryIoc Forms

### DIFF
--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -58,6 +58,7 @@ namespace Prism.DryIoc
         /// <returns>An instance of <see cref="Rules" /></returns>
         protected virtual Rules CreateContainerRules() => Rules.Default.WithAutoConcreteTypeResolution()
                                                                        .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
+                                                                       .WithoutFastExpressionCompiler()
                                                                        .WithDefaultIfAlreadyRegistered(IfAlreadyRegistered.Replace);
 
         /// <summary>


### PR DESCRIPTION
﻿### Description of Change ###

Removes FastExpressionCompiler from DryIoc Forms due to incompatibility with iOS due to it attempting to JIT.

### Bugs Fixed ###

- fixes #1806 

### API Changes ###

List all API changes here (or just put None), example:

none

### Behavioral Changes ###

prevents new API from DryIoc 4 from causing crashes on iOS

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard