### PR TITLE
Enable Strong Name for Prism.DryIoc

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -20,7 +20,7 @@
     <IsUwpProject>$(MSBuildProjectName.Contains('Windows'))</IsUwpProject>
     <IsWpfProject>$(MSBuildProjectName.Contains('Wpf'))</IsWpfProject>
     <IsFormsProject>$(MSBuildProjectName.Contains('Forms'))</IsFormsProject>
-    <SignAssembly Condition=" ('$(IsCoreProject)' Or '$(IsWpfProject)') And !$(IsTestProject) And !$(MSBuildProjectName.Contains('DryIoc')) And !$(MSBuildProjectName.Contains('StructureMap')) ">True</SignAssembly>
+    <SignAssembly Condition=" ('$(IsCoreProject)' Or '$(IsWpfProject)') And !$(IsTestProject) ">True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)prism.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
     <DisableCorePublish Condition=" '$(DisableCorePublish)' == '' ">false</DisableCorePublish>

--- a/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
@@ -6,7 +6,6 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.DryIoc</RootNamespace>
     <PackageId>Prism.DryIoc</PackageId>
-    <SignAssembly>false</SignAssembly>
     <!--<Summary>DryIoc extensions for Prism.</Summary>-->
     <Description>Use these extensions to build Prism applications based on DryIoc.</Description>
     <PackageTags>prism;dryioc;mvvm;wpf;xaml</PackageTags>


### PR DESCRIPTION
﻿## Description of Change

Enables strong name assembly signing for Prism.DryIoc

### Bugs Fixed

- Fixes #2014

### API Changes

n/a

### Behavioral Changes

n/a

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard