### PR TITLE
Fixed CurrentEntry for views not in Journal

### DIFF
--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationJournalFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationJournalFixture.cs
@@ -7,7 +7,7 @@ using Prism.Regions;
 
 namespace Prism.Wpf.Tests.Regions
 {
-    
+
     public class RegionNavigationJournalFixture
     {
         [Fact]
@@ -453,10 +453,13 @@ namespace Prism.Wpf.Tests.Regions
             Uri uri3 = new Uri("Uri3", UriKind.Relative);
             RegionNavigationJournalEntry entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
 
+            Uri uri4 = new Uri("Uri4", UriKind.Relative);
+            RegionNavigationJournalEntry entry4 = new RegionNavigationJournalEntry() { Uri = uri4 };
+
             target.RecordNavigation(entry1, true);
             target.RecordNavigation(entry2, true);
             target.RecordNavigation(entry3, false);
-
+            target.RecordNavigation(entry4, true);
 
             mockNavigationTarget
                 .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<NavigationResult>>(), null))
@@ -467,18 +470,22 @@ namespace Prism.Wpf.Tests.Regions
             mockNavigationTarget
                 .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<NavigationResult>>(), null))
                 .Callback<Uri, Action<NavigationResult>, NavigationParameters>((u, c, n) => c(new NavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri4, It.IsAny<Action<NavigationResult>>(), null))
+                .Callback<Uri, Action<NavigationResult>, NavigationParameters>((u, c, n) => c(new NavigationResult(null, true)));
 
-            // Act
+            Assert.Equal(entry4, target.CurrentEntry);
+
             target.GoBack();
 
-            // Verify
-            Assert.False(target.CanGoBack);
+            Assert.True(target.CanGoBack);
             Assert.True(target.CanGoForward);
-            Assert.Same(entry1, target.CurrentEntry);
+            Assert.Same(entry2, target.CurrentEntry);
 
-            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<NavigationResult>>(), null), Times.Once());
-            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<NavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<NavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<NavigationResult>>(), null), Times.Once());
             mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<NavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri4, It.IsAny<Action<NavigationResult>>(), null), Times.Never());
         }
     }
 }

--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationJournalFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationJournalFixture.cs
@@ -411,28 +411,32 @@ namespace Prism.Wpf.Tests.Regions
             Uri uri3 = new Uri("Uri3", UriKind.Relative);
             RegionNavigationJournalEntry entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
 
+            Uri uri4 = new Uri("Uri4", UriKind.Relative);
+            RegionNavigationJournalEntry entry4 = new RegionNavigationJournalEntry() { Uri = uri4 };
+
             target.RecordNavigation(entry1, true);
             target.RecordNavigation(entry2, true);
-            target.RecordNavigation(entry3, true);
 
             mockNavigationTarget
-                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<NavigationResult>>()))
-                .Callback<Uri, Action<NavigationResult>>((u, c) => c(new NavigationResult(null, true)));
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<NavigationResult>>(), null))
+                .Callback<Uri, Action<NavigationResult>, NavigationParameters>((u, c, n) => c(new NavigationResult(null, true)));
             mockNavigationTarget
-                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<NavigationResult>>()))
-                .Callback<Uri, Action<NavigationResult>>((u, c) => c(new NavigationResult(null, true)));
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<NavigationResult>>(), null))
+                .Callback<Uri, Action<NavigationResult>, NavigationParameters>((u, c, n) => c(new NavigationResult(null, true)));
             mockNavigationTarget
-                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<NavigationResult>>()))
-                .Callback<Uri, Action<NavigationResult>>((u, c) => c(new NavigationResult(null, true)));
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<NavigationResult>>(), null))
+                .Callback<Uri, Action<NavigationResult>, NavigationParameters>((u, c, n) => c(new NavigationResult(null, true)));
 
             target.GoBack();
 
-            // Act
-            target.RecordNavigation(new RegionNavigationJournalEntry() { Uri = new Uri("Uri4", UriKind.Relative) }, true);
+            Assert.True(target.CanGoForward);
 
+            // Act
+            target.RecordNavigation(entry3, true);
 
             // Verify
             Assert.False(target.CanGoForward);
+            Assert.Equal(entry3, target.CurrentEntry);
         }
 
         [Fact]

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationJournal.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationJournal.cs
@@ -117,13 +117,17 @@ namespace Prism.Regions
         {
             if (!this.isNavigatingInternal)
             {
-                if (this.CurrentEntry != null && persistInHistory)
+                if (this.CurrentEntry != null)
                 {
                     this.backStack.Push(this.CurrentEntry);
                 }
 
                 this.forwardStack.Clear();
-                this.CurrentEntry = entry;
+
+                if (persistInHistory)
+                    CurrentEntry = entry;
+                else
+                    CurrentEntry = null;
             }
         }
 

--- a/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
@@ -261,7 +261,7 @@ namespace Prism.Regions
                 journalEntry.Uri = navigationContext.Uri;
                 journalEntry.Parameters = navigationContext.Parameters;
 
-                bool persistInHistory = PersistInHistory(activeViews);
+                bool persistInHistory = PersistInHistory(view);
 
                 this.journal.RecordNavigation(journalEntry, persistInHistory);
 
@@ -280,13 +280,10 @@ namespace Prism.Regions
             }
         }
 
-        private static bool PersistInHistory(object[] activeViews)
+        private static bool PersistInHistory(object view)
         {
             bool persist = true;
-            if (activeViews.Length > 0)
-            {
-                MvvmHelpers.ViewAndViewModelAction<IJournalAware>(activeViews[0], ija => { persist &= ija.PersistInHistory(); });
-            }
+            MvvmHelpers.ViewAndViewModelAction<IJournalAware>(view, ija => { persist &= ija.PersistInHistory(); });
             return persist;
         }
 


### PR DESCRIPTION
﻿## Description of Change

Changed RegionNavigationJournal logic to properly handle the CurrentEntry for views no being added to the nav journal by using the IJournalAware

### Bugs Fixed

#1850 

### Behavioral Changes

The Journal.CurrentEntry does not get set to a view that is not persisted in the Journal

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard