### PR TITLE
Add Method "SetNestedProperty" on BindableBase

### DIFF
--- a/Source/Prism.Tests/Mocks/ViewModels/MockNestedModel.cs
+++ b/Source/Prism.Tests/Mocks/ViewModels/MockNestedModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Prism.Tests.Mocks.ViewModels
+{
+    public class MockNestedModel
+    {
+        public int MockNestedProperty { get; set; }
+    }
+}

--- a/Source/Prism.Tests/Mocks/ViewModels/MockViewModel.cs
+++ b/Source/Prism.Tests/Mocks/ViewModels/MockViewModel.cs
@@ -22,9 +22,22 @@ namespace Prism.Tests.Mocks.ViewModels
             }
         }
 
+        internal MockNestedModel MockNestedModel { get; set; }
+        
+        public int MockNestedProperty
+        {
+            get => MockNestedModel.MockNestedProperty;
+            set => SetNestedProperty(MockNestedModel, value);
+        }
+
         internal void InvokeOnPropertyChanged()
         {
 			RaisePropertyChanged(nameof(MockProperty));
+        }
+
+        internal void InvokeOnNestedPropertyChanged()
+        {
+            RaisePropertyChanged(nameof(MockNestedProperty));
         }
     }
 }

--- a/Source/Prism.Tests/Mvvm/BindableBaseFixture.cs
+++ b/Source/Prism.Tests/Mvvm/BindableBaseFixture.cs
@@ -18,6 +18,21 @@ namespace Prism.Tests.Mvvm
         }
 
         [Fact]
+        public void SetNestedPropertyMethodShouldSetTheNewValue()
+        {
+            int value = 10;
+            MockViewModel mockViewModel = new MockViewModel
+            {
+                MockNestedModel = new MockNestedModel()
+            };
+
+            Assert.Equal(0, mockViewModel.MockNestedProperty);
+
+            mockViewModel.MockNestedProperty = value;
+            Assert.Equal(value, mockViewModel.MockNestedProperty);
+        }
+
+        [Fact]
         public void SetPropertyMethodShouldNotSetTheNewValue()
         {
             int value = 10, newValue = 10;
@@ -33,6 +48,24 @@ namespace Prism.Tests.Mvvm
         }
 
         [Fact]
+        public void SetNestedPropertyMethodShouldNotSetTheNewValue()
+        {
+            int value = 10, newValue = 10;
+            MockViewModel mockViewModel = new MockViewModel
+            {
+                MockNestedModel = new MockNestedModel()
+            };
+            mockViewModel.MockNestedProperty = value;
+
+            bool invoked = false;
+            mockViewModel.PropertyChanged += (o, e) => { if (e.PropertyName.Equals("MockNestedProperty")) invoked = true; };
+            mockViewModel.MockNestedProperty = newValue;
+
+            Assert.False(invoked);
+            Assert.Equal(value, mockViewModel.MockNestedProperty);
+        }
+
+        [Fact]
         public void SetPropertyMethodShouldRaisePropertyRaised()
         {
             bool invoked = false;
@@ -45,6 +78,21 @@ namespace Prism.Tests.Mvvm
         }
 
         [Fact]
+        public void SetNestedPropertyMethodShouldRaisePropertyRaised()
+        {
+            bool invoked = false;
+            MockViewModel mockViewModel = new MockViewModel
+            {
+                MockNestedModel = new MockNestedModel()
+            };
+
+            mockViewModel.PropertyChanged += (o, e) => { if (e.PropertyName.Equals("MockNestedProperty")) invoked = true; };
+            mockViewModel.MockNestedProperty = 10;
+
+            Assert.True(invoked);
+        }
+
+        [Fact]
         public void OnPropertyChangedShouldExtractPropertyNameCorrectly()
         {
             bool invoked = false;
@@ -52,6 +100,21 @@ namespace Prism.Tests.Mvvm
 
             mockViewModel.PropertyChanged += (o, e) => { if (e.PropertyName.Equals("MockProperty")) invoked = true; };
             mockViewModel.InvokeOnPropertyChanged();
+
+            Assert.True(invoked);
+        }
+
+        [Fact]
+        public void OnNestedPropertyChangedShouldExtractPropertyNameCorrectly()
+        {
+            bool invoked = false;
+            MockViewModel mockViewModel = new MockViewModel
+            {
+                MockNestedModel = new MockNestedModel()
+            };
+
+            mockViewModel.PropertyChanged += (o, e) => { if (e.PropertyName.Equals("MockNestedProperty")) invoked = true; };
+            mockViewModel.InvokeOnNestedPropertyChanged();
 
             Assert.True(invoked);
         }


### PR DESCRIPTION
﻿## Description of Change

Add Method "SetNestedProperty" on BindableBase. This adds the functionallity to wrap a property of a nested object in the viewmodel, which is very useful when working with object properties in viewmodels.

### Bugs Fixed

- none

### API Changes

Added:

- BindableBase : protected virtual bool SetNestedProperty<TObject, TProperty>(TObject objectWithProperty, TProperty value, [CallerMemberName]string propertyName = null);

Example:
```
public class MyViewModel : BindableBase  
{
        public NestedModel NestedModel { get; set; } 
        public int NestedProperty
        {
            get => NestedModel.NestedProperty;
            set => SetNestedProperty(NestedModel, value);
        }
}
```

Changed:

- none

### Behavioral Changes

none

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard