### PR TITLE
added Task extensions for async/void tasks

### DIFF
--- a/src/Prism.Core/Extensions/TaskExtensions.cs
+++ b/src/Prism.Core/Extensions/TaskExtensions.cs
@@ -1,0 +1,86 @@
+﻿namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Extension methods for the Task object.
+    /// </summary>
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <param name="task">The task to be awaited</param>
+        public static void Await(this Task task)
+        {
+            task.Await(null, null, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="configureAwait">Configures an awaiter used to await this task</param>
+        public static void Await(this Task task, bool configureAwait)
+        {
+            task.Await(null, null, configureAwait);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        public static void Await(this Task task, Action completedCallback)
+        {
+            task.Await(completedCallback, null, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
+        public static void Await(this Task task, Action completedCallback, Action<Exception> errorCallback)
+        {
+            task.Await(completedCallback, errorCallback, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
+        /// <param name="configureAwait">Configures an awaiter used to await this task</param>
+        public static void Await(this Task task, Action<Exception> errorCallback)
+        {
+            task.Await(null, errorCallback, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
+        /// <param name="configureAwait">Configures an awaiter used to await this task</param>
+        public async static void Await(this Task task, Action completedCallback, Action<Exception> errorCallback, bool configureAwait)
+        {
+            try
+            {
+                await task.ConfigureAwait(configureAwait);
+                completedCallback?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                errorCallback?.Invoke(ex);
+            }
+        }       
+    }
+}

--- a/src/Prism.Core/Extensions/TaskExtensions{T}.cs
+++ b/src/Prism.Core/Extensions/TaskExtensions{T}.cs
@@ -1,0 +1,90 @@
+﻿namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Extension methods for the Task object.
+    /// </summary>
+    public static class TaskExtensionsT
+    {
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="task">The task to be awaited</param>
+        public static void Await<T>(this Task<T> task)
+        {
+            task.Await<T>(null, null, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="configureAwait">Configures an awaiter used to await this task</param>
+        public static void Await<T>(this Task<T> task, bool configureAwait)
+        {
+            task.Await<T>(null, null, configureAwait);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        public static void Await<T>(this Task<T> task, Action<T> completedCallback)
+        {
+            task.Await<T>(completedCallback, null, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
+        public static void Await<T>(this Task<T> task, Action<T> completedCallback, Action<Exception> errorCallback)
+        {
+            task.Await<T>(completedCallback, errorCallback, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
+        public static void Await<T>(this Task<T> task, Action<Exception> errorCallback)
+        {
+            task.Await<T>(null, errorCallback, false);
+        }
+
+        /// <summary>
+        /// Awaits a task without blocking the main thread.
+        /// </summary>
+        /// <remarks>Primarily used to replace async void scenarios such as ctor's and ICommands.</remarks>
+        /// <typeparam name="T">The result type</typeparam>
+        /// <param name="task">The task to be awaited</param>
+        /// <param name="completedCallback">The action to perform when the task is complete.</param>
+        /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
+        /// <param name="configureAwait">Configures an awaiter used to await this task</param>
+        public async static void Await<T>(this Task<T> task, Action<T> completedCallback, Action<Exception> errorCallback, bool configureAwait)
+        {
+            try
+            {
+                T result = await task.ConfigureAwait(configureAwait);
+                completedCallback?.Invoke(result);
+            }
+            catch (Exception ex)
+            {
+                errorCallback?.Invoke(ex);
+            }
+        }
+    }
+}

--- a/src/Prism.Core/Extensions/TaskExtensions{T}.cs
+++ b/src/Prism.Core/Extensions/TaskExtensions{T}.cs
@@ -13,7 +13,7 @@
         /// <param name="task">The task to be awaited</param>
         public static void Await<T>(this Task<T> task)
         {
-            task.Await<T>(null, null, false);
+            task.Await(null, null, false);
         }
 
         /// <summary>
@@ -25,7 +25,7 @@
         /// <param name="configureAwait">Configures an awaiter used to await this task</param>
         public static void Await<T>(this Task<T> task, bool configureAwait)
         {
-            task.Await<T>(null, null, configureAwait);
+            task.Await(null, null, configureAwait);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@
         /// <param name="completedCallback">The action to perform when the task is complete.</param>
         public static void Await<T>(this Task<T> task, Action<T> completedCallback)
         {
-            task.Await<T>(completedCallback, null, false);
+            task.Await(completedCallback, null, false);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@
         /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
         public static void Await<T>(this Task<T> task, Action<T> completedCallback, Action<Exception> errorCallback)
         {
-            task.Await<T>(completedCallback, errorCallback, false);
+            task.Await(completedCallback, errorCallback, false);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@
         /// <param name="errorCallback">The action to perform when an error occurs executing the task.</param>
         public static void Await<T>(this Task<T> task, Action<Exception> errorCallback)
         {
-            task.Await<T>(null, errorCallback, false);
+            task.Await(null, errorCallback, false);
         }
 
         /// <summary>

--- a/tests/Prism.Core.Tests/Extensions/TaskExtensionsFixture.cs
+++ b/tests/Prism.Core.Tests/Extensions/TaskExtensionsFixture.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Prism.Core.Tests.Extensions
+{
+    public class TaskExtensionsFixture
+    {
+        [Fact]
+        public void TaskIsCompleted()
+        {
+            var sus = new SystemUnderTest();
+
+            Assert.False(sus.TaskCompleted);
+            sus.RunATask().Await(() =>
+            {
+                Assert.True(sus.TaskCompleted);
+            });
+        }
+
+        [Fact]
+        public void TaskIsCompleted_WithResult()
+        {
+            var sus = new SystemUnderTest();
+
+            Assert.False(sus.TaskCompleted);
+            sus.RunATaskWithResult().Await((result) =>
+            {
+                Assert.True(sus.TaskCompleted);
+                Assert.Equal(SystemUnderTest.Result, result);
+            });
+        }
+
+        [Fact]
+        public void TaskHandlesException()
+        {
+            var sus = new SystemUnderTest();
+
+            Assert.False(sus.TaskCompleted);
+            sus.TaskThrowsException().Await((ex) =>
+            {
+                Assert.NotNull(ex);
+                Assert.IsType<Exception>(ex);
+                Assert.False(sus.TaskCompleted);
+            });
+        }
+
+        [Fact]
+        public void ExceptionInCompletedCallback_TriggersErrorCallback()
+        {
+            var sus = new SystemUnderTest();
+
+            sus.RunATask().Await(() =>
+            {
+                throw new Exception();
+            },
+            (ex) =>
+            {
+                Assert.NotNull(ex);
+                Assert.IsType<Exception>(ex);
+            });
+        }
+
+        [Fact]
+        public void ExceptionInCompletedCallback_WithResult_TriggersErrorCallback()
+        {
+            var sus = new SystemUnderTest();
+
+            sus.RunATaskWithResult().Await((result) =>
+            {
+                throw new Exception();
+            },
+            (ex) =>
+            {
+                Assert.NotNull(ex);
+                Assert.IsType<Exception>(ex);
+            });
+        }
+
+        class SystemUnderTest
+        {
+            public const string Result = "RESULT";
+
+            public bool TaskCompleted { get; set; }  = false;
+
+            public async Task RunATask()
+            {
+                await Task.Delay(500);
+                TaskCompleted = true;                
+            }
+
+            public async Task<string> RunATaskWithResult()
+            {
+                await Task.Delay(500);
+                TaskCompleted = true;
+                return Result;
+            }
+
+            public async Task TaskThrowsException()
+            {
+                await Task.Delay(500);
+                throw new System.Exception();
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

We added extension methods to the Task object to allow developers to execute and await Task based methods in void method declarations.

### Bugs Fixed

- #2082

### API Changes

Added:

Added variations of the follow APIs:

- `public async static void Await(this Task task, Action completedCallback, Action<Exception> errorCallback, bool configureAwait)`

- `public async static void Await<T>(this Task<T> task, Action<T> completedCallback, Action<Exception> errorCallback, bool configureAwait)`


### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard