### PR TITLE
Fills NavigationResult Exception for Navigations where CanNavigate is false

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -411,6 +411,69 @@ namespace Prism.Forms.Tests.Navigation
             Assert.True(viewModel.OnConfirmNavigationCalled);
             Assert.True(rootPage.Navigation.ModalStack.Count == 0);
         }
+        
+        [Fact]
+        public async void GoBack_ViewModelWithIConfirmNavigationFalse_ResultException()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage() {BindingContext = new ContentPageMockViewModel()};
+            ((IPageAware) navigationService).Page = rootPage;
+
+            var viewModel = rootPage.BindingContext as ContentPageMockViewModel;
+
+            var navParams = new NavigationParameters();
+            navParams.Add("canNavigate", false);
+
+            var navigationResult = await navigationService.GoBackAsync(navParams);
+
+            Assert.True(viewModel.OnConfirmNavigationCalled);
+            Assert.NotNull(navigationResult.Exception);
+            Assert.IsType<NavigationException>(navigationResult.Exception);
+            Assert.False(navigationResult.Success);
+            Assert.Equal(NavigationException.IConfirmNavigationReturnedFalse, navigationResult.Exception.Message);
+        }
+        
+        [Fact]
+        public async void GoBackToRoot_ViewModelWithIConfirmNavigationFalse_ResultException()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage() {BindingContext = new ContentPageMockViewModel()};
+            ((IPageAware) navigationService).Page = rootPage;
+
+            var viewModel = rootPage.BindingContext as ContentPageMockViewModel;
+
+            var navParams = new NavigationParameters();
+            navParams.Add("canNavigate", false);
+
+            var navigationResult = await navigationService.GoBackToRootAsync(navParams);
+
+            Assert.True(viewModel.OnConfirmNavigationCalled);
+            Assert.NotNull(navigationResult.Exception);
+            Assert.IsType<NavigationException>(navigationResult.Exception);
+            Assert.False(navigationResult.Success);
+            Assert.Equal(NavigationException.IConfirmNavigationReturnedFalse, navigationResult.Exception.Message);
+        }
+        
+        [Fact]
+        public async void NavigateAsync_ViewModelWithIConfirmNavigationFalse_ResultException()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage() {BindingContext = new ContentPageMockViewModel()};
+            ((IPageAware) navigationService).Page = rootPage;
+
+            var viewModel = rootPage.BindingContext as ContentPageMockViewModel;
+
+            var navParams = new NavigationParameters();
+            navParams.Add("canNavigate", false);
+
+            var navigationResult = await navigationService.NavigateAsync("ContentPage", navParams);
+
+            Assert.True(viewModel.OnConfirmNavigationCalled);
+            Assert.NotNull(navigationResult.Exception);
+            Assert.IsType<NavigationException>(navigationResult.Exception);
+            Assert.False(navigationResult.Success);
+            Assert.Equal(NavigationException.IConfirmNavigationReturnedFalse, navigationResult.Exception.Message);
+        }
 
         [Fact]
         public async void Navigate_ToNavigatonPage_ViewModelHasINavigationAware()

--- a/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs
@@ -694,7 +694,9 @@ namespace Prism.Navigation
 
             var canNavigate = await PageUtilities.CanNavigateAsync(fromPage, segmentParameters);
             if (!canNavigate)
-                return;
+            {
+                throw new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, toPage);
+            }
 
             await OnInitializedAsync(toPage, segmentParameters);
 


### PR DESCRIPTION
﻿## Description of Change

This makes `NavigationService.Push` return a `NavigationResult` with a `NavigationException` when the navigation is cancelled via `IConfirmNavigation`/`IConfirmNavigationAsync`'s `CanNavigate` method.

### Bugs Fixed

- Fixes #1912 

### API Changes

None

### Behavioral Changes

If a ViewModel tries to navigate and `CanNavigate` returns false, it will now return a `NavigationResult` with a `NavigationException` and `Success = false`. This makes `Push` consistent with the same behavior in `Back` and `BackToRoot`.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard