### PR TITLE
[Uno-UWP] Disable library layout generation

### DIFF
--- a/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.csproj
+++ b/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.csproj
@@ -3,9 +3,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid90;xamarinmac20</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299;</TargetFrameworks>
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    
+    <!-- 
+    Library layout generation is disabled as this project does not have any XAML files, and 
+    that if set to true, there is a nuget issue where Uno.Prism PRI resource get incorrectly
+    propagated to their dependents.
+    -->
+    <GenerateLibraryLayout>false</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>

--- a/src/Uno/Prism.Unity.Uno/Prism.Unity.Uno.csproj
+++ b/src/Uno/Prism.Unity.Uno/Prism.Unity.Uno.csproj
@@ -3,11 +3,17 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid90;xamarinmac20</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299;</TargetFrameworks>
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
     <RootNamespace>Prism.Unity</RootNamespace>
     <PackageId>Prism.Unity.Uno</PackageId>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    
+    <!-- 
+    Library layout generation is disabled as this project does not have any XAML files, and 
+    that if set to true, there is a nuget issue where Uno.Prism PRI resource get incorrectly
+    propagated to their dependents.
+    -->
+    <GenerateLibraryLayout>false</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>


### PR DESCRIPTION
﻿## Description of Change

Library layout generation is disabled for Prism.DryIoc.Uno and Prism.Unity.Uno projects as they do not have any XAML files, and that if set to true, there is an nuget issue where Uno.Prism PRI resources get incorrectly propagated to their dependents.

Without this change, a UWP build fails with the following error:

```
error APPX1101: Payload contains two or more files with the same destination path 'Prism.Uno\Prism.Uno.xr.xml'. Source files: 
error APPX1101: C:\Users\XX\.nuget\packages\prism.dryioc.uno\8.0.0.1693-ci\lib\uap10.0.16299\Prism.Uno\Prism.Uno.xr.xml
error APPX1101: C:\Users\XX\.nuget\packages\prism.uno\8.0.0.1693-ci\lib\uap10.0.16299\Prism.Uno\Prism.Uno.xr.xml
```

### PR Checklist

- [ ] ~~Has tests (if omitted, state reason in description)~~
- [x] Rebased on top of master at time of PR
- [ ] ~~Changes adhere to coding standard~~