### PR TITLE
Open generic pages and double tabs navigation

### DIFF
--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -303,10 +303,10 @@ namespace Prism.Common
                     navigationPage = navParent;
                     return true;
                 }
-                else if ((page.Parent is TabbedPage || page.Parent is CarouselPage) && page.Parent?.Parent is NavigationPage navigationParent)
+                else if ((page.Parent is TabbedPage || page.Parent is CarouselPage) && (page.Parent?.Parent is TabbedPage ? page.Parent?.Parent?.Parent : page.Parent?.Parent) is NavigationPage navigationParent)
                 {
                     navigationPage = navigationParent;
-                    return true;
+                    return true; 
                 }
             }
 

--- a/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
+++ b/Source/Xamarin/Prism.Forms/Common/PageUtilities.cs
@@ -303,10 +303,10 @@ namespace Prism.Common
                     navigationPage = navParent;
                     return true;
                 }
-                else if ((page.Parent is TabbedPage || page.Parent is CarouselPage) && (page.Parent?.Parent is TabbedPage ? page.Parent?.Parent?.Parent : page.Parent?.Parent) is NavigationPage navigationParent)
+                else if ((page.Parent is TabbedPage || page.Parent is CarouselPage) && page.Parent?.Parent is NavigationPage navigationParent)
                 {
                     navigationPage = navigationParent;
-                    return true; 
+                    return true;
                 }
             }
 

--- a/Source/Xamarin/Prism.Forms/Ioc/TypeAutoLoadExtensions.cs
+++ b/Source/Xamarin/Prism.Forms/Ioc/TypeAutoLoadExtensions.cs
@@ -15,7 +15,7 @@ namespace Prism.Ioc
             var regAttr = type.GetCustomAttribute<AutoRegisterForNavigationAttribute>();
             var assembly = type.Assembly;
 
-            var viewTypes = assembly.ExportedTypes.Where(t => t.IsSubclassOf(typeof(Page)));
+            var viewTypes = assembly.ExportedTypes.Where(t => t.IsSubclassOf(typeof(Page)) && !t.GetTypeInfo().IsGenericTypeDefinition && !t.GetTypeInfo().ContainsGenericParameters);
             RegisterViewsAutomatically(containerRegistry, viewTypes);
         }
 


### PR DESCRIPTION
﻿## Description of Change

Sometimes, we need to define some generic abstract classes. This could be the case for ContentPage like:
        
      MyAbstractContentPage<TOtherClass> : ContentPage where TOtherClass : IWhateverInterface

and then:

      MyContentPage : MyAbstractContentPage<MyOtherClass>

The problem is using AutoRegisterForNavigation attribute try to register MyAbstractContentPage<TOtherClass> and fails with container exception about registering open generic.
So I just added some filters on registration to ignore open generic classes.

### Bugs Fixed

- AutoRegisterForNavigation attribute throw a container registration exception when using generic page class in project

### API Changes

Changed:

- var viewTypes = assembly.ExportedTypes.Where(t => t.IsSubclassOf(typeof(Page))); 
=> 
var viewTypes = assembly.ExportedTypes.Where(t => t.IsSubclassOf(typeof(Page)) && !t.GetTypeInfo().IsGenericTypeDefinition && !t.GetTypeInfo().ContainsGenericParameters);

### Behavioral Changes

Unchanged

### PR Checklist

- [ ] Has tests
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard