### PR TITLE
Ensure Binding Context on Parameter refresh/update when using MarkupE…

### DIFF
--- a/Source/Xamarin/Prism.Forms/Xaml/ParameterExtension.cs
+++ b/Source/Xamarin/Prism.Forms/Xaml/ParameterExtension.cs
@@ -1,12 +1,30 @@
 ﻿using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Xaml.Internals;
 
 namespace Prism.Xaml
 {
     public class ParameterExtension : Parameter, IMarkupExtension<Parameter>
     {
-        public Parameter ProvideValue(IServiceProvider serviceProvider) =>
-            this;
+        public Parameter ProvideValue(IServiceProvider serviceProvider)
+        {
+            var target = serviceProvider.GetService<IProvideValueTarget>();
+            if (target != null && target.TargetObject is BindableObject bindableTargetObject)
+            {
+                var self = this;
+                bindableTargetObject.BindingContextChanged -= BindingContextChanged;
+                bindableTargetObject.BindingContextChanged += BindingContextChanged;
+
+                void BindingContextChanged(object parentObject, EventArgs args)
+                {
+                    var parent = (BindableObject)parentObject;
+                    self.BindingContext = parent?.BindingContext;
+                }
+            }
+        
+            return this;
+        }
 
         object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) =>
             ProvideValue(serviceProvider);


### PR DESCRIPTION
﻿## Description of Change

As described in issue #1917 I ran into the issue with a enhanced listview which resorts items and causes the Binding Context on elements to change. These changed Binding Contexts where not propagated through the Parameter markup extension.
This fix ensures if the Binding Context of the BindingObject in which the Parameter extension is used has changed that the Parameter Binding Context will also be updated.

### Bugs Fixed

- Fixes #1917 

### API Changes

None

### Behavioral Changes

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x ] Rebased on top of master at time of PR
- [x ] Changes adhere to coding standard