### PR TITLE
Adding Enum support from QueryStrings

### DIFF
--- a/Source/Prism.Tests/Common/Mocks/MockEnum.cs
+++ b/Source/Prism.Tests/Common/Mocks/MockEnum.cs
@@ -1,0 +1,11 @@
+﻿namespace Prism.Tests.Common.Mocks
+{
+    internal enum MockEnum
+    {
+        None = 0,
+        Foo = 1,
+        Bar = 2,
+        Fizz = 3,
+        SomethingElse = 99
+    }
+}

--- a/Source/Prism.Tests/Common/Mocks/MockParameters.cs
+++ b/Source/Prism.Tests/Common/Mocks/MockParameters.cs
@@ -1,0 +1,10 @@
+﻿using Prism.Common;
+
+namespace Prism.Tests.Common.Mocks
+{
+    internal class MockParameters : ParametersBase
+    {
+        public MockParameters() : base() { }
+        public MockParameters(string query) : base(query) { }
+    }
+}

--- a/Source/Prism.Tests/Common/ParametersFixture.cs
+++ b/Source/Prism.Tests/Common/ParametersFixture.cs
@@ -1,25 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Prism.Common;
+using Prism.Tests.Common.Mocks;
 using Xunit;
 
-namespace Prism.Tests.Mvvm
+namespace Prism.Tests.Common
 {
-    internal class MockParameters : ParametersBase
-    {
-        public MockParameters() : base() { }
-        public MockParameters(string query) : base(query) { }
-    }
-
-    internal enum MockEnum
-    {
-        None = 0,
-        Foo = 1,
-        Bar = 2,
-        Fizz = 3
-    }
-
-    public class AutoInitializeViewModelFixture
+    public class ParametersFixture
     {
         [Fact]
         public void TryGetValueOfT()
@@ -41,7 +27,7 @@ namespace Prism.Tests.Mvvm
         public void GetValuesOfT()
         {
             var parameters = new MockParameters("mock=Foo&mock=2&mock=Fizz");
-            bool success = false;
+
             IEnumerable<MockEnum> values = default;
 
             var ex = Record.Exception(() => values = parameters.GetValues<MockEnum>("mock"));

--- a/Source/Prism.Tests/Mvvm/AutoInitializeViewModelFixture.cs
+++ b/Source/Prism.Tests/Mvvm/AutoInitializeViewModelFixture.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Prism.Common;
+using Xunit;
+
+namespace Prism.Tests.Mvvm
+{
+    internal class MockParameters : ParametersBase
+    {
+        public MockParameters() : base() { }
+        public MockParameters(string query) : base(query) { }
+    }
+
+    internal enum MockEnum
+    {
+        None = 0,
+        Foo = 1,
+        Bar = 2,
+        Fizz = 3
+    }
+
+    public class AutoInitializeViewModelFixture
+    {
+        [Fact]
+        public void TryGetValueOfT()
+        {
+            var parameters = new MockParameters("mock=Foo&mock2=1");
+            bool success = false;
+            MockEnum value = default;
+            MockEnum value1 = default;
+
+            var ex = Record.Exception(() => success = parameters.TryGetValue<MockEnum>("mock", out value));
+            var ex2 = Record.Exception(() => success = parameters.TryGetValue<MockEnum>("mock2", out value1));
+            Assert.Null(ex);
+            Assert.True(success);
+            Assert.Equal(MockEnum.Foo, value);
+            Assert.Equal(value, value1);
+        }
+
+        [Fact]
+        public void GetValuesOfT()
+        {
+            var parameters = new MockParameters("mock=Foo&mock=2&mock=Fizz");
+            bool success = false;
+            IEnumerable<MockEnum> values = default;
+
+            var ex = Record.Exception(() => values = parameters.GetValues<MockEnum>("mock"));
+            Assert.Null(ex);
+            Assert.Equal(3, values.Count());
+            Assert.Equal(MockEnum.Foo, values.ElementAt(0));
+            Assert.Equal(MockEnum.Bar, values.ElementAt(1));
+            Assert.Equal(MockEnum.Fizz, values.ElementAt(2));
+        }
+
+
+        [Fact]
+        public void GetValue()
+        {
+            var parameters = new MockParameters("mock=Foo&mock1=2&mock2=Fizz");
+            MockEnum value = default;
+            MockEnum value1 = default;
+
+            var ex = Record.Exception(() => value = parameters.GetValue<MockEnum>("mock"));
+            var ex2 = Record.Exception(() => value1 = parameters.GetValue<MockEnum>("mock1"));
+            Assert.Null(ex);
+            Assert.Equal(MockEnum.Foo, value);
+            Assert.Equal(MockEnum.Bar, value1);
+        }
+    }
+}

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,7 +25,7 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
-                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
@@ -50,7 +50,7 @@ namespace Prism.Common
                         value = (T)kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
-                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
                         value = (T)Convert.ChangeType(kvp.Value, type);
@@ -79,7 +79,7 @@ namespace Prism.Common
                         values.Add((T)kvp.Value);
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
-                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
                         values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
                         values.Add((T)Convert.ChangeType(kvp.Value, type));

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -19,16 +19,10 @@ namespace Prism.Common
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
-                    if (kvp.Value == null)
-                        return GetDefault(type);
-                    else if (kvp.Value.GetType() == type)
-                        return kvp.Value;
-                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
-                        return kvp.Value;
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
-                        return Enum.Parse(type, kvp.Value.ToString());
-                    else
-                        return Convert.ChangeType(kvp.Value, type);
+                    if(TryGetValueInternal(kvp, type, out var value))
+                        return value;
+
+                    throw new InvalidCastException($"Unable to convert the value of Type '{kvp.Value.GetType().FullName}' to '{type.FullName}' for the key '{key}' ");
                 }
             }
 
@@ -44,18 +38,9 @@ namespace Prism.Common
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
-                    if (kvp.Value == null)
-                        value = default;
-                    else if (kvp.Value.GetType() == type)
-                        value = (T)kvp.Value;
-                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
-                        value = (T)kvp.Value;
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
-                        value = (T)Enum.Parse(type, kvp.Value.ToString());
-                    else
-                        value = (T)Convert.ChangeType(kvp.Value, type);
-
-                    return true;
+                    var success = TryGetValueInternal(kvp, typeof(T), out object valueAsObject);
+                    value = (T)valueAsObject;
+                    return success;
                 }
             }
 
@@ -67,26 +52,60 @@ namespace Prism.Common
         public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key)
         {
             List<T> values = new List<T>();
-            var type = typeof(T);   
+            var type = typeof(T);
 
             foreach (var kvp in parameters)
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
-                    if (kvp.Value == null)
-                        values.Add(default);
-                    else if (kvp.Value.GetType() == type)
-                        values.Add((T)kvp.Value);
-                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
-                        values.Add((T)kvp.Value);
-                    else if (type.IsEnum && Enum.IsDefined(type, kvp.Value.ToString()))
-                        values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
-                    else
-                        values.Add((T)Convert.ChangeType(kvp.Value, type));
+                    TryGetValueInternal(kvp, type, out var value);
+                    values.Add((T)value);
                 }
             }
 
             return values.AsEnumerable();
+        }
+
+        private static bool TryGetValueInternal(KeyValuePair<string, object> kvp, Type type, out object value)
+        {
+            value = GetDefault(type);
+            var success = false;
+            if (kvp.Value == null)
+            {
+                success = true;
+            }
+            else if (kvp.Value.GetType() == type)
+            {
+                success = true;
+                value = kvp.Value;
+            }
+            else if (type.IsAssignableFrom(kvp.Value.GetType()))
+            {
+                success = true;
+                value = kvp.Value;
+            }
+            else if (type.IsEnum)
+            {
+                var valueAsString = kvp.Value.ToString();
+                if (Enum.IsDefined(type, valueAsString))
+                {
+                    success = true;
+                    value = Enum.Parse(type, valueAsString);
+                }
+                else if (int.TryParse(valueAsString, out var numericValue))
+                {
+                    success = true;
+                    value = Enum.ToObject(type, numericValue);
+                }
+            }
+
+            if (!success && type.GetInterface("System.IConvertible") != null)
+            {
+                success = true;
+                value = Convert.ChangeType(kvp.Value, type);
+            }
+
+            return success;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Source/Prism/Common/ParametersExtensions.cs
+++ b/Source/Prism/Common/ParametersExtensions.cs
@@ -25,6 +25,8 @@ namespace Prism.Common
                         return kvp.Value;
                     else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         return kvp.Value;
+                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                        return Enum.Parse(type, kvp.Value.ToString());
                     else
                         return Convert.ChangeType(kvp.Value, type);
                 }
@@ -36,18 +38,22 @@ namespace Prism.Common
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool TryGetValue<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key, out T value)
         {
+            var type = typeof(T);
+
             foreach (var kvp in parameters)
             {
                 if (string.Compare(kvp.Key, key, StringComparison.Ordinal) == 0)
                 {
                     if (kvp.Value == null)
                         value = default;
-                    else if (kvp.Value.GetType() == typeof(T))
+                    else if (kvp.Value.GetType() == type)
                         value = (T)kvp.Value;
-                    else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
+                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         value = (T)kvp.Value;
+                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                        value = (T)Enum.Parse(type, kvp.Value.ToString());
                     else
-                        value = (T)Convert.ChangeType(kvp.Value, typeof(T));
+                        value = (T)Convert.ChangeType(kvp.Value, type);
 
                     return true;
                 }
@@ -61,6 +67,7 @@ namespace Prism.Common
         public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key)
         {
             List<T> values = new List<T>();
+            var type = typeof(T);   
 
             foreach (var kvp in parameters)
             {
@@ -68,12 +75,14 @@ namespace Prism.Common
                 {
                     if (kvp.Value == null)
                         values.Add(default);
-                    else if (kvp.Value.GetType() == typeof(T))
+                    else if (kvp.Value.GetType() == type)
                         values.Add((T)kvp.Value);
-                    else if (typeof(T).IsAssignableFrom(kvp.Value.GetType()))
+                    else if (type.IsAssignableFrom(kvp.Value.GetType()))
                         values.Add((T)kvp.Value);
+                    else if (type.IsEnum && (Enum.IsDefined(type, kvp.Value.ToString()) || int.TryParse(kvp.Value.ToString(), out var enumValue) && Enum.IsDefined(type, enumValue)))
+                        values.Add((T)Enum.Parse(type, kvp.Value.ToString()));
                     else
-                        values.Add((T)Convert.ChangeType(kvp.Value, typeof(T)));
+                        values.Add((T)Convert.ChangeType(kvp.Value, type));
                 }
             }
 

--- a/Source/Xamarin/Prism.Forms.Tests/Mvvm/AutoInitializeFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mvvm/AutoInitializeFixture.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Common;
+using Prism.Forms.Tests.Mvvm.Mocks.ViewModels;
+using Prism.Navigation;
+using Xunit;
+
+namespace Prism.Forms.Tests.Mvvm
+{
+    public class AutoInitializeFixture
+    {
+        [Fact]
+        public void ThrowsAnExceptionWithoutRequiredParameter()
+        {
+            var vm = new AutoInitializedViewModelMock();
+            var parameters = new NavigationParameters("?foo=bar");
+            var ex = Record.Exception(() => PageUtilities.Abracadabra(vm, parameters));
+
+            Assert.NotNull(ex);
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Fact]
+        public void NoExceptionWhenTitleIsProvided()
+        {
+            var vm = new AutoInitializedViewModelMock();
+            var parameters = new NavigationParameters("?success=true&title=Hello");
+            var ex = Record.Exception(() => PageUtilities.Abracadabra(vm, parameters));
+
+            Assert.Null(ex);
+            Assert.Equal("Hello", vm.Title);
+        }
+
+        [Fact]
+        public void SetsBooleanFromQueryString()
+        {
+            var vm = new AutoInitializedViewModelMock();
+            var parameters = new NavigationParameters("?success=true&title=Hello");
+            var ex = Record.Exception(() => PageUtilities.Abracadabra(vm, parameters));
+
+            Assert.Null(ex);
+            Assert.True(vm.Success);
+        }
+
+        [Fact]
+        public void SetsDateTimeFromQueryString()
+        {
+            var vm = new AutoInitializedViewModelMock();
+            var parameters = new NavigationParameters("?someDate=July 11, 2019 08:00&title=Hello");
+            var ex = Record.Exception(() => PageUtilities.Abracadabra(vm, parameters));
+
+            Assert.Null(ex);
+            var expected = new DateTime(2019, 7, 11, 8, 0, 0);
+            Assert.Equal(expected, vm.SomeDate);
+        }
+
+        [Theory]
+        [InlineData("status=OK", MockHttpStatus.OK)]
+        [InlineData("status=201", MockHttpStatus.Created)]
+        [InlineData("status=500", (MockHttpStatus)500)]
+        public void SetsEnumFromQueryString(string queryString, MockHttpStatus status)
+        {
+            var vm = new AutoInitializedViewModelMock();
+            var parameters = new NavigationParameters($"?{queryString}&title=Hello");
+            var ex = Record.Exception(() => PageUtilities.Abracadabra(vm, parameters));
+
+            Assert.Null(ex);
+            Assert.Equal(status, vm.Status);
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mvvm/Mocks/ViewModels/AutoInitializedViewModelMock.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mvvm/Mocks/ViewModels/AutoInitializedViewModelMock.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Prism.AppModel;
+
+namespace Prism.Forms.Tests.Mvvm.Mocks.ViewModels
+{
+    public class AutoInitializedViewModelMock : IAutoInitialize
+    {
+        [AutoInitialize(true)]
+        public string Title { get; set; }
+
+        public bool Success { get; set; }
+
+        public DateTime SomeDate { get; set; }
+
+        public MockHttpStatus Status { get; set; }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mvvm/Mocks/ViewModels/MockHttpStatus.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mvvm/Mocks/ViewModels/MockHttpStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace Prism.Forms.Tests.Mvvm.Mocks.ViewModels
+{
+    public enum MockHttpStatus
+    {
+        Continue = 100,
+        OK = 200,
+        Created = 201,
+        MultipleChoices = 300
+    }
+}


### PR DESCRIPTION
## Description of Change

This is a rebased and fixed version of PR #1916. This adds tests both for ParametersBase and IAutoInitialize specifically. Be sure to note some of the behavior changes.

### Bugs Fixed

- no issue was created

### API Changes

none

### Behavioral Changes

Updates GetValue / TryGetValue from the ParametersBase. All Get Value methods now use a single internal TryGet method so that the conversion from the KeyValuePair's Value (which may be a string if it was from the QueryString) to whatever the requested type is will use the same exact logic. We now will be intentional in throwing an InvalidArgumentException when calling GetValue in the event that we could not convert the value to the requested type. 

This also fixes a very incorrect assumption that at the event you got to the end of our type conversion logic that the value must be convertible. This now ensures that if we get to the point that we want to try `Convert.ChangeType` that we first validate that it implements `IConvertible`

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard