### PR TITLE
removing unnecessary compiler directives

### DIFF
--- a/Source/Prism/Modularity/IModuleManager.cs
+++ b/Source/Prism/Modularity/IModuleManager.cs
@@ -20,12 +20,10 @@ namespace Prism.Modularity
         /// <param name="moduleName">Name of the module requested for initialization.</param>
         void LoadModule(string moduleName);
 
-#if NET45 || NETCOREAPP
         /// <summary>
         /// Raised repeatedly to provide progress as modules are downloaded.
         /// </summary>
         event EventHandler<ModuleDownloadProgressChangedEventArgs> ModuleDownloadProgressChanged;
-#endif
 
         /// <summary>
         /// Raised when a module is loaded or fails to load.

--- a/Source/Prism/Modularity/ModuleDownloadProgressChangedEventArgs.cs
+++ b/Source/Prism/Modularity/ModuleDownloadProgressChangedEventArgs.cs
@@ -1,5 +1,3 @@
-#if NET45 || NETCOREAPP3_0
-
 using System;
 using System.ComponentModel;
 
@@ -19,32 +17,28 @@ namespace Prism.Modularity
         public ModuleDownloadProgressChangedEventArgs(IModuleInfo moduleInfo, long bytesReceived, long totalBytesToReceive)
             : base(CalculateProgressPercentage(bytesReceived, totalBytesToReceive), null)
         {
-            if (moduleInfo == null)
-                throw new ArgumentNullException(nameof(moduleInfo));
-
-            this.ModuleInfo = moduleInfo;
-            this.BytesReceived = bytesReceived;
-            this.TotalBytesToReceive = totalBytesToReceive;
+            ModuleInfo = moduleInfo ?? throw new ArgumentNullException(nameof(moduleInfo));
+            BytesReceived = bytesReceived;
+            TotalBytesToReceive = totalBytesToReceive;
         }
 
         /// <summary>
         /// Getsthe module info.
         /// </summary>
         /// <value>The module info.</value>
-        public IModuleInfo ModuleInfo { get; private set; }
+        public IModuleInfo ModuleInfo { get; }
 
         /// <summary>
         /// Gets the bytes received.
         /// </summary>
         /// <value>The bytes received.</value>
-        public long BytesReceived { get; private set; }
+        public long BytesReceived { get; }
 
         /// <summary>
         /// Gets the total bytes to receive.
         /// </summary>
         /// <value>The total bytes to receive.</value>
-        public long TotalBytesToReceive { get; private set; }
-
+        public long TotalBytesToReceive { get; }
 
         private static int CalculateProgressPercentage(long bytesReceived, long totalBytesToReceive)
         {
@@ -54,8 +48,6 @@ namespace Prism.Modularity
             }
 
             return (int)((bytesReceived * 100L) / totalBytesToReceive);
-
         }
     }
 }
-#endif

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework) == 'net45' ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/Source/Prism/Prism.csproj
+++ b/Source/Prism/Prism.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <AssemblyName>Prism</AssemblyName>
     <PackageId>Prism.Core</PackageId>
     <DebugType>pdbonly</DebugType>
@@ -16,17 +16,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) Or $(TargetFramework) == 'net45' ">
+  <ItemGroup Condition=" $(TargetFramework) == 'net45' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-    <Compile Remove="**\*.Desktop.cs" />
-    <None Include="**\*.Desktop.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.net45.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.net45.cs
@@ -1,5 +1,3 @@
-#if NET45
-
 using Prism.Properties;
 using System;
 using System.Collections.Generic;
@@ -245,4 +243,3 @@ namespace Prism.Modularity
         }
     }
 }
-#endif

--- a/Source/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.netcore.cs
+++ b/Source/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.netcore.cs
@@ -1,5 +1,4 @@
-﻿#if NETCOREAPP3_0
-using Prism.Properties;
+﻿using Prism.Properties;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -209,4 +208,3 @@ namespace Prism.Modularity
         }
     }
 }
-#endif

--- a/Source/Wpf/Prism.Wpf/Mvvm/ViewModelLocator.cs
+++ b/Source/Wpf/Prism.Wpf/Mvvm/ViewModelLocator.cs
@@ -1,11 +1,6 @@
-
-
 using System.ComponentModel;
 using System.Windows;
 
-#if NETFX_CORE
-using Windows.UI.Xaml;
-#endif
 namespace Prism.Mvvm
 {
     /// <summary>
@@ -45,8 +40,7 @@ namespace Prism.Mvvm
         /// <param name="viewModel">The object to use as the DataContext for the View</param>
         static void Bind(object view, object viewModel)
         {
-            FrameworkElement element = view as FrameworkElement;
-            if (element != null)
+            if (view is FrameworkElement element)
                 element.DataContext = viewModel;
         }
     }

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -18,8 +18,18 @@ Prism.Wpf helps you more easily design and build rich, flexible, and easy to mai
     <None Remove="Services\Dialogs\DialogWindow.xaml" />
   </ItemGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+    <Compile Remove="**\*.netcore.cs" />
+    <None Include="**\*.netcore.cs" />
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcore')) ">
+    <Compile Remove="**\*.net45.cs" />
+    <None Include="**\*.net45.cs" />
+  </ItemGroup>
+
   <ItemGroup>
-    <Reference Condition=" '$(TargetFramework)' == 'net45' " Include="System.Configuration" />
     <Reference Include="System.Windows.Interactivity">
       <HintPath>..\System.Windows.Interactivity.dll</HintPath>
     </Reference>

--- a/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.DryIoc.Forms/PrismApplication.cs
@@ -9,9 +9,7 @@ using Prism.Navigation;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 
-#if !NETSTANDARD1_0
 [assembly: Xamarin.Forms.XmlnsDefinition("http://prismlibrary.com", "Prism.DryIoc")]
-#endif
 namespace Prism.DryIoc
 {
     /// <summary>
@@ -22,7 +20,7 @@ namespace Prism.DryIoc
         /// <summary>
         /// Initializes a new instance of PrismApplication using the default constructor
         /// </summary>
-        protected PrismApplication() 
+        protected PrismApplication()
             : base() { }
 
         /// <summary>

--- a/Source/Xamarin/Prism.Forms/Modularity/ModuleManager.cs
+++ b/Source/Xamarin/Prism.Forms/Modularity/ModuleManager.cs
@@ -22,12 +22,10 @@ namespace Prism.Modularity
         /// </summary>
         public event EventHandler<LoadModuleCompletedEventArgs> LoadModuleCompleted;
 
-#if NET45 || NETCOREAPP
         /// <summary>
         /// Not used by Prism.Forms
         /// </summary>
         public event EventHandler<ModuleDownloadProgressChangedEventArgs> ModuleDownloadProgressChanged;
-#endif
 
         /// <summary>
         /// The module initializer.

--- a/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
+++ b/Source/Xamarin/Prism.Forms/Prism.Forms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81;netcoreapp3.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81</TargetFrameworks>
     <Title>Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->

--- a/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
+++ b/Source/Xamarin/Prism.Unity.Forms/PrismApplication.cs
@@ -1,16 +1,7 @@
 ﻿using Prism.Ioc;
 using Unity;
-using System.Collections.Generic;
-#if __ANDROID__
-using System;
-using Prism.Logging;
-using Unity.Resolution;
-using Xamarin.Forms.Internals;
-#endif
 
-#if !NETSTANDARD1_0
 [assembly: Xamarin.Forms.XmlnsDefinition("http://prismlibrary.com", "Prism.Unity")]
-#endif
 namespace Prism.Unity
 {
     public abstract class PrismApplication : PrismApplicationBase
@@ -18,7 +9,7 @@ namespace Prism.Unity
         /// <summary>
         /// Initializes a new instance of PrismApplication using the default constructor
         /// </summary>
-        protected PrismApplication() 
+        protected PrismApplication()
             : base() { }
 
         /// <summary>


### PR DESCRIPTION
# Description

Removes compiler directives that were simply no longer needed.
Updates Prism.Wpf to compile by convention
  - Files named `{filename}.net45.cs` will compile for the net45 target but not the netcore target
  - Files named `{filename}.netcore.cs` will compile for the netcore target but not the net45 target