### PR TITLE
[Uno] Adjust UI Tests, force mono version for macOS builds

### DIFF
--- a/build/jobs/uno-uitest.yml
+++ b/build/jobs/uno-uitest.yml
@@ -47,6 +47,7 @@ jobs:
     clean: all
 
   steps:
+  - template: ../steps/set-runtime.yml
 
   - bash: |
       build/scripts/android-uitest-run.sh
@@ -82,6 +83,7 @@ jobs:
     clean: all
 
   steps:
+  - template: ../steps/set-runtime.yml
 
   - bash: |
       build/scripts/ios-uitest-run.sh

--- a/e2e/Uno/HelloUnoWorld.Shared/ViewModels/ShellViewModel.cs
+++ b/e2e/Uno/HelloUnoWorld.Shared/ViewModels/ShellViewModel.cs
@@ -42,17 +42,17 @@ namespace HelloUnoWorld.ViewModels
             var message = "This is a message that should be shown in the dialog.";
 
             //using the dialog service as-is
-            //_dialogService.Show("NotificationDialog", new DialogParameters($"message={message}"), r =>
-            //{
-            //    if (r.Result == ButtonResult.None)
-            //        Title = "Result is None";
-            //    else if (r.Result == ButtonResult.OK)
-            //        Title = "Result is OK";
-            //    else if (r.Result == ButtonResult.Cancel)
-            //        Title = "Result is Cancel";
-            //    else
-            //        Title = "I Don't know what you did!?";
-            //});
+            _dialogService.ShowDialog("NotificationDialog", new DialogParameters($"message={message}"), r =>
+            {
+                if (r.Result == ButtonResult.None)
+                    Title = "Result is None";
+                else if (r.Result == ButtonResult.OK)
+                    Title = "Result is OK";
+                else if (r.Result == ButtonResult.Cancel)
+                    Title = "Result is Cancel";
+                else
+                    Title = "I Don't know what you did!?";
+            });
 
             //using custom extenions methods to simplify the app's dialogs
             //_dialogService.ShowNotification(message, r =>
@@ -79,17 +79,17 @@ namespace HelloUnoWorld.ViewModels
             //        Title = "I Don't know what you did!?";
             //});
 
-            _dialogService.ShowNotificationInAnotherContentDialog(message, r =>
-            {
-                if (r.Result == ButtonResult.None)
-                    Title = "Result is None";
-                else if (r.Result == ButtonResult.OK)
-                    Title = "Result is OK";
-                else if (r.Result == ButtonResult.Cancel)
-                    Title = "Result is Cancel";
-                else
-                    Title = "I Don't know what you did!?";
-            });
+            //_dialogService.ShowNotificationInAnotherContentDialog(message, r =>
+            //{
+            //    if (r.Result == ButtonResult.None)
+            //        Title = "Result is None";
+            //    else if (r.Result == ButtonResult.OK)
+            //        Title = "Result is OK";
+            //    else if (r.Result == ButtonResult.Cancel)
+            //        Title = "Result is Cancel";
+            //    else
+            //        Title = "I Don't know what you did!?";
+            //});
         }
     }
 

--- a/e2e/Uno/HelloUnoWorld.UITests/Constants.cs
+++ b/e2e/Uno/HelloUnoWorld.UITests/Constants.cs
@@ -14,6 +14,6 @@ namespace Sample.UITests
         public readonly static string AndroidAppName = "com.prismlibrary.helloworld";
         public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";
 
-        public readonly static Platform CurrentPlatform = Platform.Android;
+        public readonly static Platform CurrentPlatform = Platform.Browser;
     }
 }

--- a/e2e/Uno/HelloUnoWorld.UITests/Dialog_Tests.cs
+++ b/e2e/Uno/HelloUnoWorld.UITests/Dialog_Tests.cs
@@ -12,7 +12,7 @@ namespace Sample.UITests
     public class Dialog_Tests : TestBase
     {
         [Test]
-        public void TestViewA()
+        public void ShowDialog()
         {
             Query testSelector = q => q.Marked("showDialog");
             Query OkSelector = q => q.Marked("OKButton");


### PR DESCRIPTION
﻿## Description of Change

- Aligns the UI Tests for using the default dialog after the removal of the custom dialog.
- Use the set-runtime step to force the mono runtime version on macOS builds.

### API Changes

None.

### Behavioral Changes

None.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard