### PR TITLE
Fixed ConfigureViewModelLocator implementation

### DIFF
--- a/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -47,7 +47,7 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            PrismInitializationExtensions.ConfigureViewModelLocator(Container);
+            PrismInitializationExtensions.ConfigureViewModelLocator();
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using Prism.Ioc;
 using Prism.Modularity;
+using Prism.Mvvm;
 using Prism.Regions;
 
 namespace Prism
@@ -47,7 +48,10 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            PrismInitializationExtensions.ConfigureViewModelLocator(Container);
+            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
+            {
+                return Container.Resolve(type);
+            });
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -2,7 +2,6 @@
 using System.Windows;
 using Prism.Ioc;
 using Prism.Modularity;
-using Prism.Mvvm;
 using Prism.Regions;
 
 namespace Prism
@@ -48,10 +47,7 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
-            {
-                return Container.Resolve(type);
-            });
+            PrismInitializationExtensions.ConfigureViewModelLocator(Container);
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
@@ -1,5 +1,6 @@
 ﻿using Prism.Ioc;
 using Prism.Modularity;
+using Prism.Mvvm;
 using Prism.Regions;
 using System;
 using System.Windows;
@@ -44,7 +45,10 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            PrismInitializationExtensions.ConfigureViewModelLocator(Container);
+            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
+            {
+                return Container.Resolve(type);
+            });
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
@@ -44,7 +44,7 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            PrismInitializationExtensions.ConfigureViewModelLocator(Container);
+            PrismInitializationExtensions.ConfigureViewModelLocator();
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
@@ -1,6 +1,5 @@
 ﻿using Prism.Ioc;
 using Prism.Modularity;
-using Prism.Mvvm;
 using Prism.Regions;
 using System;
 using System.Windows;
@@ -45,10 +44,7 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
-            {
-                return Container.Resolve(type);
-            });
+            PrismInitializationExtensions.ConfigureViewModelLocator(Container);
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -2,6 +2,7 @@
 using Prism.Ioc;
 using Prism.Logging;
 using Prism.Modularity;
+using Prism.Mvvm;
 using Prism.Regions;
 using Prism.Regions.Behaviors;
 using Prism.Services.Dialogs;
@@ -18,6 +19,14 @@ namespace Prism
 {
     internal static class PrismInitializationExtensions
     {
+        internal static void ConfigureViewModelLocator(IContainerProvider containerProvider)
+        {
+            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
+            {
+                return containerProvider.Resolve(type);
+            });
+        }
+
         internal static void RegisterRequiredTypes(this IContainerRegistry containerRegistry, IModuleCatalog moduleCatalog)
         {
             containerRegistry.RegisterInstance(moduleCatalog);

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -2,7 +2,6 @@
 using Prism.Ioc;
 using Prism.Logging;
 using Prism.Modularity;
-using Prism.Mvvm;
 using Prism.Regions;
 using Prism.Regions.Behaviors;
 using Prism.Services.Dialogs;
@@ -19,14 +18,6 @@ namespace Prism
 {
     internal static class PrismInitializationExtensions
     {
-        internal static void ConfigureViewModelLocator(IContainerProvider containerProvider)
-        {
-            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
-            {
-                return containerProvider.Resolve(type);
-            });
-        }
-
         internal static void RegisterRequiredTypes(this IContainerRegistry containerRegistry, IModuleCatalog moduleCatalog)
         {
             containerRegistry.RegisterInstance(moduleCatalog);

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -19,11 +19,11 @@ namespace Prism
 {
     internal static class PrismInitializationExtensions
     {
-        internal static void ConfigureViewModelLocator(IContainerProvider containerProvider)
+        internal static void ConfigureViewModelLocator()
         {
             ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
             {
-                return containerProvider.Resolve(type);
+                return ContainerLocator.Container.Resolve(type);
             });
         }
 


### PR DESCRIPTION
﻿## Description of Change

Reverted the use of the PrismInitializationExtensions.ConfigureViewModelLocator. This actually didn't work properly because we need to access the Container for each view being resolved during the life of the app.

### Bugs Fixed

- #2106

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard