### PR TITLE
Allow mocking the method "SelectTabAsync"

### DIFF
--- a/Source/Xamarin/Prism.Forms/Navigation/INavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/INavigationService.cs
@@ -55,5 +55,12 @@ namespace Prism.Navigation
         /// <param name="name">The name of the target to navigate to.</param>
         /// <param name="parameters">The navigation parameters</param>
         Task<INavigationResult> NavigateAsync(string name, INavigationParameters parameters);
+
+        /// <summary>
+        /// Selects a Tab of the TabbedPage parent.
+        /// </summary>
+        /// <param name="name">The name of the tab to select</param>
+        /// <param name="parameters">The navigation parameters</param>
+        Task<INavigationResult> SelectTabAsync(string name, INavigationParameters parameters);
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/IPlatformNavigationService.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/IPlatformNavigationService.cs
@@ -12,5 +12,7 @@ namespace Prism.Navigation
         Task<INavigationResult> NavigateAsync(string name, INavigationParameters parameters, bool? useModalNavigation, bool animated);
 
         Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters, bool? useModalNavigation, bool animated);
+
+        Task<INavigationResult> SelectTabAsync(string name, INavigationParameters parameters);
     }
 }

--- a/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Navigation/TabbedPages/INavigationServiceExtensions.cs
@@ -1,7 +1,4 @@
-﻿using Prism.Common;
-using System;
-using System.Threading.Tasks;
-using Xamarin.Forms;
+﻿using System.Threading.Tasks;
 
 namespace Prism.Navigation.TabbedPages
 {
@@ -12,72 +9,9 @@ namespace Prism.Navigation.TabbedPages
         /// </summary>
         /// <param name="name">The name of the tab to select</param>
         /// <param name="parameters">The navigation parameters</param>
-        public static async Task<INavigationResult> SelectTabAsync(this INavigationService navigationService, string name, INavigationParameters parameters = null)
+        public static Task<INavigationResult> SelectTabAsync(this INavigationService navigationService, string name, INavigationParameters parameters = null)
         {
-            try
-            {
-                var currentPage = ((IPageAware)navigationService).Page;
-
-                var canNavigate = await PageUtilities.CanNavigateAsync(currentPage, parameters);
-                if (!canNavigate)
-                    throw new Exception($"IConfirmNavigation for {currentPage} returned false");
-
-                TabbedPage tabbedPage = null;
-
-                if (currentPage.Parent is TabbedPage parent)
-                {
-                    tabbedPage = parent;
-                }
-                else if (currentPage.Parent is NavigationPage navPage)
-                {
-                    if (navPage.Parent != null && navPage.Parent is TabbedPage parent2)
-                    {
-                        tabbedPage = parent2;
-                    }
-                }
-
-                if (tabbedPage == null)
-                    throw new Exception("No parent TabbedPage could be found");
-
-                var tabToSelectedType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(name));
-                if (tabToSelectedType is null)
-                    throw new Exception($"No View Type has been registered for '{name}'");
-
-                Page target = null;
-                foreach (var child in tabbedPage.Children)
-                {
-                    if (child.GetType() == tabToSelectedType)
-                    {
-                        target = child;
-                        break;
-                    }
-
-                    if (child is NavigationPage childNavPage)
-                    {
-                        if (childNavPage.CurrentPage.GetType() == tabToSelectedType || 
-                            childNavPage.RootPage.GetType() == tabToSelectedType)
-                        {
-                            target = child;
-                            break;
-                        }
-                    }
-                }
-
-                if (target is null)
-                    throw new Exception($"Could not find a Child Tab for '{name}'");
-
-                var tabParameters = UriParsingHelper.GetSegmentParameters(name, parameters);
-
-                tabbedPage.CurrentPage = target;
-                PageUtilities.OnNavigatedFrom(currentPage, tabParameters);
-                PageUtilities.OnNavigatedTo(target, tabParameters);
-            }
-            catch(Exception ex)
-            {
-                return new NavigationResult { Exception = ex };
-            }
-
-            return new NavigationResult { Success = true };
+            return ((IPlatformNavigationService)navigationService).SelectTabAsync(name, parameters);
         }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

The code contained within the extension method `Prism.Navigation.TabbedPages.INavigationServiceExtensions.SelectTabAsync(...)` has been moved to the page navigation service. Now, it is inside the public, virtual method `Prism.Navigation.PageNavigationService.SelectTabAsync(...)`.

**This change makes this method mockable and, therefore, testable**.

### Enhancement Implemented

- #1921: Unable to mock `SelectTabAsync` because it is an extension method.

### API Changes

Added:

- `Task<INavigationResult> INavigationService.SelectTabAsync(string name, INavigationParameters parameters)`
- `Task<INavigationResult> IPlatformNavigationService.SelectTabAsync(string name, INavigationParameters parameters)`

Removed:

- Nothing (even though its code has been moved, the extension method has been kept where it was).

### Behavioral Changes

None.

### PR Checklist

- [ ] Has tests (the code affected didn't already have tests, and it hasn't even been added or modified, but just moved)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard