### PR TITLE
Do not override owner in DialogService

### DIFF
--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
@@ -113,8 +113,8 @@ namespace Prism.Services.Dialogs
             window.Content = dialogContent;
             window.DataContext = viewModel; //we want the host window and the dialog to share the same data contex
 
-            //TODO: is there a better way to set the owner
-            window.Owner = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
+            if (window.Owner == null)
+                window.Owner = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.IsActive);
         }
     }
 }


### PR DESCRIPTION
﻿## Do not override owner in DialogService

### Bugs Fixed

- [#1666](https://github.com/PrismLibrary/Prism/issues/1666#issuecomment-496558216)

### API Changes

None

### Behavioral Changes

Check DialogWindow's Owner whether is null during configuration.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard