### PR TITLE
added RegiserMappings generic method

### DIFF
--- a/Source/Wpf/Prism.Wpf.Tests/Regions/RegionAdapterMappingsFixture.cs
+++ b/Source/Wpf/Prism.Wpf.Tests/Regions/RegionAdapterMappingsFixture.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using Xunit;
 using Prism.Regions;
 using Prism.Wpf.Tests.Mocks;
+using CommonServiceLocator;
 
 namespace Prism.Wpf.Tests.Regions
 {
@@ -24,6 +25,46 @@ namespace Prism.Wpf.Tests.Regions
 
             Assert.NotNull(returnedAdapter);
             Assert.Same(regionAdapter, returnedAdapter);
+        }
+
+        [Fact]
+        public void ShouldGetRegisteredMapping_UsingGenericControl()
+        {
+            var regionAdapterMappings = new RegionAdapterMappings();
+            var regionAdapter = new MockRegionAdapter();
+
+            regionAdapterMappings.RegisterMapping<ItemsControl>(regionAdapter);
+
+            var returnedAdapter = regionAdapterMappings.GetMapping<ItemsControl>();
+
+            Assert.NotNull(returnedAdapter);
+            Assert.Same(regionAdapter, returnedAdapter);
+        }
+
+        [Fact]
+        public void ShouldGetRegisteredMapping_UsingGenericControlAndAdapter()
+        {
+            try
+            {
+                var regionAdapterMappings = new RegionAdapterMappings();
+                var regionAdapter = new MockRegionAdapter();
+
+                ServiceLocator.SetLocatorProvider(() => new MockServiceLocator
+                    {
+                        GetInstance = t => regionAdapter
+                    });
+
+                regionAdapterMappings.RegisterMapping<ItemsControl, MockRegionAdapter>();
+
+                var returnedAdapter = regionAdapterMappings.GetMapping<ItemsControl>();
+
+                Assert.NotNull(returnedAdapter);
+                Assert.Same(regionAdapter, returnedAdapter);
+            }
+            finally
+            {
+                ServiceLocator.SetLocatorProvider(null);
+            }            
         }
 
         [Fact]
@@ -76,7 +117,6 @@ namespace Prism.Wpf.Tests.Regions
                 regionAdapterMappings.RegisterMapping(typeof(ItemsControl), regionAdapter);
                 regionAdapterMappings.RegisterMapping(typeof(ItemsControl), regionAdapter);
             });
-
         }
 
         [Fact]

--- a/Source/Wpf/Prism.Wpf/Regions/RegionAdapterMappings.cs
+++ b/Source/Wpf/Prism.Wpf/Regions/RegionAdapterMappings.cs
@@ -1,5 +1,3 @@
-
-
 using Prism.Properties;
 using System;
 using System.Collections.Generic;
@@ -37,6 +35,25 @@ namespace Prism.Regions
         }
 
         /// <summary>
+        /// Registers the mapping between a type and an adapter.
+        /// </summary>
+        /// <typeparam name="TControl">The type of the control</typeparam>
+        public void RegisterMapping<TControl>(IRegionAdapter adapter)
+        {
+            RegisterMapping(typeof(TControl), adapter);
+        }
+
+        /// <summary>
+        /// Registers the mapping between a type and an adapter.
+        /// </summary>
+        /// <typeparam name="TControl">The type of the control</typeparam>
+        /// <typeparam name="TAdapter">The type of the IRegionAdapter to use with the TControl</typeparam>
+        public void RegisterMapping<TControl, TAdapter>() where TAdapter : IRegionAdapter
+        {
+            RegisterMapping(typeof(TControl), (IRegionAdapter)CommonServiceLocator.ServiceLocator.Current.GetInstance(typeof(TAdapter)));
+        }
+
+        /// <summary>
         /// Returns the adapter associated with the type provided.
         /// </summary>
         /// <param name="controlType">The type to obtain the <see cref="IRegionAdapter"/> mapped.</param>
@@ -60,6 +77,21 @@ namespace Prism.Regions
                 currentType = currentType.BaseType;
             }
             throw new KeyNotFoundException(String.Format(CultureInfo.CurrentCulture, Resources.NoRegionAdapterException, controlType));
+        }
+
+        /// <summary>
+        /// Returns the adapter associated with the type provided.
+        /// </summary>
+        /// <typeparam name="T">The control type used to obtain the <see cref="IRegionAdapter"/> mapped.</typeparam>
+        /// <returns>The <see cref="IRegionAdapter"/> mapped to the <typeparamref name="T"/>.</returns>
+        /// <remarks>This class will look for a registered type for <typeparamref name="T"/> and if there is not any,
+        /// it will look for a registered type for any of its ancestors in the class hierarchy.
+        /// If there is no registered type for <typeparamref name="T"/> or any of its ancestors,
+        /// an exception will be thrown.</remarks>
+        /// <exception cref="KeyNotFoundException">When there is no registered type for <typeparamref name="T"/> or any of its ancestors.</exception>
+        public IRegionAdapter GetMapping<T>()
+        {
+            return GetMapping(typeof(T));
         }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Added generic method to the RegionAdapterMappings to simplify registering new adapters.

### Bugs Fixed

- #2026 

### API Changes

Added:

`regionAdapterMappings.RegisterMapping<StackPanel, StackPanelRegionAdapter>();`

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard