### PR TITLE
added RegisterViewWithRegion generic method

### DIFF
--- a/Source/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -285,6 +285,19 @@ namespace Prism.Regions
         /// will be added to the Views collection of the region
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <typeparam name="T">The type of the view to register</typeparam>
+        /// <returns>The regionmanager, for adding several views easily</returns>
+        public IRegionManager RegisterViewWithRegion<T>(string regionName)
+        {
+            return RegisterViewWithRegion(regionName, typeof(T));
+        }
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <param name="viewType">The type of the view to register with the </param>
         /// <returns>The regionmanager, for adding several views easily</returns>
         public IRegionManager RegisterViewWithRegion(string regionName, Type viewType)


### PR DESCRIPTION
﻿## Description of Change

Adds a generic method for the RegionManager.RegisterViewWithRegion method

### Bugs Fixed

- #2027 

### API Changes

Added:

`RegionManager.RegisterViewWithRegion<ViewA>("ContentRegion");`

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard