### PR TITLE
added support for multiple dialog windows

### DIFF
--- a/Sandbox/Wpf/HelloWorld/HelloWorld/App.xaml.cs
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/App.xaml.cs
@@ -25,7 +25,8 @@ namespace HelloWorld
             containerRegistry.RegisterDialog<ConfirmationDialog, ConfirmationDialogViewModel>();
 
             //register a custom window host
-            //containerRegistry.RegisterDialogWindow<CustomDialogWindow>();
+            containerRegistry.RegisterDialogWindow<CustomDialogWindow>();
+            containerRegistry.RegisterDialogWindow<AnotherDialogWindow>(nameof(AnotherDialogWindow));
         }
     }
 }

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/AnotherDialogWindow.xaml
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/AnotherDialogWindow.xaml
@@ -1,10 +1,12 @@
-﻿<Window x:Class="HelloWorld.Dialogs.CustomDialogWindow"
+﻿<Window x:Class="HelloWorld.Dialogs.AnotherDialogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:HelloWorld.Dialogs"
         mc:Ignorable="d"
-        Title="Custom Dialog Window" Height="450" Width="800" Background="Red">
-
+        Title="AnotherDialogWindow" Height="450" Width="800" Background="Green">
+    <Grid>
+        
+    </Grid>
 </Window>

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/AnotherDialogWindow.xaml.cs
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/AnotherDialogWindow.xaml.cs
@@ -1,0 +1,30 @@
+﻿using Prism.Services.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace HelloWorld.Dialogs
+{
+    /// <summary>
+    /// Interaction logic for AnotherDialogWindow.xaml
+    /// </summary>
+    public partial class AnotherDialogWindow : Window, IDialogWindow
+    {
+        public AnotherDialogWindow()
+        {
+            InitializeComponent();
+        }
+
+        public IDialogResult Result { get; set; }
+    }
+}

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/NotificationDialog.xaml
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Dialogs/NotificationDialog.xaml
@@ -4,6 +4,16 @@
              xmlns:prism="http://prismlibrary.com/"
              prism:ViewModelLocator.AutoWireViewModel="True"
              Width="300" Height="150">
+
+    <prism:Dialog.WindowStyle>
+        <Style TargetType="Window">
+            <Setter Property="prism:Dialog.WindowStartupLocation" Value="CenterScreen" />
+            <Setter Property="ResizeMode" Value="NoResize"/>
+            <Setter Property="ShowInTaskbar" Value="False"/>
+            <Setter Property="SizeToContent" Value="WidthAndHeight"/>
+        </Style>
+    </prism:Dialog.WindowStyle>
+
     <Grid x:Name="LayoutRoot" Margin="5">
         <Grid.RowDefinitions>
             <RowDefinition />
@@ -11,6 +21,6 @@
         </Grid.RowDefinitions>
 
         <TextBlock Text="{Binding Message}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="0" TextWrapping="Wrap" />
-        <Button Command="{Binding CloseDialogCommand}" Content="OK" Width="75" Height="25" HorizontalAlignment="Right" Margin="0,10,0,0" Grid.Row="1" IsDefault="True" />
+        <Button Command="{Binding CloseDialogCommand}" CommandParameter="True" Content="OK" Width="75" Height="25" HorizontalAlignment="Right" Margin="0,10,0,0" Grid.Row="1" IsDefault="True" />
     </Grid>
 </UserControl>

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -60,9 +60,16 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Dialogs\AnotherDialogWindow.xaml.cs">
+      <DependentUpon>AnotherDialogWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\ViewA.xaml.cs">
       <DependentUpon>ViewA.xaml</DependentUpon>
     </Compile>
+    <Page Include="Dialogs\AnotherDialogWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Dialogs\ConfirmationDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/ViewModels/MainWindowViewModel.cs
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/ViewModels/MainWindowViewModel.cs
@@ -42,7 +42,7 @@ namespace HelloWorld.ViewModels
             var message = "This is a message that should be shown in the dialog.";
 
             //using the dialog service as-is
-            //_dialogService.ShowDialog("NotificationDialog", new DialogParameters($"message={message}"), r =>
+            //_dialogService.Show("NotificationDialog", new DialogParameters($"message={message}"), r =>
             //{
             //    if (r.Result == ButtonResult.None)
             //        Title = "Result is None";
@@ -67,7 +67,19 @@ namespace HelloWorld.ViewModels
             //        Title = "I Don't know what you did!?";
             //});
 
-            _dialogService.ShowConfirmation(message, r =>
+            //_dialogService.ShowConfirmation(message, r =>
+            //{
+            //    if (r.Result == ButtonResult.None)
+            //        Title = "Result is None";
+            //    else if (r.Result == ButtonResult.OK)
+            //        Title = "Result is OK";
+            //    else if (r.Result == ButtonResult.Cancel)
+            //        Title = "Result is Cancel";
+            //    else
+            //        Title = "I Don't know what you did!?";
+            //});
+
+            _dialogService.ShowNotificationInAnotherWindow(message, r =>
             {
                 if (r.Result == ButtonResult.None)
                     Title = "Result is None";
@@ -91,6 +103,11 @@ namespace HelloWorld.ViewModels
         public static void ShowConfirmation(this IDialogService dialogService, string message, Action<IDialogResult> callBack)
         {
             dialogService.ShowDialog("ConfirmationDialog", new DialogParameters($"message={message}"), callBack);
+        }
+
+        public static void ShowNotificationInAnotherWindow(this IDialogService dialogService, string message, Action<IDialogResult> callBack)
+        {
+            dialogService.ShowDialog("NotificationDialog", new DialogParameters($"message={message}"), callBack, "AnotherDialogWindow");
         }
     }
 }

--- a/Sandbox/Wpf/HelloWorld/HelloWorld/Views/MainWindow.xaml
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/Views/MainWindow.xaml
@@ -11,10 +11,10 @@
             <RowDefinition Height="auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <!--<Button Command="{Binding ShowDialogCommand}" Content="Show Dialog" />-->
+        <Button Command="{Binding ShowDialogCommand}" Content="Show Dialog" />
         <!--<ContentControl prism:RegionManager.RegionName="ContentRegion" />-->
-        <Button Command="{Binding NavigateCommand}" CommandParameter="{x:Static local:App.ViewAName}">Navigate to Named View</Button>
-        <TabControl Grid.Row="1" prism:RegionManager.RegionName="ContentRegion" />
+        <!--<Button Command="{Binding NavigateCommand}" CommandParameter="{x:Static local:App.ViewAName}">Navigate to Named View</Button>
+        <TabControl Grid.Row="1" prism:RegionManager.RegionName="ContentRegion" />-->
         
     </Grid>
 </Window>

--- a/Source/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
+++ b/Source/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
@@ -39,6 +39,17 @@ namespace Prism.Ioc
         }
 
         /// <summary>
+        /// Registers an object that implements IDialogWindow to be used to host all dialogs in the IDialogService.
+        /// </summary>
+        /// <typeparam name="TWindow">The Type of the Window class that will be used to host dialogs in the IDialogService</typeparam>
+        /// <param name="containerRegistry"></param>
+        /// <param name="name">The name of the dialog window</param>
+        public static void RegisterDialogWindow<TWindow>(this IContainerRegistry containerRegistry, string name) where TWindow : Services.Dialogs.IDialogWindow
+        {
+            containerRegistry.Register(typeof(Services.Dialogs.IDialogWindow), typeof(TWindow), name);
+        }
+
+        /// <summary>
         /// Registers an object for navigation
         /// </summary>
         /// <param name="containerRegistry"></param>

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
@@ -21,14 +21,24 @@ namespace Prism.Services.Dialogs
             ShowDialogInternal(name, parameters, callback, false);
         }
 
+        public void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName)
+        {
+            ShowDialogInternal(name, parameters, callback, false, windowName);
+        }
+
         public void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback)
         {
             ShowDialogInternal(name, parameters, callback, true);
         }
 
-        void ShowDialogInternal(string name, IDialogParameters parameters, Action<IDialogResult> callback, bool isModal)
+        public void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName)
         {
-            IDialogWindow dialogWindow = CreateDialogWindow();
+            ShowDialogInternal(name, parameters, callback, true, windowName);
+        }
+
+        void ShowDialogInternal(string name, IDialogParameters parameters, Action<IDialogResult> callback, bool isModal, string windowName = null)
+        {
+            IDialogWindow dialogWindow = CreateDialogWindow(windowName);
             ConfigureDialogWindowEvents(dialogWindow, callback);
             ConfigureDialogWindowContent(name, dialogWindow, parameters);
 
@@ -38,9 +48,12 @@ namespace Prism.Services.Dialogs
                 dialogWindow.Show();
         }
 
-        IDialogWindow CreateDialogWindow()
+        IDialogWindow CreateDialogWindow(string name)
         {
-            return _containerExtension.Resolve<IDialogWindow>();
+            if (string.IsNullOrWhiteSpace(name))
+                return _containerExtension.Resolve<IDialogWindow>();
+            else
+                return _containerExtension.Resolve<IDialogWindow>(name);
         }
 
         void ConfigureDialogWindowContent(string dialogName, IDialogWindow window, IDialogParameters parameters)

--- a/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogService.cs
+++ b/Source/Wpf/Prism.Wpf/Services/Dialogs/IDialogService.cs
@@ -13,11 +13,30 @@ namespace Prism.Services.Dialogs
         void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback);
 
         /// <summary>
+        /// Shows a non-modal dialog
+        /// </summary>
+        /// <param name="name">The name of the dialog to show</param>
+        /// <param name="parameters">The parameters to pass to the dialog</param>
+        /// <param name="callback">The action to perform when the dialog is closed.</param>
+        /// <param name="windowName">The name of the hosting window registered with the IContainerRegistry</param>
+        void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName);
+
+        /// <summary>
         /// Shows a modal dialog
         /// </summary>
         /// <param name="name">The name of the dialog to show</param>
         /// <param name="parameters">The parameters to pass to the dialog</param>
         /// <param name="callback">The action to perform when the dialog is closed.</param>
         void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback);
+
+
+        /// <summary>
+        /// Shows a modal dialog
+        /// </summary>
+        /// <param name="name">The name of the dialog to show</param>
+        /// <param name="parameters">The parameters to pass to the dialog</param>
+        /// <param name="callback">The action to perform when the dialog is closed.</param>
+        /// <param name="windowName">The name of the hosting window registered with the IContainerRegistry</param>
+        void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName);
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Added support for multiple dialog window hosts. Now when registering a dialog window to act as a dialog host, you can now specify a named dialog window. Using this name, you can then show a specific dialog window when calling `IDialogService.Show` or `IDialogService.ShowDialog`

First register your dialog window with a name:
```
containerRegistry.RegisterDialogWindow<AnotherDialogWindow>("myAwesomeDialogWindow");
```

Then to show you dialog window, provide the name in the `Show()` or `ShowDialog()` methods
```
_dialogService.Show("NotificationDialog", new DialogParameters($"message={message}"), r =>
{
    //handle result and parameters in callback
}, "myAwesomeDialogWindow");
```
### Issue Fixed

- #1903 

### API Changes

List all API changes here (or just put None), example:

Added:

- static void RegisterDialogWindow<TWindow>(this IContainerRegistry containerRegistry, string name)
- void Show(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName);
- void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName);

### Behavioral Changes

none

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard