### PR TITLE
tests(wasm): Fix snapshots publication for UI Tests

### DIFF
--- a/build/jobs/uno-uitest.yml
+++ b/build/jobs/uno-uitest.yml
@@ -28,6 +28,7 @@ jobs:
       testRunTitle: 'WebAssembly Test Run'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(build.sourcesdirectory)/build/TestResult.xml'
+      searchFolder: '$(build.artifactstagingdirectory)/e2e/uno/wasm' # https://github.com/microsoft/azure-pipelines-tasks/issues/10072
 
   - task: PublishBuildArtifacts@1
     condition: always()


### PR DESCRIPTION
﻿## Description of Change

Fixes the publication of WebAssembly UI tests by adding a search path to the test results publicatio task. This issue happens as the UI tests are run in a container environment.

### PR Checklist

- ~~[ ] Has tests (if omitted, state reason in description)~~
- [x] Rebased on top of master at time of PR
- ~~[ ] Changes adhere to coding standard~~