### PR TITLE
Maintain Binding Context for Dialogs

### DIFF
--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -1,4 +1,4 @@
-﻿using Prism.AppModel;
+using Prism.AppModel;
 using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
@@ -257,6 +257,7 @@ namespace Prism.Services.Dialogs
             var overlay = new AbsoluteLayout();
             overlay.SetValue(IsPopupHostProperty, true);
             var existingContent = currentPage.Content;
+            existingContent.BindingContext = currentPage.BindingContext;
             var content = new DialogContainer
             {
                 Padding = currentPage.Padding,


### PR DESCRIPTION
﻿## Description of Change

While this shouldn't theoretically be an issue, this ensures we set the Binding Context of the Page Content to the Binding Context of the Page before we update the Page's content to display a Dialog.

### Bugs Fixed

- fixes #1948 

### API Changes

none

### Behavioral Changes

shouldn't be any changes

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard