### PR TITLE
Set _executeMethod readonly in DelegateCommand

### DIFF
--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Linq.Expressions;
-using System.Windows.Input;
-using Prism.Properties;
-
 namespace Prism.Commands
 {
+    using System;
+    using System.Linq.Expressions;
+    using System.Windows.Input;
+    using Prism.Properties;
+
     /// <summary>
     /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute()"/> and <see cref="CanExecute()"/>.
     /// </summary>

--- a/Source/Prism/Commands/DelegateCommand.cs
+++ b/Source/Prism/Commands/DelegateCommand.cs
@@ -1,10 +1,10 @@
+using System;
+using System.Linq.Expressions;
+using System.Windows.Input;
+using Prism.Properties;
+
 namespace Prism.Commands
 {
-    using System;
-    using System.Linq.Expressions;
-    using System.Windows.Input;
-    using Prism.Properties;
-
     /// <summary>
     /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute()"/> and <see cref="CanExecute()"/>.
     /// </summary>
@@ -12,7 +12,7 @@ namespace Prism.Commands
     /// <see cref="DelegateCommand{T}"/>
     public class DelegateCommand : DelegateCommandBase
     {
-        Action _executeMethod;
+        readonly Action _executeMethod;
         Func<bool> _canExecuteMethod;
 
         /// <summary>


### PR DESCRIPTION
﻿## Description of Change

Set _executeMethod readonly in Delegate Command

### Bugs Fixed

None

### API Changes

None

Added:

None

Changed:

Set _executeMethod readonly in DelegateCommand

### Behavioral Changes

None

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard