### PR TITLE
Dialog service fixes

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Services/DialogServiceTests.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/DialogServiceTests.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Ioc;
+using Prism.Services.Dialogs;
+using Xunit;
+using Prism.Forms.Tests.Mocks;
+using Prism.Common;
+using Prism.Forms.Tests.Services.Mocks.Dialogs;
+using Xamarin.Forms;
+using Prism.Forms.Tests.Services.Mocks;
+using Prism.Services.Dialogs.Xaml;
+
+namespace Prism.Forms.Tests.Services
+{
+    public class DialogServiceTests
+    {
+        private const string DialogMockViewName = nameof(DialogMock);
+        private MockApplication _currentApp;
+
+        public DialogServiceTests()
+        {
+            Xamarin.Forms.Mocks.MockForms.Init();
+        }
+
+        [Fact]
+        public void DoesNotThrowExceptionWithNullParametersAndCallback()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            var ex = Record.Exception(() => dialogService.ShowDialog(DialogMockViewName));
+            Assert.Null(ex);
+            ex = Record.Exception(() => DialogMock.Current.ViewModel.SendRequestClose());
+            Assert.Null(ex);
+            _currentApp = null;
+        }
+
+        [Fact]
+        public void DoesNotThrowExceptionWithNullParameters()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            var ex = Record.Exception(() => dialogService.ShowDialog(DialogMockViewName, null, p => { }));
+            Assert.Null(ex);
+            ex = Record.Exception(() => DialogMock.Current.ViewModel.SendRequestClose());
+            Assert.Null(ex);
+            _currentApp = null;
+        }
+
+        [Fact]
+        public void DoesNotThrowExceptionWithNullCallback()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            var ex = Record.Exception(() => dialogService.ShowDialog(DialogMockViewName, new DialogParameters(), null));
+            Assert.Null(ex);
+            ex = Record.Exception(() => DialogMock.Current.ViewModel.SendRequestClose());
+            Assert.Null(ex);
+            _currentApp = null;
+        }
+
+        [Fact]
+        public void MainPageContentPreservedOnClose()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            dialogService.ShowDialog(DialogMockViewName);
+
+            Assert.IsType<ContentPage>(_currentApp.MainPage);
+            var mainPage = _currentApp.MainPage as ContentPage;
+            Assert.IsType<AbsoluteLayout>(mainPage.Content);
+            Assert.True((bool)mainPage.Content.GetValue(DialogService.IsPopupHostProperty));
+
+            DialogMock.Current.ViewModel.SendRequestClose();
+
+            Assert.IsType<Label>(mainPage.Content);
+            Assert.Equal("Hello World", ((Label)mainPage.Content).Text);
+        }
+
+        [Fact]
+        public void DefaultStyleAddedToCurrentApplication()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            dialogService.ShowDialog(DialogMockViewName);
+
+            Assert.True(_currentApp.Resources.ContainsKey(DialogService.PopupOverlayStyle));
+        }
+
+        [Fact]
+        public void CustomStyleUsedForMask()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            var style = new Style(typeof(BoxView));
+            DialogMock.ConstructorCallback = v => DialogLayout.SetMaskStyle(v, style);
+            dialogService.ShowDialog(DialogMockViewName);
+
+            var mainPage = _currentApp.MainPage as ContentPage;
+            var layout = mainPage.Content as AbsoluteLayout;
+            var mask = layout.Children[1];
+
+            Assert.Equal(style, mask.Style);
+        }
+
+        [Fact]
+        public void CanClosePreventsCallbackAndClose()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            bool didCallback = false;
+
+            dialogService.ShowDialog(DialogMockViewName, r => didCallback = true);
+
+            var vm = DialogMock.Current.ViewModel;
+            vm.CanClose = false;
+
+            vm.SendRequestClose();
+            Assert.False(didCallback);
+            var mainPage = _currentApp.MainPage as ContentPage;
+            Assert.IsType<AbsoluteLayout>(mainPage.Content);
+
+            vm.CanClose = true;
+            vm.SendRequestClose();
+            Assert.True(didCallback);
+            Assert.IsType<Label>(mainPage.Content);
+        }
+
+        [Fact]
+        public void IAutoInitializeSetsProperties()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            var title = "This message was set automagically";
+            dialogService.ShowDialog(DialogMockViewName, new DialogParameters { { "title", title } });
+
+            var dialog = DialogMock.Current;
+            Assert.Equal(title, dialog.ViewModel.Title);
+            var titleLabel = dialog.Children[1] as Label;
+            Assert.Equal(title, titleLabel.Text);
+        }
+
+        [Fact]
+        public void UseMaskFalseProhibitsMaskInsersion()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            DialogMock.ConstructorCallback = v => DialogLayout.SetUseMask(v, false);
+            dialogService.ShowDialog(DialogMockViewName);
+            DialogMock.ConstructorCallback = null;
+
+            var useMask = DialogLayout.GetUseMask(DialogMock.Current);
+            Assert.NotNull(useMask);
+            Assert.False(useMask.Value);
+            var mainPage = _currentApp.MainPage as ContentPage;
+            var layout = mainPage.Content as AbsoluteLayout;
+
+            Assert.Equal(2, layout.Children.Count);
+        }
+
+        [Fact]
+        public void UseMaskTrueDefaultMaskInsersion()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            DialogMock.ConstructorCallback = v => DialogLayout.SetUseMask(v, true);
+            dialogService.ShowDialog(DialogMockViewName);
+
+            var useMask = DialogLayout.GetUseMask(DialogMock.Current);
+            Assert.NotNull(useMask);
+            Assert.True(useMask.Value);
+            var mainPage = _currentApp.MainPage as ContentPage;
+            var layout = mainPage.Content as AbsoluteLayout;
+
+            Assert.Equal(3, layout.Children.Count);
+        }
+
+        [Fact]
+        public void CustomMaskIsInserted()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            var customMask = new Image();
+            DialogMock.ConstructorCallback = v => DialogLayout.SetMask(v, customMask);
+            dialogService.ShowDialog(DialogMockViewName);
+
+            var mainPage = _currentApp.MainPage as ContentPage;
+            var layout = mainPage.Content as AbsoluteLayout;
+
+            Assert.IsType<Image>(layout.Children[1]);
+        }
+
+        [Fact]
+        public void MaskDoesNotHaveDismissGestureByDefault()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            dialogService.ShowDialog(DialogMockViewName);
+
+            var mainPage = _currentApp.MainPage as ContentPage;
+            var layout = mainPage.Content as AbsoluteLayout;
+            var mask = layout.Children[1];
+
+            Assert.Empty(mask.GestureRecognizers);
+        }
+
+        [Fact]
+        public void MaskHasDismissGestureRecognizer()
+        {
+            SetMainPage();
+            var dialogService = CreateDialogService();
+            DialogMock.ConstructorCallback = v => DialogLayout.SetCloseOnBackgroundTapped(v, true);
+            dialogService.ShowDialog(DialogMockViewName);
+
+            var mainPage = _currentApp.MainPage as ContentPage;
+            var layout = mainPage.Content as AbsoluteLayout;
+            var mask = layout.Children[1];
+
+            Assert.Single(mask.GestureRecognizers);
+        }
+
+        private IDialogService CreateDialogService()
+        {
+            if(_currentApp is null)
+            {
+                _currentApp = new MockApplication();
+            }
+
+            DialogMock.ConstructorCallback = null;
+
+            return new DialogService(_currentApp, _currentApp.Container as IContainerExtension);
+        }
+
+        private void SetMainPage(Page page = null, bool resetApp = true)
+        {
+            if(resetApp)
+            {
+                _currentApp = null;
+            }
+
+            if (_currentApp is null)
+            {
+                _currentApp = new MockApplication();
+            }
+
+            if (page is null)
+            {
+                page = new ContentPage
+                {
+                    Content = new Label { Text = "Hello World" }
+                };
+            }
+
+            _currentApp.MainPage = page;
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Dialogs/DialogMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Dialogs/DialogMock.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Services.Mocks.Dialogs
+{
+    public class DialogMock : StackLayout
+    {
+        public const string Message = "This is a Dialog";
+        public static DialogMock Current { get; private set; }
+        public DialogMockViewModel ViewModel => BindingContext as DialogMockViewModel;
+
+        internal static Action<View> ConstructorCallback { get; set; }
+
+        public DialogMock()
+        {
+            Current = this;
+            Children.Add(new Label { Text = Message });
+            var title = new Label();
+            title.SetBinding(Label.TextProperty, "Title");
+            Children.Add(title);
+            ConstructorCallback?.Invoke(this);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Dialogs/DialogMockViewModel.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Dialogs/DialogMockViewModel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Prism.AppModel;
+using Prism.Mvvm;
+using Prism.Services.Dialogs;
+
+namespace Prism.Forms.Tests.Services.Mocks.Dialogs
+{
+    public class DialogMockViewModel : BindableBase, IAutoInitialize, IDialogAware
+    {
+        private string _title;
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        public event Action<IDialogParameters> RequestClose;
+
+        public bool CanClose { get; set; } = true;
+
+        bool IDialogAware.CanCloseDialog() => CanClose;
+
+        void IDialogAware.OnDialogClosed()
+        {
+
+        }
+
+        void IDialogAware.OnDialogOpened(IDialogParameters parameters)
+        {
+
+        }
+
+        public void SendRequestClose(IDialogParameters parameters = null) => RequestClose(parameters);
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Ioc/DialogContainerExtension.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Ioc/DialogContainerExtension.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Prism.Ioc;
+
+namespace Prism.Forms.Tests.Services.Mocks.Ioc
+{
+    public class DialogContainerExtension : IContainerExtension
+    {
+        private readonly MockContainer _container = new MockContainer();
+
+        public void FinalizeExtension()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRegistered(Type type)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsRegistered(Type type, string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IContainerRegistry Register(Type from, Type to)
+        {
+            _container.Add(new TransientRegistration
+            {
+                ServiceType = from,
+                ImplementingType = to
+            });
+            return this;
+        }
+
+        public IContainerRegistry Register(Type from, Type to, string name)
+        {
+            _container.Add(new TransientRegistration
+            {
+                ServiceType = from,
+                ImplementingType = to,
+                Name = name
+            });
+            return this;
+        }
+
+        public IContainerRegistry RegisterInstance(Type type, object instance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IContainerRegistry RegisterInstance(Type type, object instance, string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IContainerRegistry RegisterSingleton(Type from, Type to)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IContainerRegistry RegisterSingleton(Type from, Type to, string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Resolve(Type type)
+        {
+            return _container.GetRegistration(type).Create();
+        }
+
+        public object Resolve(Type type, params (Type Type, object Instance)[] parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Resolve(Type type, string name)
+        {
+            return _container.GetRegistration(type, name).Create();
+        }
+
+        public object Resolve(Type type, string name, params (Type Type, object Instance)[] parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        private class MockContainer
+        {
+            private readonly IList<IRegistration> _registrations = new List<IRegistration>();
+
+            public void Add(IRegistration registration) => _registrations.Add(registration);
+
+            public IRegistration GetRegistration(Type type) =>
+                _registrations.FirstOrDefault(x => x.ServiceType == type && string.IsNullOrEmpty(x.Name));
+
+            public IRegistration GetRegistration(Type type, string name) =>
+                _registrations.FirstOrDefault(x => x.ServiceType == type && x.Name == name);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Ioc/IRegistration.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Ioc/IRegistration.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Prism.Forms.Tests.Services.Mocks.Ioc
+{
+    public interface IRegistration
+    {
+        Type ServiceType { get; }
+        string Name { get; }
+        object Create();
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Ioc/TransientRegistration.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/Ioc/TransientRegistration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Prism.Forms.Tests.Services.Mocks.Ioc
+{
+    public class TransientRegistration : IRegistration
+    {
+        public Type ServiceType { get; set; }
+        public Type ImplementingType { get; set; }
+        public string Name { get; set; }
+
+        public object Create() => Activator.CreateInstance(ImplementingType ?? ServiceType);
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/MockApplication.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Services/Mocks/MockApplication.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Prism.Common;
+using Prism.Forms.Tests.Mocks;
+using Prism.Forms.Tests.Services.Mocks.Dialogs;
+using Prism.Forms.Tests.Services.Mocks.Ioc;
+using Prism.Ioc;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Tests.Services.Mocks
+{
+    public class MockApplication : Application, IApplicationProvider
+    {
+        public MockApplication()
+        {
+            Container = new DialogContainerExtension();
+            RegisterTypes(Container);
+        }
+
+        public IContainerExtension Container { get; }
+
+        private void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+            containerRegistry.RegisterDialog<DialogMock, DialogMockViewModel>();
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -1,4 +1,4 @@
-﻿using Prism.AppModel;
+using Prism.AppModel;
 using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
@@ -287,10 +287,10 @@ namespace Prism.Services.Dialogs
             var relativeHeight = DialogLayout.GetRelativeHeightRequest(popupView);
             if (relativeHeight != null)
             {
-                popupContainer.SetBinding(DialogContainer.WidthRequestProperty,
+                popupContainer.SetBinding(DialogContainer.HeightRequestProperty,
                     new Binding("Height",
                                 BindingMode.OneWay,
-                                new RelativeContentSizeConverter { RelativeSize = relativeWidth.Value },
+                                new RelativeContentSizeConverter { RelativeSize = relativeHeight.Value },
                                 source: currentPage));
             }
 

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -46,14 +46,14 @@ namespace Prism.Services.Dialogs
                         }
 
                         dialogAware.RequestClose -= DialogAware_RequestClose;
-                        callback(result);
+                        callback?.Invoke(result);
                         GC.Collect();
                     }
                     catch(DialogException dex)
                     {
                         if(dex.Message != DialogException.CanCloseIsFalse)
                         {
-                            callback(new DialogResult
+                            callback?.Invoke(new DialogResult
                             {
                                 Exception = dex,
                                 Parameters = parameters
@@ -62,7 +62,7 @@ namespace Prism.Services.Dialogs
                     }
                     catch (Exception ex)
                     {
-                        callback(new DialogResult
+                        callback?.Invoke(new DialogResult
                         {
                             Exception = ex,
                             Parameters = parameters
@@ -87,7 +87,7 @@ namespace Prism.Services.Dialogs
             catch (Exception ex)
             {
                 var error = ex.ToString();
-                callback(new DialogResult { Exception = ex });
+                callback?.Invoke(new DialogResult { Exception = ex });
             }
         }
 

--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -1,4 +1,4 @@
-using Prism.AppModel;
+﻿using Prism.AppModel;
 using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
@@ -301,7 +301,7 @@ namespace Prism.Services.Dialogs
             AbsoluteLayout.SetLayoutBounds(popupContainer, popupBounds);
             overlay.Children.Add(content);
 
-            if(DialogLayout.GetUseMask(popupContainer) ?? true)
+            if (DialogLayout.GetUseMask(popupContainer.Content) ?? true)
             {
                 overlay.Children.Add(mask);
             }
@@ -338,7 +338,7 @@ namespace Prism.Services.Dialogs
             return overlayStyle;
         }
 
-        private static readonly BindableProperty IsPopupHostProperty =
+        internal static readonly BindableProperty IsPopupHostProperty =
             BindableProperty.CreateAttached("IsPopupHost", typeof(bool), typeof(DialogService), false);
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Fixes a few bugs and adding overdue tests for DialogService. Note that layout specific tests could not be added for Relative Height/Width as we would have to generate some renderers for the test harness to get it to actually do a proper layout.

### Bugs Fixed

- Fixes #1894 Relative Height bug from some copy paste
- Fixes #1883 Null callback action would generate NullReferenceException
- Fixes issue with UseMask property being evaluated on the wrong element

### API Changes

none

### Behavioral Changes

none

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard