### PR TITLE
Allow bind Enum values in IAutoInitialize ViewModels

### DIFF
--- a/Source/Prism.Tests/Mvvm/AutoInitializeViewModelFixture.cs
+++ b/Source/Prism.Tests/Mvvm/AutoInitializeViewModelFixture.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Prism.Common;
+using Xunit;
+
+namespace Prism.Tests.Mvvm
+{
+    internal class MockParameters : ParametersBase
+    {
+        public MockParameters() : base() { }
+        public MockParameters(string query) : base(query) { }
+    }
+
+    internal enum MockEnum
+    {
+        None = 0,
+        Foo = 1,
+        Bar = 2,
+        Fizz = 3
+    }
+
+    public class AutoInitializeViewModelFixture
+    {
+        [Fact]
+        public void TryGetValueOfT()
+        {
+            var parameters = new MockParameters("mock=Foo&mock2=1");
+            bool success = false;
+            MockEnum value = default;
+            MockEnum value1 = default;
+
+            var ex = Record.Exception(() => success = parameters.TryGetValue<MockEnum>("mock", out value));
+            var ex2 = Record.Exception(() => success = parameters.TryGetValue<MockEnum>("mock2", out value1));
+            Assert.Null(ex);
+            Assert.True(success);
+            Assert.Equal(MockEnum.Foo, value);
+            Assert.Equal(value, value1);
+        }
+
+        [Fact]
+        public void GetValuesOfT()
+        {
+            var parameters = new MockParameters("mock=Foo&mock=2&mock=Fizz");
+            bool success = false;
+            IEnumerable<MockEnum> values = default;
+
+            var ex = Record.Exception(() => values = parameters.GetValues<MockEnum>("mock"));
+            Assert.Null(ex);
+            Assert.Equal(3, values.Count());
+            Assert.Equal(MockEnum.Foo, values.ElementAt(0));
+            Assert.Equal(MockEnum.Bar, values.ElementAt(1));
+            Assert.Equal(MockEnum.Fizz, values.ElementAt(2));
+        }
+
+
+        [Fact]
+        public void GetValue()
+        {
+            var parameters = new MockParameters("mock=Foo&mock1=2&mock2=Fizz");
+            MockEnum value = default;
+            MockEnum value1 = default;
+
+            var ex = Record.Exception(() => value = parameters.GetValue<MockEnum>("mock"));
+            var ex2 = Record.Exception(() => value1 = parameters.GetValue<MockEnum>("mock1"));
+            Assert.Null(ex);
+            Assert.Equal(MockEnum.Foo, value);
+            Assert.Equal(MockEnum.Bar, value1);
+        }
+    }
+}

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,8 +25,8 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
-                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
-                        return Enum.Parse(type, kvp.Value.ToString());
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                        return Enum.Parse(type, kvp.Value.ToString(), true);
                     else
                         return Convert.ChangeType(kvp.Value, type);
                 }
@@ -50,8 +50,8 @@ namespace Prism.Common
                         value = (T)kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
-                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
-                        value = (T)Enum.Parse(type, kvp.Value.ToString());
+                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
+                        value = enumValue;
                     else
                         value = (T)Convert.ChangeType(kvp.Value, type);
 
@@ -79,8 +79,8 @@ namespace Prism.Common
                         values.Add((T)kvp.Value);
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
-                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
-                        values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
+                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
+                        value.Add(enumValue);
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, type));
                 }

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,7 +25,7 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
@@ -50,7 +50,7 @@ namespace Prism.Common
                         value = (T)kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
                         value = (T)Convert.ChangeType(kvp.Value, type);
@@ -79,7 +79,7 @@ namespace Prism.Common
                         values.Add((T)kvp.Value);
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, type));

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,6 +25,8 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
+                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                        return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
                 }
@@ -36,18 +38,22 @@ namespace Prism.Common
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool TryGetValue<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key, out T value)
         {
+            var type = typeof(T);
+
             foreach (var kvp in parameters)
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
                     if (kvp.Value == null)
                         value = default;
-                    else if (kvp.Value.GetType() == typeof(T))
+                    else if (kvp.Value.GetType() == type)
                         value = (T)kvp.Value;
-                    else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
+                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
+                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                        value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
-                        value = (T)Convert.ChangeType(kvp.Value, typeof(T));
+                        value = (T)Convert.ChangeType(kvp.Value, type);
 
                     return true;
                 }
@@ -61,6 +67,7 @@ namespace Prism.Common
         public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key)
         {
             List<T> values = new List<T>();
+            var type = typeof(T);   
 
             foreach (var kvp in parameters)
             {
@@ -68,12 +75,14 @@ namespace Prism.Common
                 {
                     if (kvp.Value == null)
                         values.Add(default);
-                    else if (kvp.Value.GetType() == typeof(T))
+                    else if (kvp.Value.GetType() == type)
                         values.Add((T)kvp.Value);
-                    else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
+                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
+                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                        values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
-                        values.Add((T)Convert.ChangeType(kvp.Value, typeof(T)));
+                        values.Add((T)Convert.ChangeType(kvp.Value, type));
                 }
             }
 

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -26,7 +26,7 @@ namespace Prism.Common
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
                     else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
-                        return Enum.Parse(type, kvp.Value.ToString(), true);
+                        return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
                 }
@@ -50,8 +50,8 @@ namespace Prism.Common
                         value = (T)kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
-                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
-                        value = enumValue;
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                        value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
                         value = (T)Convert.ChangeType(kvp.Value, type);
 
@@ -79,8 +79,8 @@ namespace Prism.Common
                         values.Add((T)kvp.Value);
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
-                    else if (type.IsEnum && Enum.TryParse<T>(kvp.Value, true, out var enumValue))
-                        value.Add(enumValue);
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value))
+                        values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, type));
                 }


### PR DESCRIPTION

﻿## Description of Change

Currently if anyone try pass through a enum value as raw type(value or name) within INavigationParameters get an error of conversion, to solve this problem was included more conversion conditions.

### Bugs Fixed

- N/A

### API Changes

N/A

### PR Checklist

- [x] Has tests
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard