### PR TITLE
Allow bind Enum values in IAutoInitialize ViewModels

### DIFF
--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,7 +25,7 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
@@ -50,7 +50,7 @@ namespace Prism.Common
                         value = (T)kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
                         value = (T)Convert.ChangeType(kvp.Value, type);
@@ -79,7 +79,7 @@ namespace Prism.Common
                         values.Add((T)kvp.Value);
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, type));

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -26,7 +26,7 @@ namespace Prism.Common
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
                     else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
-                        return Enum.Parse(type, kvp.Value.ToString(), true);
+                        return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
                 }
@@ -38,20 +38,22 @@ namespace Prism.Common
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool TryGetValue<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key, out T value)
         {
+            var type = typeof(T);
+
             foreach (var kvp in parameters)
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
                     if (kvp.Value == null)
                         value = default;
-                    else if (kvp.Value.GetType() == typeof(T))
+                    else if (kvp.Value.GetType() == type)
                         value = (T)kvp.Value;
-                    else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
+                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
-                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
-                        value = enumValue;
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                        value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
-                        value = (T)Convert.ChangeType(kvp.Value, typeof(T));
+                        value = (T)Convert.ChangeType(kvp.Value, type);
 
                     return true;
                 }
@@ -65,21 +67,22 @@ namespace Prism.Common
         public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key)
         {
             List<T> values = new List<T>();
-
+            var type = typeof(T);
+            
             foreach (var kvp in parameters)
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
                     if (kvp.Value == null)
                         values.Add(default);
-                    else if (kvp.Value.GetType() == typeof(T))
+                    else if (kvp.Value.GetType() == type)
                         values.Add((T)kvp.Value);
-                    else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
+                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
-                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
-                        value.Add(enumValue);
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                        values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
-                        values.Add((T)Convert.ChangeType(kvp.Value, typeof(T)));
+                        values.Add((T)Convert.ChangeType(kvp.Value, type));
                 }
             }
 

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,6 +25,8 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                        return Enum.Parse(type, kvp.Value.ToString(), true);
                     else
                         return Convert.ChangeType(kvp.Value, type);
                 }
@@ -46,6 +48,8 @@ namespace Prism.Common
                         value = (T)kvp.Value;
                     else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
+                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
+                        value = enumValue;
                     else
                         value = (T)Convert.ChangeType(kvp.Value, typeof(T));
 
@@ -72,6 +76,8 @@ namespace Prism.Common
                         values.Add((T)kvp.Value);
                     else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
+                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
+                        value.Add(enumValue);
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, typeof(T)));
                 }


### PR DESCRIPTION


﻿## Description of Change

Currently if anyone try pass through a enum value as raw type(value or name) within INavigationParameters get an error of conversion, to solve this problem was included more conversion conditions.

### Bugs Fixed

- N/A

### API Changes

N/A


### PR Checklist

- [ ] Has tests
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard