### PR TITLE
Using Enum for IDialogResult.Result

### DIFF
--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/DialogViewModelBase.cs
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/DialogViewModelBase.cs
@@ -22,12 +22,12 @@ namespace HelloWorld.Dialogs
 
         protected virtual void CloseDialog(string parameter)
         {
-            bool? result = null;
+            ButtonResult result = ButtonResult.None;
 
             if (parameter?.ToLower() == "true")
-                result = true;
+                result = ButtonResult.OK;
             else if (parameter?.ToLower() == "false")
-                result = false;
+                result = ButtonResult.Cancel;
 
             RequestClose?.Invoke(new DialogResult(result));
         }

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/ViewModels/MainWindowViewModel.cs
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/ViewModels/MainWindowViewModel.cs
@@ -31,44 +31,44 @@ namespace HelloWorld.ViewModels
             //using the dialog service as-is
             //_dialogService.ShowDialog("NotificationDialog", new DialogParameters($"message={message}"), r =>
             //{
-            //    if (!r.Result.HasValue)
-            //        Title = "Result is null";
-            //    else if (r.Result == true)
-            //        Title = "Result is True";
-            //    else if (r.Result == false)
-            //        Title = "Result is False";
+            //    if (r.Result == ButtonResult.None)
+            //        Title = "Result is None";
+            //    else if (r.Result == ButtonResult.OK)
+            //        Title = "Result is OK";
+            //    else if (r.Result == ButtonResult.Cancel)
+            //        Title = "Result is Cancel";
             //    else
-            //        Title = "What the hell did you do?";
+            //        Title = "I Don't know what you did!?";
             //});
 
             //using custom extenions methods to simplify the app's dialogs
             //_dialogService.ShowNotification(message, r =>
             //{
-            //    if (!r.Result.HasValue)
-            //        Title = "Result is null";
-            //    else if (r.Result == true)
-            //        Title = "Result is True";
-            //    else if (r.Result == false)
-            //        Title = "Result is False";
+            //    if (r.Result == ButtonResult.None)
+            //        Title = "Result is None";
+            //    else if (r.Result == ButtonResult.OK)
+            //        Title = "Result is OK";
+            //    else if (r.Result == ButtonResult.Cancel)
+            //        Title = "Result is Cancel";
             //    else
-            //        Title = "What the hell did you do?";
+            //        Title = "I Don't know what you did!?";
             //});
 
             _dialogService.ShowConfirmation(message, r =>
             {
-                if (!r.Result.HasValue)
-                    Title = "Result is null";
-                else if (r.Result == true)
-                    Title = "Result is True";
-                else if (r.Result == false)
-                    Title = "Result is False";
+                if (r.Result == ButtonResult.None)
+                    Title = "Result is None";
+                else if (r.Result == ButtonResult.OK)
+                    Title = "Result is OK";
+                else if (r.Result == ButtonResult.Cancel)
+                    Title = "Result is Cancel";
                 else
-                    Title = "What the hell did you do?";
+                    Title = "I Don't know what you did!?";
             });
         }
     }
 
-    public static class DialogServiceEstensions
+    public static class DialogServiceExtensions
     {
         public static void ShowNotification(this IDialogService dialogService, string message, Action<IDialogResult> callBack)
         {

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/ButtonResult.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/ButtonResult.cs
@@ -1,0 +1,14 @@
+﻿namespace Prism.Services.Dialogs
+{
+    public enum ButtonResult
+    {
+        Abort = 3,
+        Cancel = 2,
+        Ignore = 5,
+        No = 7,
+        None = 0,
+        OK = 1,
+        Retry = 4,        
+        Yes = 6
+    }
+}

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogParameters.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogParameters.cs
@@ -2,7 +2,6 @@
 
 namespace Prism.Services.Dialogs
 {
-    //TODO: should we reuse the NavigationParameters? I'm not sure I want to add the regions namespace requirement for using dialogs
     public class DialogParameters : NavigationParameters, IDialogParameters
     {
         public DialogParameters() : base() { }

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogResult.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogResult.cs
@@ -4,16 +4,16 @@
     {
         public IDialogParameters Parameters { get; private set; } = new DialogParameters();
 
-        public bool? Result { get; private set; }
+        public ButtonResult Result { get; private set; } = ButtonResult.None;
 
         public DialogResult() { }
 
-        public DialogResult(bool? result)
+        public DialogResult(ButtonResult result)
         {
             Result = result;
         }
 
-        public DialogResult(bool? result, IDialogParameters parameters)
+        public DialogResult(ButtonResult result, IDialogParameters parameters)
         {
             Result = result;
             Parameters = parameters;

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogAware.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogAware.cs
@@ -22,9 +22,9 @@ namespace Prism.Services.Dialogs
         void OnDialogOpened(IDialogParameters parameters);
 
         /// <summary>
-        /// The title of the dialog that wil show in the Window title bar.
+        /// The title of the dialog that will show in the Window title bar.
         /// </summary>
-        string Title { get; set; }
+        string Title { get; }
 
         /// <summary>
         /// Instructs the IDialogWindow to close the dialog.

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogResult.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogResult.cs
@@ -10,6 +10,6 @@
         /// <summary>
         /// The result of the dialog.
         /// </summary>
-        bool? Result { get; }        
+        ButtonResult Result { get; }        
     }
 }

--- a/Source/build/azure-pipelines.yml
+++ b/Source/build/azure-pipelines.yml
@@ -58,7 +58,7 @@ stages:
 
 - stage: deploy
   displayName: Deploy Artifacts
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   jobs:
   - deployment: MyGet
     displayName: MyGet.org

--- a/Source/build/azure-pipelines.yml
+++ b/Source/build/azure-pipelines.yml
@@ -58,7 +58,7 @@ stages:
 
 - stage: deploy
   displayName: Deploy Artifacts
-  condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   jobs:
   - deployment: MyGet
     displayName: MyGet.org


### PR DESCRIPTION
﻿## Description of Change

Removed the use of a `bool?` as the `IDialogResult.Result` property. Instead, added a new enum called `ButtonResult`

### API Changes

List all API changes here (or just put None), example:

Added:

```
    public enum ButtonResult
    {
        Abort = 3,
        Cancel = 2,
        Ignore = 5,
        No = 7,
        None = 0,
        OK = 1,
        Retry = 4,        
        Yes = 6
    }
```

Changed:

- `bool? IDialogResult.Result` => `ButtonResult IDialogResult.Result`

### Behavioral Changes

The `IDialogResult.Result` property no longer returns a `bool?`, instead is now returns a `ButtonResult` enum value.

### PR Checklist

- [x] Has tests (if omitted, state reason in description) - I'm lazy, so no tests yet
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard