### PR TITLE
Added overload for IEventAggregator to provide filter

### DIFF
--- a/build/steps/prepare-build.yml
+++ b/build/steps/prepare-build.yml
@@ -3,11 +3,12 @@ parameters:
 
 steps:
 - task: UseDotNet@2
+  displayName: Use .NET 3.1
   inputs:
     packageType: 'sdk'
     useGlobalJson: true
 
-- task: NuGetToolInstaller@0
+- task: NuGetToolInstaller@1
   displayName: Use latest NuGet
   inputs:
     checkLatest: true

--- a/src/Prism.Core/Events/PubSubEvent.cs
+++ b/src/Prism.Core/Events/PubSubEvent.cs
@@ -154,6 +154,17 @@ namespace Prism.Events
         }
 
         /// <summary>
+        /// Subscribes a delegate to an event that will be published on the <see cref="ThreadOption.PublisherThread"/>
+        /// </summary>
+        /// <param name="action">The delegate that gets executed when the event is raised.</param>
+        /// <param name="filter">Filter to evaluate if the subscriber should receive the event.</param>
+        /// <returns>A <see cref="SubscriptionToken"/> that uniquely identifies the added subscription.</returns>
+        public virtual SubscriptionToken Subscribe(Action<TPayload> action, Predicate<TPayload> filter)
+        {
+            return Subscribe(action, ThreadOption.PublisherThread, false, filter);
+        }
+
+        /// <summary>
         /// Subscribes a delegate to an event.
         /// PubSubEvent will maintain a <see cref="WeakReference"/> to the Target of the supplied <paramref name="action"/> delegate.
         /// </summary>

--- a/tests/Prism.Core.Tests/Events/PubSubEventFixture.cs
+++ b/tests/Prism.Core.Tests/Events/PubSubEventFixture.cs
@@ -144,6 +144,24 @@ namespace Prism.Tests.Events
         }
 
         [Fact]
+        public void FilterEnablesActionTarget_Weak()
+        {
+            TestablePubSubEvent<string> pubSubEvent = new TestablePubSubEvent<string>();
+            var goodFilter = new MockFilter { FilterReturnValue = true };
+            var actionGoodFilter = new ActionHelper();
+            var badFilter = new MockFilter { FilterReturnValue = false };
+            var actionBadFilter = new ActionHelper();
+            pubSubEvent.Subscribe(actionGoodFilter.Action, goodFilter.FilterString);
+            pubSubEvent.Subscribe(actionBadFilter.Action, badFilter.FilterString);
+
+            pubSubEvent.Publish("test");
+
+            Assert.True(actionGoodFilter.ActionCalled);
+            Assert.False(actionBadFilter.ActionCalled);
+
+        }
+
+        [Fact]
         public void SubscribeDefaultsThreadOptionAndNoFilter()
         {
             TestablePubSubEvent<string> pubSubEvent = new TestablePubSubEvent<string>();


### PR DESCRIPTION
﻿## Description of Change

Add an overload to the event aggregation to provide the action and filter

### Bugs Fixed

- #2046 

### API Changes

Added:

`SubscriptionToken Subscribe(Action<TPayload> action, Predicate<TPayload> filter)`

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard