### PR TITLE
Update to NetCoreApp3.1

### DIFF
--- a/Sandbox/Wpf/HelloWorld/HelloWorld/HelloWorld.csproj
+++ b/Sandbox/Wpf/HelloWorld/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <RootNamespace>HelloWorld</RootNamespace>
     <AssemblyName>HelloWorld</AssemblyName>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -61,7 +61,7 @@
     <DefineConstants>$(DefineConstants);__ANDROID__</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" $(IsPackable) ">
+  <ItemGroup Condition=" $(IsPackable) And '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/Prism.Tests/Prism.Tests.csproj
+++ b/Source/Prism.Tests/Prism.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/Wpf/Prism.DryIoc.Wpf.Tests/Prism.DryIoc.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.DryIoc.Wpf.Tests/Prism.DryIoc.Wpf.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.DryIoc</RootNamespace>
     <PackageId>Prism.DryIoc</PackageId>

--- a/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
+++ b/Source/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net47;net48;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.DryIoc</RootNamespace>
     <PackageId>Prism.DryIoc</PackageId>

--- a/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Prism.IocContainer.Wpf.Tests.Support.csproj
+++ b/Source/Wpf/Prism.IocContainer.Wpf.Tests.Support/Prism.IocContainer.Wpf.Tests.Support.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Wpf/Prism.Ninject.Wpf.Tests/Prism.Ninject.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Ninject.Wpf.Tests/Prism.Ninject.Wpf.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/Wpf/Prism.Ninject.Wpf/Prism.Ninject.Wpf.csproj
+++ b/Source/Wpf/Prism.Ninject.Wpf/Prism.Ninject.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageId>Prism.Ninject</PackageId>
     <RootNamespace>Prism.Ninject</RootNamespace>

--- a/Source/Wpf/Prism.Ninject.Wpf/Prism.Ninject.Wpf.csproj
+++ b/Source/Wpf/Prism.Ninject.Wpf/Prism.Ninject.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net47;net48;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageId>Prism.Ninject</PackageId>
     <RootNamespace>Prism.Ninject</RootNamespace>

--- a/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf.Tests/Prism.Unity.Wpf.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.Unity</RootNamespace>
     <PackageId>Prism.Unity</PackageId>

--- a/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
+++ b/Source/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net47;net48;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.Unity</RootNamespace>
     <PackageId>Prism.Unity</PackageId>

--- a/Source/Wpf/Prism.Wpf.Tests/Prism.Wpf.Tests.csproj
+++ b/Source/Wpf/Prism.Wpf.Tests/Prism.Wpf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFrameworks>net45;net47;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <!--<Summary>Prism libraries related to user interface composition, regions, and modularity for WPF.</Summary>-->
     <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.

--- a/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/Source/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFrameworks>net45;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;net47;net48;netcoreapp3.1</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <!--<Summary>Prism libraries related to user interface composition, regions, and modularity for WPF.</Summary>-->
     <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, Windows 10 UWP, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.

--- a/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>$(DefineConstants);DryIoc</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>

--- a/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);Unity</DefineConstants>
   </PropertyGroup>

--- a/Source/global.json
+++ b/Source/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.1.101"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.54"

--- a/Source/global.json
+++ b/Source/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.101"
+    "version": "3.1.100",
+    "rollForward": "latestMinor"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.54"


### PR DESCRIPTION
﻿## Description of Change

Updates Prism to require NetCoreApp3.1 instead of NetCoreApp3.0

### Bugs Fixed

- n/a

### API Changes

- n/a

### Behavioral Changes

n/a

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard