### PR TITLE
Fully support bindings for Xaml Navigation 

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/MyMasterDetailViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/ViewModels/MyMasterDetailViewModel.cs
@@ -13,6 +13,10 @@ namespace HelloWorld.ViewModels
     {
         INavigationService _navigationService;
 
+        public string NavigatePath => "MyNavigationPage/ViewA";
+
+        public string Message => "Hello from MyMasterDetailViewModel";
+
         public DelegateCommand<string> NavigateCommand { get; set; }
         public MyMasterDetailViewModel(INavigationService navigationService)
         {

--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <MasterDetailPage xmlns="http://xamarin.com/schemas/2014/forms"
                   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                  xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
-                  xmlns:nav="clr-namespace:Prism.Navigation.Xaml;assembly=Prism.Forms"
+                  xmlns:prism="http://prismlibrary.com"
                   prism:ViewModelLocator.AutowireViewModel="True"
                   x:Class="HelloWorld.Views.MyMasterDetail">
 
@@ -13,9 +12,15 @@
                 <Button Text="ViewA" Command="{Binding NavigateCommand}" CommandParameter="MyTabbedPage?selectedTab=ViewA" />
                 <Button Text="ViewB" Command="{Binding NavigateCommand}" CommandParameter="MyTabbedPage?selectedTab=ViewB" />
                 <Button Text="ViewC" Command="{Binding NavigateCommand}" CommandParameter="MyTabbedPage?selectedTab=ViewC" />
-                <Button Text="XamlNav" Command="{nav:NavigateTo 'MyNavigationPage/ViewA'}" />
-                <Button Text="XamlNav wihout animation" Command="{nav:NavigateTo 'MyNavigationPage/ViewA', Animated=False}" />
-                <Button Text="XamlNav modal" Command="{nav:NavigateTo 'MyNavigationPage/ViewA', UseModalNavigation=True}" />
+                <Button Text="XamlNav" Command="{prism:NavigateTo Name={Binding NavigatePath}}">
+                    <Button.CommandParameter>
+                        <prism:NavigationParameters>
+                            <prism:NavigationParameter Key="message" Value="{Binding Message}" />
+                        </prism:NavigationParameters>
+                    </Button.CommandParameter>
+                </Button>
+                <Button Text="XamlNav wihout animation" Command="{prism:NavigateTo 'MyNavigationPage/ViewA', Animated=False}" />
+                <Button Text="XamlNav modal" Command="{prism:NavigateTo 'MyNavigationPage/ViewA', UseModalNavigation=True}" />
             </StackLayout>
         </ContentPage>
     </MasterDetailPage.Master>

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/ViewModels/ViewAViewModel.cs
@@ -9,7 +9,7 @@ using Prism.Navigation.TabbedPages;
 
 namespace ModuleA.ViewModels
 {
-    public class ViewAViewModel : BindableBase, INavigationAware, IActiveAware, IApplicationLifecycleAware, IPageLifecycleAware
+    public class ViewAViewModel : BindableBase, IAutoInitialize, INavigationAware, IActiveAware, IApplicationLifecycleAware, IPageLifecycleAware
     {
         private readonly INavigationService _navigationService;
 
@@ -22,6 +22,12 @@ namespace ModuleA.ViewModels
 
         private bool _canNavigate = true;
 
+        string _message = "No Message Set.";
+        public string Message
+        {
+            get => _message;
+            set => SetProperty(ref _message, value);
+        }
 
 
         public bool CanNavigate

--- a/Sandbox/Xamarin/HelloWorld/ModuleA/Views/ViewA.xaml
+++ b/Sandbox/Xamarin/HelloWorld/ModuleA/Views/ViewA.xaml
@@ -4,17 +4,25 @@
              xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms"
              prism:ViewModelLocator.AutowireViewModel="True"
              x:Class="ModuleA.Views.ViewA"
+             Padding="{OnPlatform iOS='0,20,0,0'}"
              Title="View A">
-    <ContentPage.Padding>
-        <OnPlatform x:TypeArguments="Thickness">
-            <On Platform="iOS" Value="0,20,0,0" />
-        </OnPlatform>
-    </ContentPage.Padding>
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Label">
+                <Setter Property="HorizontalTextAlignment" Value="Center" />
+            </Style>
+            <Style TargetType="Button">
+                <Setter Property="HorizontalOptions" Value="Center" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
 
-	<StackLayout>
-		<Label Text="{Binding Title}" VerticalOptions="Center" HorizontalOptions="Center" />
-		<Label Text="{Binding IsActive}" />
-		<Button Command="{Binding NavigateCommand}" Text="Navigate" />
-	</StackLayout>
+    <StackLayout VerticalOptions="Center"
+                 HorizontalOptions="Center">
+        <Label Text="{Binding Title}" />
+        <Label Text="{Binding Message}" />
+        <Label Text="{Binding IsActive, StringFormat='IsActive: {0}'}" />
+        <Button Command="{Binding NavigateCommand}" Text="Navigate" />
+    </StackLayout>
 
 </ContentPage>

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationExtensionBase.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationExtensionBase.cs
@@ -132,12 +132,14 @@ namespace Prism.Navigation.Xaml
             {
                 SourcePage = parentPage;
 
-                if(parentPage.Parent is MasterDetailPage mdp 
+                if(parentPage.Parent is MasterDetailPage mdp
                     && mdp.Master == parentPage)
                 {
                     SourcePage = mdp;
                 }
             }
+
+            BindingContext = SourcePage.BindingContext;
         }
 
         private IEnumerable<Element> GetBindableStack()

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationParameterExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationParameterExtensions.cs
@@ -17,6 +17,7 @@ namespace Prism.Navigation.Xaml
                     xamlParameter.BindingContext = xamlParameter.BindingContext ?? parent.BindingContext;
                     return new PrismNavParameters { { xamlParameter.Key, xamlParameter.Value } };
                 case XamlNavParams xamlParameters:
+                    xamlParameters.BindingContext = parent.BindingContext;
                     return xamlParameters.ToNavigationParameters(parent);
                 default:
                     return new PrismNavParameters { { KnownNavigationParameters.XamlParam, parameter } };

--- a/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationParameters.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/Xaml/NavigationParameters.cs
@@ -81,11 +81,15 @@ namespace Prism.Navigation.Xaml
             void BindingContextChanged(object parentObject, EventArgs args)
             {
                 var parent = (BindableObject) parentObject;
-                for (var index = 0; index < self._list.Count; index++)
-                {
-                    var parameter = self._list[index];
-                    parameter.BindingContext = parent.BindingContext;
-                }
+                self.BindingContext = parent?.BindingContext;
+            }
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            foreach(var param in this)
+            {
+                param.BindingContext = BindingContext;
             }
         }
     }


### PR DESCRIPTION
﻿## Description of Change

Fully supports Bindings for Xaml Navigation. You can now use bindings without issue for any of the Properties on the Navigation Extensions or the XAML Navigation Parameters.

### Bugs Fixed

- fixes #1754

### API Changes

none

### Behavioral Changes

none

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard