### PR TITLE
Dialog Updates

### DIFF
--- a/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
+++ b/Sandbox/Xamarin/HelloWorld/HelloWorld/HelloWorld/Views/MyMasterDetail.xaml
@@ -23,6 +23,8 @@
                 <Button Text="XamlNav modal" Command="{prism:NavigateTo 'MyNavigationPage/ViewA', UseModalNavigation=True}" />
                 <Button Text="Dialog Demo"
                         Command="{prism:NavigateTo 'MyNavigationPage/DialogDemoPage'}" />
+                <Button Text="Show Dialog"
+                        Command="{prism:ShowDialog 'DemoDialog?message=Hello%20From%20Prism%20DialogService!&amp;closeOnBackgroundTapped=true'}" />
             </StackLayout>
         </ContentPage>
     </MasterDetailPage.Master>

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -70,8 +70,16 @@ namespace Prism.Services.Dialogs
                     }
                 }
 
-                parameters.TryGetValue<bool>(KnownDialogParameters.CloseOnBackgroundTapped, out var hideOnBackgroundTapped);
-                InsertPopupViewInCurrentPage(currentPage as ContentPage, view, hideOnBackgroundTapped, DialogAware_RequestClose);
+                if(!parameters.TryGetValue<bool>(KnownDialogParameters.CloseOnBackgroundTapped, out var closeOnBackgroundTapped))
+                {
+                    var dialogLayoutCloseOnBackgroundTapped = DialogLayout.GetCloseOnBackgroundTapped(view);
+                    if(dialogLayoutCloseOnBackgroundTapped.HasValue)
+                    {
+                        closeOnBackgroundTapped = dialogLayoutCloseOnBackgroundTapped.Value;
+                    }
+                }
+
+                InsertPopupViewInCurrentPage(currentPage as ContentPage, view, closeOnBackgroundTapped, DialogAware_RequestClose);
 
                 PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(currentPage, aa => aa.IsActive = false);
                 PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(view, aa => aa.IsActive = true);

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -242,12 +242,12 @@ namespace Prism.Services.Dialogs
 
             var overlay = new AbsoluteLayout();
             overlay.SetValue(IsPopupHostProperty, true);
+            var existingContent = currentPage.Content;
             var content = new DialogContainer
             {
                 Padding = currentPage.Padding,
                 HorizontalOptions = LayoutOptions.FillAndExpand,
                 VerticalOptions = LayoutOptions.FillAndExpand,
-                Content = currentPage.Content,
                 IsPageContent = true
             };
             currentPage.Padding = new Thickness(0);
@@ -289,6 +289,9 @@ namespace Prism.Services.Dialogs
             overlay.Children.Add(mask);
             overlay.Children.Add(popupContainer);
             currentPage.Content = overlay;
+
+            // The original content needs to be reparented after the Page Content has been reset.
+            content.Content = existingContent;
         }
 
         private static Style GetOverlayStyle(View popupView)

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -204,12 +204,24 @@ namespace Prism.Services.Dialogs
                 case NavigationPage np:
                     return GetCurrentPage(np.CurrentPage);
                 case CarouselPage carouselPage:
-                    return carouselPage.CurrentPage;
+                    return GetCurrentPage(carouselPage.CurrentPage);
                 case MasterDetailPage mdp:
+                    mdp.IsPresented = false;
                     return GetCurrentPage(mdp.Detail);
                 default:
+                    // If we get some random Page Type
+                    if(page != null)
+                    {
+                        Xamarin.Forms.Internals.Log.Warning("Warning", $"An Unknown Page type {page.GetType()} was found walk walking the Navigation Stack. This is not supported by the DialogService");
+                        return null;
+                    }
+
                     var mainPage = _applicationProvider.MainPage;
-                    if (mainPage is null) return null;
+                    if (mainPage is null)
+                    {
+                        return null;
+                    }
+
                     return GetCurrentPage(mainPage);
             }
         }
@@ -286,7 +298,12 @@ namespace Prism.Services.Dialogs
             var popupBounds = DialogLayout.GetLayoutBounds(popupView);
             AbsoluteLayout.SetLayoutBounds(popupContainer, popupBounds);
             overlay.Children.Add(content);
-            overlay.Children.Add(mask);
+
+            if(DialogLayout.GetUseMask(popupContainer) ?? true)
+            {
+                overlay.Children.Add(mask);
+            }
+
             overlay.Children.Add(popupContainer);
             currentPage.Content = overlay;
 

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/Xaml/DialogLayout.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/Xaml/DialogLayout.cs
@@ -52,5 +52,13 @@ namespace Prism.Services.Dialogs.Xaml
         public static void SetMask(BindableObject bindable, View value) =>
             bindable.SetValue(MaskProperty, value);
 
+        public static readonly BindableProperty CloseOnBackgroundTappedProperty =
+            BindableProperty.CreateAttached("CloseOnBackgroundTapped", typeof(bool?), typeof(DialogLayout), null);
+
+        public static bool? GetCloseOnBackgroundTapped(BindableObject bindable) =>
+            (bool?)bindable.GetValue(CloseOnBackgroundTappedProperty);
+
+        public static void SetCloseOnBackgroundTapped(BindableObject bindable, bool? value) =>
+            bindable.SetValue(CloseOnBackgroundTappedProperty, value);
     }
 }

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/Xaml/DialogLayout.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/Xaml/DialogLayout.cs
@@ -52,6 +52,15 @@ namespace Prism.Services.Dialogs.Xaml
         public static void SetMask(BindableObject bindable, View value) =>
             bindable.SetValue(MaskProperty, value);
 
+        public static readonly BindableProperty UseMaskProperty =
+            BindableProperty.CreateAttached("UseMask", typeof(bool?), typeof(DialogLayout), null);
+
+        public static bool? GetUseMask(BindableObject bindable) =>
+            (bool?)bindable.GetValue(UseMaskProperty);
+
+        public static void SetUseMask(BindableObject bindable, bool? value) =>
+            bindable.SetValue(UseMaskProperty, value);
+
         public static readonly BindableProperty CloseOnBackgroundTappedProperty =
             BindableProperty.CreateAttached("CloseOnBackgroundTapped", typeof(bool?), typeof(DialogLayout), null);
 

--- a/Source/build/steps/build.yml
+++ b/Source/build/steps/build.yml
@@ -13,3 +13,4 @@ steps:
     solution: ${{ parameters.solution }}
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
+    msbuildArguments: '/p:JavaSdkDirectory="$(JAVA_HOME)"'


### PR DESCRIPTION
﻿## Description of Change

Small bug fixes and enhancements for DialogService

### Bugs Fixed

- Fixes crash on Android with Screen Reader caused by reparenting ordering

### API Changes

Added:

- UseMask attached property to allow the opting out of having a mask layer
- CloseOnBackgroundTapped attached property to specify it as 

### Behavioral Changes

- Sets MasterDetailPage.IsPresented to false. This helps when invoked from the XAML Extension from the MasterDetailPage.Master

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard