### PR TITLE
Update DialogService to support modal pages

### DIFF
--- a/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/Source/Xamarin/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -31,7 +31,7 @@ namespace Prism.Services.Dialogs
                 var view = CreateViewFor(UriParsingHelper.GetSegmentName(name));
 
                 var dialogAware = InitializeDialog(view, parameters);
-                var currentPage = GetCurrentPage();
+                var currentPage = GetCurrentContentPage();
 
                 dialogAware.RequestClose += DialogAware_RequestClose;
 
@@ -191,6 +191,24 @@ namespace Prism.Services.Dialogs
             }
 
             return dialog;
+        }
+        
+        private ContentPage GetCurrentContentPage()
+        {
+            var cp = GetCurrentPage();
+            var mp = TryGetModalPage(cp);
+            return mp ?? cp;
+        }
+
+        private ContentPage TryGetModalPage(ContentPage cp)
+        {
+            var mp = cp.Navigation.ModalStack.LastOrDefault();
+            if (mp != null)
+            {
+                return GetCurrentPage(mp);
+            }
+
+            return null;
         }
 
         private ContentPage GetCurrentPage(Page page = null)


### PR DESCRIPTION
﻿## Description of Change

The current solution does not support dialogs on modal pages, it opens dialog on last non-modal page, these changes search for the last modal page if it exists

### Bugs Fixed

- If current appeared page is a modal page, DialogService will open dialog on last non-modal page

### API Changes

List all API changes here (or just put None), example:

None

### Behavioral Changes

Dialogs could be opened on modal pages

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard