### PR TITLE
Ensure ModuleName is provided

### DIFF
--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BadInitializationModule.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BadInitializationModule.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class BadInitializationModule : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+            throw new Exception(nameof(OnInitialized));
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BadModule.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BadModule.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class BadModule : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+            throw new Exception(nameof(OnInitialized));
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+            throw new Exception(nameof(RegisterTypes));
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicCatalog.xaml
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicCatalog.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ModuleCatalog xmlns="http://prismlibrary.com"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:mock="clr-namespace:Prism.Forms.Tests.Mocks.Modules"
+               x:Class="Prism.Forms.Tests.Mocks.Modules.BasicCatalog">
+  <ModuleInfo ModuleType="{x:Type mock:ModuleA}"
+              ModuleName="ModuleATest" />
+  <ModuleInfo ModuleType="{x:Type mock:ModuleB}" />
+  <ModuleInfo ModuleType="{x:Type mock:ModuleC}"
+              ModuleName=""
+              InitializationMode="OnDemand" />
+</ModuleCatalog>

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicCatalog.xaml.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicCatalog.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Modularity;
+using Xamarin.Forms.Xaml;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class BasicCatalog : ModuleCatalog
+    {
+        public BasicCatalog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicDependencyCatalog.xaml
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicDependencyCatalog.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ModuleCatalog xmlns="http://prismlibrary.com"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:mock="clr-namespace:Prism.Forms.Tests.Mocks.Modules"
+               x:Class="Prism.Forms.Tests.Mocks.Modules.BasicDependencyCatalog">
+  <ModuleInfo ModuleType="{x:Type mock:ModuleA}"
+              InitializationMode="OnDemand">
+    <x:String>ModuleB</x:String>
+  </ModuleInfo>
+  <ModuleInfo ModuleType="{x:Type mock:ModuleB}"
+              InitializationMode="OnDemand" />
+  <ModuleInfo ModuleType="{x:Type mock:ModuleC}"
+              InitializationMode="OnDemand" />
+  <ModuleInfo ModuleType="{x:Type mock:MasterModule}"
+              InitializationMode="OnDemand" />
+</ModuleCatalog>

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicDependencyCatalog.xaml.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/BasicDependencyCatalog.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Modularity;
+using Xamarin.Forms.Xaml;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class BasicDependencyCatalog : ModuleCatalog
+    {
+        public BasicDependencyCatalog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/DependentModuleA.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/DependentModuleA.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class DependentModuleA : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/DependentModuleB.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/DependentModuleB.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class DependentModuleB : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/MasterModule.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/MasterModule.cs
@@ -1,0 +1,20 @@
+﻿using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    [ModuleDependency(nameof(DependentModuleA))]
+    [ModuleDependency(nameof(DependentModuleB))]
+    public class MasterModule : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/ModuleA.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/ModuleA.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class ModuleA : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/ModuleB.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/ModuleB.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class ModuleB : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/ModuleC.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Mocks/Modules/ModuleC.cs
@@ -1,0 +1,18 @@
+﻿using Prism.Ioc;
+using Prism.Modularity;
+
+namespace Prism.Forms.Tests.Mocks.Modules
+{
+    public class ModuleC : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+
+        }
+    }
+}

--- a/Source/Xamarin/Prism.Forms.Tests/Modularity/ModuleFixture.cs
+++ b/Source/Xamarin/Prism.Forms.Tests/Modularity/ModuleFixture.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Linq;
+using Prism.Forms.Tests.Mocks;
+using Prism.Forms.Tests.Mocks.Modules;
+using Prism.Modularity;
+using Xunit;
+
+namespace Prism.Forms.Tests.Modularity
+{
+    public class ModuleFixture
+    {
+        [Fact]
+        public void BasicCatalogHasThreeModules()
+        {
+            var catalog = new BasicCatalog();
+
+            Assert.Equal(3, catalog.Modules.Count());
+        }
+
+        [Fact]
+        public void ModuleAUsesCustomModuleName()
+        {
+            var catalog = new BasicCatalog();
+
+            Assert.Single(catalog.Modules, mi => mi.ModuleName == "ModuleATest");
+
+            var mi = catalog.Modules.First(x => x.ModuleName == "ModuleATest");
+
+            Assert.Equal(typeof(ModuleA), Type.GetType(mi.ModuleType));
+        }
+
+        [Fact]
+        public void ModuleBUsesTypeName()
+        {
+            var catalog = new BasicCatalog();
+
+            Assert.Contains(catalog.Modules, mi => mi.ModuleName == typeof(ModuleB).Name);
+        }
+
+        [Fact]
+        public void ModuleCUsesTypeNameNotExplicitEmptyString()
+        {
+            var catalog = new BasicCatalog();
+
+            Assert.Empty(catalog.Modules.Where(mi => string.IsNullOrEmpty(mi.ModuleName)));
+            Assert.Single(catalog.Modules, mi => mi.ModuleName == typeof(ModuleC).Name);
+        }
+
+        [Theory]
+        [InlineData("ModuleATest", InitializationMode.WhenAvailable)]
+        [InlineData("ModuleB", InitializationMode.WhenAvailable)]
+        [InlineData("ModuleC", InitializationMode.OnDemand)]
+        public void ModuleHasSpecifiedInitializationMode(string moduleName, InitializationMode mode)
+        {
+            var catalog = new BasicCatalog();
+            Assert.Single(catalog.Modules, mi => mi.ModuleName == moduleName && mi.InitializationMode == mode);
+        }
+
+        [Fact]
+        public void DependenciesAreSpecifiedInXaml()
+        {
+            var catalog = new BasicDependencyCatalog();
+
+            var mi = catalog.Modules.First(x => x.ModuleName == nameof(ModuleA));
+
+            Assert.Contains(mi.DependsOn, d => d == nameof(ModuleB));
+        }
+
+        [Fact]
+        public void DependsOnAttributeAddsDependencies()
+        {
+            var catalog = new BasicDependencyCatalog();
+
+            var mi = catalog.Modules.First(x => x.ModuleName == nameof(MasterModule));
+
+            Assert.Contains(mi.DependsOn, d => d == nameof(DependentModuleA));
+            Assert.Contains(mi.DependsOn, d => d == nameof(DependentModuleB));
+        }
+
+        [Fact]
+        public void BadModuleThrowsException()
+        {
+            var catalog = new ModuleCatalog();
+            catalog.AddModule<BadModule>();
+
+            var initializer = new ModuleInitializer(new PageNavigationContainerMock());
+            var manager = new ModuleManager(initializer, catalog);
+            manager.LoadModuleCompleted += OnModuleLoaded;
+            void OnModuleLoaded(object sender, LoadModuleCompletedEventArgs args)
+            {
+                Assert.Equal(nameof(BadModule), args.ModuleInfo.ModuleName);
+                Assert.NotNull(args.Error);
+                Assert.Equal(nameof(BadModule.RegisterTypes), args.Error.Message);
+                manager.LoadModuleCompleted -= OnModuleLoaded;
+            }
+            var ex = Record.Exception(() => manager.LoadModule(nameof(BadModule)));
+        }
+
+        [Fact]
+        public void BadInitializationModuleThrowsException()
+        {
+            var catalog = new ModuleCatalog();
+            catalog.AddModule<BadInitializationModule>();
+
+            var initializer = new ModuleInitializer(new PageNavigationContainerMock());
+            var manager = new ModuleManager(initializer, catalog);
+            manager.LoadModuleCompleted += OnModuleLoaded;
+            void OnModuleLoaded(object sender, LoadModuleCompletedEventArgs args)
+            {
+                Assert.Equal(nameof(BadInitializationModule), args.ModuleInfo.ModuleName);
+                Assert.NotNull(args.Error);
+                Assert.Equal(nameof(BadInitializationModule.OnInitialized), args.Error.Message);
+                manager.LoadModuleCompleted -= OnModuleLoaded;
+            }
+            var ex = Record.Exception(() => manager.LoadModule(nameof(BadInitializationModule)));
+        }
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

Ensures that ModuleName is not null/empty

### Bugs Fixed

- fixes #1989 

### API Changes

n/a

### Behavioral Changes

Prevents ModuleName from being null/empty 

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard