### PR TITLE
[Uno] Adjust the initialization sequence based on tree navigation constraints

### DIFF
--- a/PrismLibrary_Uno.sln
+++ b/PrismLibrary_Uno.sln
@@ -12,6 +12,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Core", "src\Prism.Core\Prism.Core.csproj", "{CF74BE80-F9A0-4C02-A59C-30F43EDAB866}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Containers\Prism.Unity.Shared\Prism.Unity.Shared.projitems*{4338e214-2ba3-4043-90b6-6c1269c58865}*SharedItemsImports = 5
+		src\Containers\Prism.DryIoc.Shared\Prism.DryIoc.Shared.projitems*{b09fc94c-8100-4eb2-846c-99acb056a993}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU
 		Ad-Hoc|ARM = Ad-Hoc|ARM

--- a/e2e/Uno/HelloUnoWorld.Shared/App.xaml.cs
+++ b/e2e/Uno/HelloUnoWorld.Shared/App.xaml.cs
@@ -22,6 +22,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Prism.Modularity;
 using HelloWorld.ViewModels;
+using Prism.Regions;
 
 namespace HelloUnoWorld
 {
@@ -117,9 +118,17 @@ namespace HelloUnoWorld
             moduleCatalog.AddModule<ModuleA.ModuleAModule>(InitializationMode.OnDemand);
         }
 
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            var regionManager = Container.Resolve<IRegionManager>();
+            regionManager.RequestNavigate("InitialRegion", nameof(InitialView));
+        }
+
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
         {
             containerRegistry.RegisterForNavigation<ViewA>(nameof(ViewA));
+            containerRegistry.RegisterForNavigation<InitialView>(nameof(InitialView));
             containerRegistry.RegisterForNavigation<ModulesPage, ModulesPageViewModel>();
 
             containerRegistry.RegisterDialog<NotificationDialog, NotificationDialogViewModel>();

--- a/e2e/Uno/HelloUnoWorld.Shared/HelloUnoWorld.Shared.projitems
+++ b/e2e/Uno/HelloUnoWorld.Shared/HelloUnoWorld.Shared.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>6279c845-92f8-4333-ab99-3d213163593c</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>HelloUnoWorld.Shared</Import_RootNamespace>
+    <Import_RootNamespace>HelloUnoWorld</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <ApplicationDefinition Include="$(MSBuildThisFileDirectory)App.xaml">
@@ -32,6 +32,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Dialogs\NotificationDialogViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\ModulesPageViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\ShellViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Views\InitialView.xaml.cs">
+      <DependentUpon>InitialView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Views\ModulesPage.xaml.cs">
       <DependentUpon>ModulesPage.xaml</DependentUpon>
     </Compile>
@@ -52,6 +55,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Dialogs\NotificationDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Views\InitialView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/e2e/Uno/HelloUnoWorld.Shared/Views/InitialView.xaml
+++ b/e2e/Uno/HelloUnoWorld.Shared/Views/InitialView.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="HelloUnoWorld.Views.InitialView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:HelloUnoWorld.Shared.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+        <TextBlock x:Name="InitialViewTextBlock" FontSize="20" Text="Initial view" />
+    </Grid>
+</UserControl>

--- a/e2e/Uno/HelloUnoWorld.Shared/Views/InitialView.xaml.cs
+++ b/e2e/Uno/HelloUnoWorld.Shared/Views/InitialView.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace HelloUnoWorld.Views
+{
+	public sealed partial class InitialView : UserControl
+	{
+		public InitialView()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/e2e/Uno/HelloUnoWorld.Shared/Views/Shell.xaml
+++ b/e2e/Uno/HelloUnoWorld.Shared/Views/Shell.xaml
@@ -8,14 +8,19 @@
                 xmlns:toolkit="using:Uno.UI.Toolkit"
                 xmlns:local="clr-namespace:HelloWorld">
 
-  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" toolkit:VisibleBoundsPadding.PaddingMask="All">
+  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+        toolkit:VisibleBoundsPadding.PaddingMask="All">
     <Grid.RowDefinitions>
       <RowDefinition Height="auto" />
       <RowDefinition Height="auto" />
+      <RowDefinition Height="auto" />
+      <RowDefinition Height="*" />
       <RowDefinition />
     </Grid.RowDefinitions>
-    <TextBlock Text="{Binding Title}" FontSize="30" />
-    <StackPanel Grid.Row="1" Orientation="Vertical">
+    <TextBlock Text="{Binding Title}"
+               FontSize="30" />
+    <StackPanel Grid.Row="1"
+                Orientation="Vertical">
       <Button x:Name="viewAButton"
               Command="{Binding NavigateCommand}"
               CommandParameter="ViewA"
@@ -31,8 +36,10 @@
               Command="{Binding NavigateCommand}"
               CommandParameter="ModulePageA"
               Content="Navigate to Named View in Module" />
-      </StackPanel>
+    </StackPanel>
     <ContentControl Grid.Row="2"
+                    prismRegions:RegionManager.RegionName="InitialRegion" />
+    <ContentControl Grid.Row="3"
                     prismRegions:RegionManager.RegionName="ContentRegion" />
   </Grid>
 </ContentControl>

--- a/e2e/Uno/HelloUnoWorld.UITests/Region_Tests.cs
+++ b/e2e/Uno/HelloUnoWorld.UITests/Region_Tests.cs
@@ -12,6 +12,17 @@ namespace Sample.UITests
     public class Region_Tests : TestBase
     {
         [Test]
+        public void InitialView()
+        {
+            Query initialView = q => q.Marked("InitialViewTextBlock");
+
+            App.WaitForElement(initialView);
+            TakeScreenshot("Initial");
+
+            App.WaitForDependencyPropertyValue(initialView, "Text", "Initial view");
+        }
+
+        [Test]
         public void TestViewA()
         {
             Query testSelector = q => q.Marked("viewAButton");

--- a/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
+++ b/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
@@ -35,7 +35,7 @@ namespace Prism.DryIoc
 
 #if !ContainerExtensions
         /// <summary>
-        /// Constructs a default instance of the <see cref="DryIocContainerExtension"
+        /// Constructs a default instance of the <see cref="DryIocContainerExtension" />
         /// </summary>
         public DryIocContainerExtension()
             : this(new Container(DefaultRules))


### PR DESCRIPTION
﻿## Description of Change

This change takes into account the fact that the visual tree cannot be navigated until it is loaded, preventing navigation from `PrismApplicationBase.OnInitialized` or `IModule.OnInitialized`. 



### Bugs Fixed

This fixes #2102.

### API Changes

No change.

### Behavioral Changes

This change implies that `PrismApplicationBase.OnLaunched` and `PrismApplicationBase.OnInitialized` may not be invoked synchronously.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard