### PR TITLE
fix(uno-e2e): Disable build fail on android UI tests failure

### DIFF
--- a/build/jobs/uno-uitest.yml
+++ b/build/jobs/uno-uitest.yml
@@ -28,6 +28,7 @@ jobs:
       testRunTitle: 'WebAssembly Test Run'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(build.sourcesdirectory)/build/TestResult.xml'
+      failTaskOnFailedTests: true
 
   - task: PublishBuildArtifacts@1
     condition: always()
@@ -64,6 +65,7 @@ jobs:
       testRunTitle: 'Android Test Run'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(build.sourcesdirectory)/build/TestResult.xml'
+      failTaskOnFailedTests: false # Android tests may randomly fail because of the System UI not responding. https://github.com/PrismLibrary/Prism/issues/2099
 
   - task: PublishBuildArtifacts@1
     condition: always()
@@ -99,6 +101,7 @@ jobs:
       testRunTitle: 'iOS Test Run'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(build.sourcesdirectory)/build/TestResult.xml'
+      failTaskOnFailedTests: true
 
   - task: PublishBuildArtifacts@1
     condition: always()

--- a/build/scripts/android-uitest-run.sh
+++ b/build/scripts/android-uitest-run.sh
@@ -38,4 +38,4 @@ mono nuget.exe install NUnit.ConsoleRunner -Version 3.10.0
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
 
 mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe \
-	$BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/bin/Release/net47/HelloUnoWorld.UITests.dll
+	$BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/bin/Release/net47/HelloUnoWorld.UITests.dll || true

--- a/build/scripts/ios-uitest-run.sh
+++ b/build/scripts/ios-uitest-run.sh
@@ -26,4 +26,4 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 --inprocess \
 --agents=1 \
 --workers=1 \
-$BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/bin/Release/net47/HelloUnoWorld.UITests.dll
+$BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/bin/Release/net47/HelloUnoWorld.UITests.dll || true

--- a/build/scripts/wasm-uitest-run.sh
+++ b/build/scripts/wasm-uitest-run.sh
@@ -33,4 +33,4 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 --inprocess \
 --agents=1 \
 --workers=1 \
-$BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/bin/Release/net47/HelloUnoWorld.UITests.dll
+$BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/bin/Release/net47/HelloUnoWorld.UITests.dll || true


### PR DESCRIPTION
﻿## Description of Change

This change disables build failures for the Android e2e tests on Uno Platform, and ensures that iOS and Wasm fail at the publishing step (and not the execution step).

### Bugs Fixed

- https://github.com/PrismLibrary/Prism/issues/2099

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] ~~Changes adhere to coding standard~~