### PR TITLE
Partial views changes

### DIFF
--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -25,10 +25,9 @@ namespace Prism.Common
                 }
             }
 
-            if(view is Page page)
+            if (view is Page page && page.GetPartialViews() is List<BindableObject> partials)
             {
-                var partials = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty) ?? new List<BindableObject>();
-                foreach(var partial in partials)
+                foreach (var partial in partials)
                 {
                     InvokeViewAndViewModelAction(partial, action);
                 }
@@ -48,9 +47,8 @@ namespace Prism.Common
                 }
             }
 
-            if (view is Page page)
+            if (view is Page page && page.GetPartialViews() is List<BindableObject> partials)
             {
-                var partials = (List<BindableObject>)page.GetValue(ViewModelLocator.PartialViewsProperty) ?? new List<BindableObject>();
                 foreach (var partial in partials)
                 {
                     await InvokeViewAndViewModelActionAsync(partial, action);

--- a/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
+++ b/Source/Xamarin/Prism.Forms/Mvvm/ViewModelLocator.cs
@@ -53,6 +53,11 @@ namespace Prism.Mvvm
             bindable.SetValue(AutowirePartialViewProperty, page);
         }
 
+        internal static List<BindableObject> GetPartialViews(this Page page)
+        {
+            return (List<BindableObject>)page.GetValue(PartialViewsProperty);
+        }
+
         private static void OnAutowireViewModelChanged(BindableObject bindable, object oldValue, object newValue)
         {
             bool? bNewValue = (bool?)newValue;
@@ -65,20 +70,17 @@ namespace Prism.Mvvm
             if (oldValue == newValue)
                 return;
 
-            if(oldValue is Page oldPage)
+            if (oldValue is Page oldPage)
             {
-                var oldPartials = (List<BindableObject>)oldPage.GetValue(PartialViewsProperty);
-                oldPartials?.Clear();
-                oldPage.SetValue(PartialViewsProperty, null);
+                List<BindableObject> oldPartials = oldPage.GetPartialViews();
+                oldPartials.Remove(bindable);
             }
 
-            List<BindableObject> partialViews = null;
-            if (newValue != null && newValue is Page page)
+            if (newValue is Page page)
             {
                 // Add View to Views Collection for Page.
-                partialViews = page.GetValue(PartialViewsProperty) as List<BindableObject>;
-
-                if(partialViews == null)
+                List<BindableObject> partialViews = page.GetPartialViews();
+                if (partialViews == null)
                 {
                     partialViews = new List<BindableObject>();
                     page.SetValue(PartialViewsProperty, partialViews);
@@ -86,7 +88,7 @@ namespace Prism.Mvvm
 
                 partialViews.Add(bindable);
                 // Set Autowire Property
-                if(bindable.GetValue(AutowireViewModelProperty) == null)
+                if (bindable.GetValue(AutowireViewModelProperty) == null)
                 {
                     bindable.SetValue(AutowireViewModelProperty, true);
                 }


### PR DESCRIPTION
﻿## Description of Change

Currently, when a partial-view removes itself from the Page by calling `SetAutowirePartialView(view, null)`, all the other partial views are also removed from the Page's inner partial view collection.
This PR makes only the partial view calling `SetAutowirePartialView(view, null)` be removed.
This gives the possibility to add/remove partial views dynamically.

### Bugs Fixed

#1726

### API Changes

None

### Behavioral Changes

See description

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard