### PR TITLE
Added a "BeginInvokeOnMainThreadAsync" method to "IDeviceService"

### DIFF
--- a/src/Forms/Prism.Forms/Prism.Forms.csproj
+++ b/src/Forms/Prism.Forms/Prism.Forms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid90;MonoAndroid10.0</TargetFrameworks>
     <Title>Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Forms/Prism.Forms/Prism.Forms.csproj
+++ b/src/Forms/Prism.Forms/Prism.Forms.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Forms/Prism.Forms/Services/DeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/DeviceService.cs
@@ -1,5 +1,6 @@
 ﻿using Prism.AppModel;
 using System;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 
 namespace Prism.Services
@@ -64,6 +65,30 @@ namespace Prism.Services
         public void BeginInvokeOnMainThread(Action action)
         {
             Device.BeginInvokeOnMainThread(action);
+        }
+
+        /// <summary>
+        /// Invokes an action (which can be awaited) on the device main UI thread.
+        /// </summary>
+        /// <param name="action">The Action to invoke</param>
+        public Task BeginInvokeOnMainThreadAsync(Action action)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                try
+                {
+                    action();
+                    tcs.TrySetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            });
+            
+            return tcs.Task;
         }
 
         /// <summary>

--- a/src/Forms/Prism.Forms/Services/DeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/DeviceService.cs
@@ -1,5 +1,7 @@
 ﻿using Prism.AppModel;
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 
@@ -18,6 +20,16 @@ namespace Prism.Services
         public const string UWP = "UWP";
         public const string WPF = "WPF";
 
+
+        /// <summary>
+        /// Gets a list of custom flags that were set on the device before Xamarin.Forms was initialized.
+        /// </summary>
+        public IReadOnlyList<string> Flags => Device.Flags;
+
+        /// <summary>
+        /// Gets the flow direction on the device.
+        /// </summary>
+        public FlowDirection FlowDirection => Device.FlowDirection;
 
         /// <summary>
         /// Gets the kind of device that Xamarin.Forms is currently working on.
@@ -68,7 +80,38 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Invokes an awaitable action on the device main UI thread.
+        /// Returns the current SynchronizationContext from the main thread.
+        /// </summary>
+        /// <returns>The current SynchronizationContext from the main thread.</returns>
+        public Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync()
+        {
+            return Device.GetMainThreadSynchronizationContextAsync();
+        }
+
+        /// <summary>
+        /// Returns a double that represents a font size that corresponds to size on targetElement.
+        /// </summary>
+        /// <param name="size">The named size for which to get the numeric size.</param>
+        /// <param name="targetElement">The element for which to calculate the numeric size.</param>
+        /// <returns>A double that represents a font size that corresponds to size on targetElement.</returns>
+        public double GetNamedSize(NamedSize size, Element targetElement)
+        {
+            return Device.GetNamedSize(size, targetElement);
+        }
+
+        /// <summary>
+        /// Returns a double that represents the named size for the font that is used on the element on the native platform.
+        /// </summary>
+        /// <param name="size">The named size for which to get the numeric size.</param>
+        /// <param name="targetElementType">The element type for which to calculate the numeric size.</param>
+        /// <returns>The named size for the font that is used on the element on the native platform.</returns>
+        public double GetNamedSize(NamedSize size, Type targetElementType)
+        {
+            return Device.GetNamedSize(size, targetElementType);
+        }
+
+        /// <summary>
+        /// Invokes an Action on the device main (UI) thread.
         /// </summary>
         /// <param name="action">The Action to invoke</param>
         /// <returns>A task representing the work to be performed</returns>
@@ -78,10 +121,10 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Invokes an awaitable func of type TResult on the device main UI thread.
+        /// Invokes a Func on the device main (UI) thread.
         /// </summary>
-        /// <param name="func">The func to invoke</param>
-        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <param name="func">The Func to invoke.</param>
+        /// <typeparam name="T">The return type of the Func.</typeparam>
         /// <returns>A task of type T representing the work to be performed</returns>
         public Task<T> InvokeOnMainThreadAsync<T>(Func<T> func)
         {
@@ -89,10 +132,10 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Invokes an awaitable func of type Task TResult on the device main UI thread.
+        /// Invokes a Func on the device main (UI) thread.
         /// </summary>
-        /// <param name="funcTask">The func to invoke</param>
-        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <param name="funcTask">The return type of the Func.</param>
+        /// <typeparam name="T">The return type of the Func.</typeparam>
         /// <returns>A task of type T representing the work to be performed</returns>
         public Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
         {
@@ -100,13 +143,31 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Invokes an awaitable func of type Task on the device main UI thread.
+        /// Invokes a Func on the device main (UI) thread.
         /// </summary>
-        /// <param name="funcTask">The func to invoke</param>
+        /// <param name="funcTask">The Func to invoke.</param>
         /// <returns>A task representing the work to be performed</returns>
         public Task InvokeOnMainThreadAsync(Func<Task> funcTask)
         {
             return Device.InvokeOnMainThreadAsync(funcTask);
+        }
+        
+        /// <summary>
+        /// Sets a list of custom flags on the device.
+        /// </summary>
+        /// <param name="flags">The list of custom flag values.</param>
+        public void SetFlags(IReadOnlyList<string> flags)
+        {
+            Device.SetFlags(flags);
+        }
+
+        /// <summary>
+        /// Sets the flow direction on the device.
+        /// </summary>
+        /// <param name="flowDirection">The new flow direction value to set.</param>
+        public void SetFlowDirection(FlowDirection flowDirection)
+        {
+            Device.SetFlowDirection(flowDirection);
         }
 
         /// <summary>

--- a/src/Forms/Prism.Forms/Services/DeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/DeviceService.cs
@@ -89,28 +89,6 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Returns a double that represents a font size that corresponds to size on targetElement.
-        /// </summary>
-        /// <param name="size">The named size for which to get the numeric size.</param>
-        /// <param name="targetElement">The element for which to calculate the numeric size.</param>
-        /// <returns>A double that represents a font size that corresponds to size on targetElement.</returns>
-        public double GetNamedSize(NamedSize size, Element targetElement)
-        {
-            return Device.GetNamedSize(size, targetElement);
-        }
-
-        /// <summary>
-        /// Returns a double that represents the named size for the font that is used on the element on the native platform.
-        /// </summary>
-        /// <param name="size">The named size for which to get the numeric size.</param>
-        /// <param name="targetElementType">The element type for which to calculate the numeric size.</param>
-        /// <returns>The named size for the font that is used on the element on the native platform.</returns>
-        public double GetNamedSize(NamedSize size, Type targetElementType)
-        {
-            return Device.GetNamedSize(size, targetElementType);
-        }
-
-        /// <summary>
         /// Invokes an Action on the device main (UI) thread.
         /// </summary>
         /// <param name="action">The Action to invoke</param>

--- a/src/Forms/Prism.Forms/Services/DeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/DeviceService.cs
@@ -68,27 +68,45 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Invokes an action (which can be awaited) on the device main UI thread.
+        /// Invokes an awaitable action on the device main UI thread.
         /// </summary>
         /// <param name="action">The Action to invoke</param>
-        public Task BeginInvokeOnMainThreadAsync(Action action)
+        /// <returns>A task representing the work to be performed</returns>
+        public Task InvokeOnMainThreadAsync(Action action)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                try
-                {
-                    action();
-                    tcs.TrySetResult(true);
-                }
-                catch (Exception ex)
-                {
-                    tcs.TrySetException(ex);
-                }
-            });
-            
-            return tcs.Task;
+            return Device.InvokeOnMainThreadAsync(action);
+        }
+
+        /// <summary>
+        /// Invokes an awaitable func of type TResult on the device main UI thread.
+        /// </summary>
+        /// <param name="func">The func to invoke</param>
+        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <returns>A task of type T representing the work to be performed</returns>
+        public Task<T> InvokeOnMainThreadAsync<T>(Func<T> func)
+        {
+            return Device.InvokeOnMainThreadAsync(func);
+        }
+
+        /// <summary>
+        /// Invokes an awaitable func of type Task TResult on the device main UI thread.
+        /// </summary>
+        /// <param name="funcTask">The func to invoke</param>
+        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <returns>A task of type T representing the work to be performed</returns>
+        public Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
+        {
+            return Device.InvokeOnMainThreadAsync(funcTask);
+        }
+
+        /// <summary>
+        /// Invokes an awaitable func of type Task on the device main UI thread.
+        /// </summary>
+        /// <param name="funcTask">The func to invoke</param>
+        /// <returns>A task representing the work to be performed</returns>
+        public Task InvokeOnMainThreadAsync(Func<Task> funcTask)
+        {
+            return Device.InvokeOnMainThreadAsync(funcTask);
         }
 
         /// <summary>

--- a/src/Forms/Prism.Forms/Services/IDeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/IDeviceService.cs
@@ -48,22 +48,6 @@ namespace Prism.Services
         /// </summary>
         /// <returns>The current SynchronizationContext from the main thread.</returns>
         Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync();
-
-        /// <summary>
-        /// Returns a double that represents a font size that corresponds to size on targetElement.
-        /// </summary>
-        /// <param name="size">The named size for which to get the numeric size.</param>
-        /// <param name="targetElement">The element for which to calculate the numeric size.</param>
-        /// <returns>A double that represents a font size that corresponds to size on targetElement.</returns>
-        double GetNamedSize(NamedSize size, Element targetElement);
-
-        /// <summary>
-        /// Returns a double that represents the named size for the font that is used on the element on the native platform.
-        /// </summary>
-        /// <param name="size">The named size for which to get the numeric size.</param>
-        /// <param name="targetElementType">The element type for which to calculate the numeric size.</param>
-        /// <returns>The named size for the font that is used on the element on the native platform.</returns>
-        double GetNamedSize(NamedSize size, Type targetElementType);
         
         /// <summary>
         /// Invokes an Action on the device main (UI) thread.

--- a/src/Forms/Prism.Forms/Services/IDeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/IDeviceService.cs
@@ -1,5 +1,6 @@
 ﻿using Prism.AppModel;
 using System;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 
 namespace Prism.Services
@@ -29,6 +30,12 @@ namespace Prism.Services
         /// </summary>
         /// <param name="action">The Action to invoke</param>
         void BeginInvokeOnMainThread(Action action);
+        
+        /// <summary>
+        /// Invokes an action (which can be awaited) on the device main UI thread.
+        /// </summary>
+        /// <param name="action">The Action to invoke</param>
+        Task BeginInvokeOnMainThreadAsync(Action action);
 
         /// <summary>
         /// Starts a recurring timer using the Device clock capabilities.

--- a/src/Forms/Prism.Forms/Services/IDeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/IDeviceService.cs
@@ -1,5 +1,7 @@
 ﻿using Prism.AppModel;
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 
@@ -11,10 +13,20 @@ namespace Prism.Services
     public interface IDeviceService
     {
         /// <summary>
+        /// Gets a list of custom flags that were set on the device before Xamarin.Forms was initialized.
+        /// </summary>
+        IReadOnlyList<string> Flags { get; }
+        
+        /// <summary>
+        /// Gets the flow direction on the device.
+        /// </summary>
+        FlowDirection FlowDirection { get; }
+        
+        /// <summary>
         /// Gets the kind of device that Xamarin.Forms is currently working on.
         /// </summary>
         TargetIdiom Idiom { get; }
-
+        
         /// <summary>
         /// Gets the Platform (OS) that the application is running on.  This is the native Device.RunTimePlatform property.
         /// </summary>
@@ -30,36 +42,70 @@ namespace Prism.Services
         /// </summary>
         /// <param name="action">The Action to invoke</param>
         void BeginInvokeOnMainThread(Action action);
+
+        /// <summary>
+        /// Returns the current SynchronizationContext from the main thread.
+        /// </summary>
+        /// <returns>The current SynchronizationContext from the main thread.</returns>
+        Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync();
+
+        /// <summary>
+        /// Returns a double that represents a font size that corresponds to size on targetElement.
+        /// </summary>
+        /// <param name="size">The named size for which to get the numeric size.</param>
+        /// <param name="targetElement">The element for which to calculate the numeric size.</param>
+        /// <returns>A double that represents a font size that corresponds to size on targetElement.</returns>
+        double GetNamedSize(NamedSize size, Element targetElement);
+
+        /// <summary>
+        /// Returns a double that represents the named size for the font that is used on the element on the native platform.
+        /// </summary>
+        /// <param name="size">The named size for which to get the numeric size.</param>
+        /// <param name="targetElementType">The element type for which to calculate the numeric size.</param>
+        /// <returns>The named size for the font that is used on the element on the native platform.</returns>
+        double GetNamedSize(NamedSize size, Type targetElementType);
         
         /// <summary>
-        /// Invokes an awaitable action on the device main UI thread.
+        /// Invokes an Action on the device main (UI) thread.
         /// </summary>
         /// <param name="action">The Action to invoke</param>
         /// <returns>A task representing the work to be performed</returns>
         Task InvokeOnMainThreadAsync(Action action);
 
         /// <summary>
-        /// Invokes an awaitable func of type TResult on the device main UI thread.
+        /// Invokes a Func on the device main (UI) thread.
         /// </summary>
-        /// <param name="func">The func to invoke</param>
-        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <param name="func">The Func to invoke.</param>
+        /// <typeparam name="T">The return type of the Func.</typeparam>
         /// <returns>A task of type T representing the work to be performed</returns>
         Task<T> InvokeOnMainThreadAsync<T>(Func<T> func);
 
         /// <summary>
-        /// Invokes an awaitable func of type Task TResult on the device main UI thread.
+        /// Invokes a Func on the device main (UI) thread.
         /// </summary>
-        /// <param name="funcTask">The func to invoke</param>
-        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <param name="funcTask">The return type of the Func.</param>
+        /// <typeparam name="T">The return type of the Func.</typeparam>
         /// <returns>A task of type T representing the work to be performed</returns>
         Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask);
 
         /// <summary>
-        /// Invokes an awaitable func of type Task on the device main UI thread.
+        /// Invokes a Func on the device main (UI) thread.
         /// </summary>
-        /// <param name="funcTask">The func to invoke</param>
+        /// <param name="funcTask">The Func to invoke.</param>
         /// <returns>A task representing the work to be performed</returns>
         Task InvokeOnMainThreadAsync(Func<Task> funcTask);
+
+        /// <summary>
+        /// Sets a list of custom flags on the device.
+        /// </summary>
+        /// <param name="flags">The list of custom flag values.</param>
+        void SetFlags(IReadOnlyList<string> flags);
+        
+        /// <summary>
+        /// Sets the flow direction on the device.
+        /// </summary>
+        /// <param name="flowDirection">The new flow direction value to set.</param>
+        void SetFlowDirection(FlowDirection flowDirection);
 
         /// <summary>
         /// Starts a recurring timer using the Device clock capabilities.

--- a/src/Forms/Prism.Forms/Services/IDeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/IDeviceService.cs
@@ -32,10 +32,34 @@ namespace Prism.Services
         void BeginInvokeOnMainThread(Action action);
         
         /// <summary>
-        /// Invokes an action (which can be awaited) on the device main UI thread.
+        /// Invokes an awaitable action on the device main UI thread.
         /// </summary>
         /// <param name="action">The Action to invoke</param>
-        Task BeginInvokeOnMainThreadAsync(Action action);
+        /// <returns>A task representing the work to be performed</returns>
+        Task InvokeOnMainThreadAsync(Action action);
+
+        /// <summary>
+        /// Invokes an awaitable func of type TResult on the device main UI thread.
+        /// </summary>
+        /// <param name="func">The func to invoke</param>
+        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <returns>A task of type T representing the work to be performed</returns>
+        Task<T> InvokeOnMainThreadAsync<T>(Func<T> func);
+
+        /// <summary>
+        /// Invokes an awaitable func of type Task TResult on the device main UI thread.
+        /// </summary>
+        /// <param name="funcTask">The func to invoke</param>
+        /// <typeparam name="T">The return type of the task</typeparam>
+        /// <returns>A task of type T representing the work to be performed</returns>
+        Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask);
+
+        /// <summary>
+        /// Invokes an awaitable func of type Task on the device main UI thread.
+        /// </summary>
+        /// <param name="funcTask">The func to invoke</param>
+        /// <returns>A task representing the work to be performed</returns>
+        Task InvokeOnMainThreadAsync(Func<Task> funcTask);
 
         /// <summary>
         /// Starts a recurring timer using the Device clock capabilities.

--- a/tests/Forms/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/tests/Forms/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Forms/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/tests/Forms/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Forms/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/tests/Forms/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Humanizer.Core" Version="2.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Forms/Prism.Forms.Tests/Prism.Forms.Tests.csproj
+++ b/tests/Forms/Prism.Forms.Tests/Prism.Forms.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Humanizer.Core" Version="2.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Forms/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/tests/Forms/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Forms/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/tests/Forms/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
     <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
﻿## Description of Change

Added an async version of "BeginInvokeOnMainThread as detailed here (https://github.com/PrismLibrary/Prism/issues/2043)

I've not written any tests, as I couldn't see any existing tests for that class. I'm happy to write some tests for that class if required, unless I've just missed existing ones.

### Bugs Fixed

- Provide links to bugs here

### API Changes

Added:

- Task IDeviceService.BeginInvokeOnMainThreadAsync(Action)
- Task DeviceService.BeginInvokeOnMainThreadAsync(Action)

### Behavioral Changes

The developer now has the ability to await Actions invoked on the main thread.

### PR Checklist

- [x ] Has tests (if omitted, state reason in description)
- [ x] Rebased on top of master at time of PR
- [ x] Changes adhere to coding standard