### PR TITLE
Support for Navigation into sub-pages of TabbedPage.CurrentPage using selectedTab

### DIFF
--- a/e2e/Forms/src/HelloWorld/ViewModels/MyMasterDetailViewModel.cs
+++ b/e2e/Forms/src/HelloWorld/ViewModels/MyMasterDetailViewModel.cs
@@ -29,7 +29,7 @@ namespace HelloWorld.ViewModels
             var result = await _navigationService.NavigateAsync(name);
             if (!result.Success)
             {
-
+                Console.WriteLine(result.Exception);
             }
         }
 

--- a/e2e/Forms/src/ModuleA/Models/Item.cs
+++ b/e2e/Forms/src/ModuleA/Models/Item.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ModuleA.Models
+{
+    public class Item
+    {
+        public int Id { get; set; }
+        public string Text { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/e2e/Forms/src/ModuleA/ModuleAModule.cs
+++ b/e2e/Forms/src/ModuleA/ModuleAModule.cs
@@ -20,6 +20,8 @@ namespace ModuleA
             containerRegistry.RegisterForNavigation<ViewA>();
             containerRegistry.RegisterForNavigation<ViewB>();
             containerRegistry.RegisterForNavigation<ViewC>();
+            containerRegistry.RegisterForNavigation<ItemListPage>();
+            containerRegistry.RegisterForNavigation<ItemDetailPage>();
             containerRegistry.RegisterForNavigation<MyCarouselPage>();
 
             containerRegistry.RegisterSingleton<IApplicationCommands, ApplicationCommands>();

--- a/e2e/Forms/src/ModuleA/Services/IDataStore.cs
+++ b/e2e/Forms/src/ModuleA/Services/IDataStore.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ModuleA.Services
+{
+    public interface IDataStore<T>
+    {
+        Task<bool> AddItemAsync(T item);
+        Task<bool> UpdateItemAsync(T item);
+        Task<bool> DeleteItemAsync(int id);
+        Task<T> GetItemAsync(int id);
+        Task<IEnumerable<T>> GetItemsAsync(bool forceRefresh = false);
+    }
+}

--- a/e2e/Forms/src/ModuleA/Services/MockDataStore.cs
+++ b/e2e/Forms/src/ModuleA/Services/MockDataStore.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ModuleA.Models;
+
+namespace ModuleA.Services
+{
+    public class MockDataStore : IDataStore<Item>
+    {
+        readonly List<Item> items;
+
+        public MockDataStore()
+        {
+            items = new List<Item>()
+            {
+                new Item { Id = 1, Text = "First item", Description="This is an item description." },
+                new Item { Id = 2, Text = "Second item", Description="This is an item description." },
+                new Item { Id = 3, Text = "Third item", Description="This is an item description." },
+                new Item { Id = 4, Text = "Fourth item", Description="This is an item description." },
+                new Item { Id = 5, Text = "Fifth item", Description="This is an item description." },
+                new Item { Id = 6, Text = "Sixth item", Description="This is an item description." }
+            };
+        }
+
+        public async Task<bool> AddItemAsync(Item item)
+        {
+            items.Add(item);
+
+            return await Task.FromResult(true);
+        }
+
+        public async Task<bool> UpdateItemAsync(Item item)
+        {
+            var oldItem = items.Where((Item arg) => arg.Id == item.Id).FirstOrDefault();
+            items.Remove(oldItem);
+            items.Add(item);
+
+            return await Task.FromResult(true);
+        }
+
+        public async Task<bool> DeleteItemAsync(int id)
+        {
+            var oldItem = items.Where((Item arg) => arg.Id == id).FirstOrDefault();
+            items.Remove(oldItem);
+
+            return await Task.FromResult(true);
+        }
+
+        public async Task<Item> GetItemAsync(int id)
+        {
+            return await Task.FromResult(items.FirstOrDefault(s => s.Id == id));
+        }
+
+        public async Task<IEnumerable<Item>> GetItemsAsync(bool forceRefresh = false)
+        {
+            return await Task.FromResult(items);
+        }
+    }
+}

--- a/e2e/Forms/src/ModuleA/ViewModels/ItemDetailViewModel.cs
+++ b/e2e/Forms/src/ModuleA/ViewModels/ItemDetailViewModel.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Prism.Navigation;
+using ModuleA.Models;
+using ModuleA.Services;
+
+namespace ModuleA.ViewModels
+{
+    public class ItemDetailPageViewModel : ViewModelBase, INavigationAware
+    {
+        private readonly MockDataStore _datastore;
+
+        private Item _item;
+        public Item Item
+        {
+            get => _item;
+            set => SetProperty(ref _item, value);
+        }
+
+        private string _title;
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        public ItemDetailPageViewModel()
+        {
+            _datastore = new MockDataStore();
+        }
+
+        public void OnNavigatedFrom(INavigationParameters parameters)
+        {
+        }
+
+        public async void OnNavigatedTo(INavigationParameters parameters)
+        {
+            try
+            {
+                if (parameters.TryGetValue(nameof(Item), out Item item) && item != null)
+                {
+                    Item = item;
+                    Title = item?.Text;
+                }
+                else if (parameters.TryGetValue("Id", out int itemId))
+                {
+                    var selectedItem = await _datastore.GetItemAsync(itemId);
+                    Item = selectedItem;
+                    Title = selectedItem?.Text;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/e2e/Forms/src/ModuleA/ViewModels/ItemListViewModel.cs
+++ b/e2e/Forms/src/ModuleA/ViewModels/ItemListViewModel.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using ModuleA.Views;
+using Prism.Commands;
+using Prism.Navigation;
+using ModuleA.Models;
+using ModuleA.Services;
+using Xamarin.Forms;
+using NavigationParameters = Prism.Navigation.NavigationParameters;
+using Prism;
+using Prism.AppModel;
+
+namespace ModuleA.ViewModels
+{
+    public class ItemListPageViewModel : ViewModelBase
+    {
+        private readonly INavigationService _navigationService;
+        private readonly MockDataStore _datastore;
+        public ObservableCollection<Item> Items { get; }= new ObservableCollection<Item>();
+        public DelegateCommand LoadItemsCommand { get; }
+        public DelegateCommand AddItemCommand { get; }
+        public DelegateCommand<Item> ItemSelectedCommand { get; }
+        public ItemListPageViewModel(INavigationService navigationService)
+        {
+            _navigationService = navigationService;
+            
+            LoadItemsCommand = new DelegateCommand(OnLoadItems);
+            ItemSelectedCommand = new DelegateCommand<Item>(OnItemSelected);
+            _datastore = new MockDataStore();
+        }
+
+        private async void OnLoadItems()
+        {
+            try
+            {
+                Items.Clear();
+                var items = await _datastore.GetItemsAsync(true);
+                foreach (var item in items)
+                {
+                    Items.Add(item);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+        }
+
+        private async void OnItemSelected(Item item)
+        {
+            var result = await _navigationService.NavigateAsync(nameof(ItemDetailPage),
+                new NavigationParameters {{nameof(Item), item}});
+            if (!result.Success)
+            {
+                Console.WriteLine(result.Exception);
+            }
+        }
+
+        public override void OnAppearing()
+        {
+            base.OnAppearing();
+            OnLoadItems();
+        }
+    }
+}

--- a/e2e/Forms/src/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/e2e/Forms/src/ModuleA/ViewModels/ViewAViewModel.cs
@@ -35,7 +35,8 @@ namespace ModuleA.ViewModels
             set { SetProperty(ref _canNavigate, value); }
         }
 
-        public DelegateCommand NavigateCommand { get; set; }
+        public DelegateCommand<string> SelectTabCommand { get; set; }
+        public DelegateCommand<string> NavigateCommand { get; set; }
 
         public DelegateCommand SaveCommand { get; private set; }
 
@@ -58,7 +59,8 @@ namespace ModuleA.ViewModels
         {
             _navigationService = navigationService;
 
-            NavigateCommand = new DelegateCommand(Navigate).ObservesCanExecute(() => CanNavigate);
+            SelectTabCommand = new DelegateCommand<string>(SelectTab).ObservesCanExecute(() => CanNavigate);
+            NavigateCommand = new DelegateCommand<string>(Navigate).ObservesCanExecute(() => CanNavigate);
             SaveCommand = new DelegateCommand(Save);
             ResetCommand = new DelegateCommand(Reset);
 
@@ -76,10 +78,25 @@ namespace ModuleA.ViewModels
             Title = "Saved";
         }
 
-        async void Navigate()
+        async void SelectTab(string tabName)
         {
             CanNavigate = false;
-            await _navigationService.SelectTabAsync("ViewC");
+            var result = await _navigationService.SelectTabAsync(tabName);
+            if (!result.Success)
+            {
+                Console.WriteLine(result.Exception);
+            }
+            CanNavigate = true;
+        }
+
+        async void Navigate(string url)
+        {
+            CanNavigate = false;
+            var result = await _navigationService.NavigateAsync(url);
+            if (!result.Success)
+            {
+                Console.WriteLine(result.Exception);
+            }
             CanNavigate = true;
         }
 

--- a/e2e/Forms/src/ModuleA/ViewModels/ViewModelBase.cs
+++ b/e2e/Forms/src/ModuleA/ViewModels/ViewModelBase.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading.Tasks;
+using Prism;
+using Prism.AppModel;
+using Prism.Mvvm;
+using Prism.Navigation;
+
+namespace ModuleA.ViewModels
+{
+    public class ViewModelBase : BindableBase, INavigationAware, IInitialize, IInitializeAsync, IDestructible, IConfirmNavigation, IConfirmNavigationAsync, IPageLifecycleAware, IActiveAware
+    {
+        bool isBusy = false;
+        public bool IsBusy
+        {
+            get => isBusy;
+            set => SetProperty(ref isBusy, value);
+        }
+
+        string title = string.Empty;
+        public string Title
+        {
+            get => title;
+            set => SetProperty(ref title, value);
+        }
+
+        private bool active;
+        public bool IsActive
+        {
+            get => active;
+            set => SetProperty(ref active, value, () => Console.WriteLine($"{GetType().Name}: IsActive: {value}"));
+        }
+
+        public event EventHandler IsActiveChanged;
+
+        public bool CanNavigate(INavigationParameters parameters)
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(CanNavigate)}");
+            return true;
+        }
+
+        public Task<bool> CanNavigateAsync(INavigationParameters parameters)
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(CanNavigateAsync)}");
+            return Task.FromResult(true);
+        }
+
+        public void Destroy()
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(Destroy)}");
+        }
+
+        public void Initialize(INavigationParameters parameters)
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(Initialize)}");
+        }
+
+        public Task InitializeAsync(INavigationParameters parameters)
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(InitializeAsync)}");
+            return Task.CompletedTask;
+        }
+
+        public virtual void OnAppearing()
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(OnAppearing)}");
+        }
+
+        public virtual void OnDisappearing()
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(OnDisappearing)}");
+        }
+
+        public virtual void OnNavigatedFrom(INavigationParameters parameters)
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(OnNavigatedFrom)}");
+        }
+
+        public virtual void OnNavigatedTo(INavigationParameters parameters)
+        {
+            Console.WriteLine($"{GetType().Name}: {nameof(OnNavigatedTo)}");
+        }
+    }
+}

--- a/e2e/Forms/src/ModuleA/Views/ItemDetailPage.xaml
+++ b/e2e/Forms/src/ModuleA/Views/ItemDetailPage.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:prism="http://prismlibrary.com"
+             prism:ViewModelLocator.AutowireViewModel="True"
+             x:Class="ModuleA.Views.ItemDetailPage" 
+             Title="{Binding Title}"
+             AutomationId="ItemDetailPage">
+    <StackLayout Spacing="20" Padding="15">
+        <Label Text="ID:" FontSize="Medium" />
+        <Label AutomationId="ItemIdLabel" Text="{Binding Item.Id}" FontSize="Small" />
+        <Label Text="Text:" FontSize="Medium" />
+        <Label Text="{Binding Item.Text}" FontSize="Small" />
+        <Label Text="Description:" FontSize="Medium" />
+        <Label Text="{Binding Item.Description}" FontSize="Small" />
+    </StackLayout>
+</ContentPage>

--- a/e2e/Forms/src/ModuleA/Views/ItemDetailPage.xaml.cs
+++ b/e2e/Forms/src/ModuleA/Views/ItemDetailPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+using Xamarin.Forms;
+
+namespace ModuleA.Views
+{
+    // Learn more about making custom code visible in the Xamarin.Forms previewer
+    // by visiting https://aka.ms/xamarinforms-previewer
+    [DesignTimeVisible(false)]
+    public partial class ItemDetailPage : ContentPage
+    { 
+        public ItemDetailPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/e2e/Forms/src/ModuleA/Views/ItemListPage.xaml
+++ b/e2e/Forms/src/ModuleA/Views/ItemListPage.xaml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:prism="http://prismlibrary.com"
+             xmlns:vm="clr-namespace:ModuleA.ViewModels"
+             prism:ViewModelLocator.AutowireViewModel="True"
+             x:Class="ModuleA.Views.ItemListPage" 
+             Title="{Binding Title}" 
+             x:Name="BrowseItemsPage">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Command="{Binding AddItemCommand}"/>
+    </ContentPage.ToolbarItems>
+    <CollectionView x:Name="ItemsCollectionView" ItemsSource="{Binding Items}">
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <StackLayout Padding="10">
+                    <Label Text="{Binding Text}" LineBreakMode="NoWrap" Style="{DynamicResource ListItemTextStyle}" FontSize="16" />
+                    <Label Text="{Binding Description}" LineBreakMode="NoWrap" Style="{DynamicResource ListItemDetailTextStyle}" FontSize="13" />
+                    <StackLayout.GestureRecognizers>
+                        <TapGestureRecognizer NumberOfTapsRequired="1" 
+                                              Command="{Binding Source={x:Reference BrowseItemsPage}, Path=BindingContext.ItemSelectedCommand}"
+                                              CommandParameter="{Binding .}"/>
+                    </StackLayout.GestureRecognizers>
+                </StackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/e2e/Forms/src/ModuleA/Views/ItemListPage.xaml.cs
+++ b/e2e/Forms/src/ModuleA/Views/ItemListPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+using Xamarin.Forms;
+
+namespace ModuleA.Views
+{
+    // Learn more about making custom code visible in the Xamarin.Forms previewer
+    // by visiting https://aka.ms/xamarinforms-previewer
+    [DesignTimeVisible(false)]
+    public partial class ItemListPage : ContentPage
+    {
+        public ItemListPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/e2e/Forms/src/ModuleA/Views/MyTabbedPage.xaml
+++ b/e2e/Forms/src/ModuleA/Views/MyTabbedPage.xaml
@@ -29,8 +29,10 @@
 
   <local:ViewC Title="View C" />
 
-  <!--<local:ViewA Title="View A" />-->
-  <!--<local:ViewB Title="View B"/>-->
-  <!--<local:ViewC Title="View C"/>-->
+  <NavigationPage Title="Items">
+    <x:Arguments>
+      <local:ItemListPage Title="Items" />
+    </x:Arguments>
+  </NavigationPage>
 
 </TabbedPage>

--- a/e2e/Forms/src/ModuleA/Views/ViewA.xaml
+++ b/e2e/Forms/src/ModuleA/Views/ViewA.xaml
@@ -23,14 +23,20 @@
     <Label AutomationId="MessageLabel" Text="{Binding Message}" />
     <Label AutomationId="IsActiveLabel"  Text="{Binding IsActive, StringFormat='IsActive: {0}'}" />
     <Button AutomationId="NavigateButton"
-            Text="Navigate"
-            Command="{Binding NavigateCommand}" />
+            Text="Select Tab C"
+            Command="{Binding SelectTabCommand}" CommandParameter="ViewC"/>
     <Button AutomationId="NavigateToViewBButton"
             Text="View B"
             Command="{prism:NavigateTo ViewB}" />
     <Button AutomationId="SelectTabCButton"
-            Text="Select Tab C"
+            Text="Select Tab C (XAML)"
             Command="{prism:SelectTab ViewC}" />
+    <Button AutomationId="NavigateToItem2XamlButton"
+            Text="Items - Item Detail - 2 (XAML)"
+            Command="{prism:NavigateTo '/MyTabbedPage?selectedTab=ItemListPage|ItemDetailPage?Id=2'}" />
+    <Button AutomationId="NavigateToItem2Button"
+            Text="Items - Item Detail - 2"
+            Command="{Binding NavigateCommand}" CommandParameter="/MyTabbedPage?selectedTab=ItemListPage|ItemDetailPage?Id=2" />
     <Button AutomationId="Show Demo Dialog Button"
             Text="Show Demo Dialog"
             Command="{prism:ShowDialog 'DemoDialog?message=Hello%20From%20ViewA!&amp;closeOnBackgroundTapped=true'}" />

--- a/e2e/Forms/tests/HelloWorld.UITests/AppManager.cs
+++ b/e2e/Forms/tests/HelloWorld.UITests/AppManager.cs
@@ -40,7 +40,6 @@ namespace HelloWorld.UITests
                     .Android
                     // Used to run a .apk file:
                     .EnableLocalScreenshots()
-                    .ApkFile(@"Z:\repos\Twitch\Prism\Sandbox\Xamarin\HelloWorld\HelloWorld\HelloWorld.Android\bin\Release\com.prismlibrary.helloworld.apk")
                     .StartApp();
             }
 
@@ -52,6 +51,7 @@ namespace HelloWorld.UITests
                     //.AppBundle("path/to/file.app")
                     // Used to run a .ipa file on a physical ios device:
                     //.InstalledApp("com.company.bundleid")
+                    .EnableLocalScreenshots()
                     .StartApp();
             }
         }

--- a/e2e/Forms/tests/HelloWorld.UITests/HelloWorld.UITests.csproj
+++ b/e2e/Forms/tests/HelloWorld.UITests/HelloWorld.UITests.csproj
@@ -15,4 +15,14 @@
     <PackageReference Include="Xamarin.UITest" Version="3.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\HelloWorld.iOS\HelloWorld.iOS.csproj">
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\HelloWorld.Android\HelloWorld.Android.csproj">
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/e2e/Forms/tests/HelloWorld.UITests/Pages/ItemDetailPage.cs
+++ b/e2e/Forms/tests/HelloWorld.UITests/Pages/ItemDetailPage.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+using Query = System.Func<Xamarin.UITest.Queries.AppQuery, Xamarin.UITest.Queries.AppQuery>;
+
+namespace HelloWorld.UITests.Pages
+{
+    public class ItemDetailPage : BasePage
+    {
+        Query pageIdQuery = x => x.Marked("ItemDetailPage");
+        Query itemIdLabelQuery = x => x.Marked("ItemIdLabel");
+
+        protected override PlatformQuery Trait => new PlatformQuery
+        {
+            Android = pageIdQuery,
+            iOS = pageIdQuery
+        };
+
+        public int GetItemIdLabelValue()
+        {
+            app.WaitForElement(itemIdLabelQuery);
+
+            var result = app.Query(itemIdLabelQuery).Single();
+            return Convert.ToInt32(result.Text);
+        }
+    }
+}

--- a/e2e/Forms/tests/HelloWorld.UITests/Pages/ViewA.cs
+++ b/e2e/Forms/tests/HelloWorld.UITests/Pages/ViewA.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Query = System.Func<Xamarin.UITest.Queries.AppQuery, Xamarin.UITest.Queries.AppQuery>;
+﻿using Query = System.Func<Xamarin.UITest.Queries.AppQuery, Xamarin.UITest.Queries.AppQuery>;
 
 namespace HelloWorld.UITests.Pages
 {
     public class ViewA : BasePage
     {
         readonly Query navigateToViewBButton;
+        readonly Query navigateToItem2XamlButton;
+        readonly Query navigateToItem2Button;
 
         protected override PlatformQuery Trait => new PlatformQuery
         {
@@ -20,6 +17,8 @@ namespace HelloWorld.UITests.Pages
         public ViewA()
         {
             navigateToViewBButton = x => x.Marked("NavigateToViewBButton");
+            navigateToItem2XamlButton = x => x.Marked("NavigateToItem2XamlButton");
+            navigateToItem2Button = x => x.Marked("NavigateToItem2Button");
         }
 
         public void NavigateToViewB()
@@ -27,6 +26,20 @@ namespace HelloWorld.UITests.Pages
             app.WaitForElement(navigateToViewBButton);
             app.Screenshot("Tap Navigate to ViewB Button");
             app.Tap(navigateToViewBButton);
+        }
+
+        public void NavigateToItem2Xaml()
+        {
+            app.WaitForElement(navigateToItem2XamlButton);
+            app.Screenshot("Tap Navigate to Item List > Item Detail - ID 2 (XAML) Button");
+            app.Tap(navigateToItem2XamlButton);
+        }
+
+        public void NavigateToItem2()
+        {
+            app.WaitForElement(navigateToItem2Button);
+            app.Screenshot("Tap Navigate to Item List > Item Detail - ID 2 Button");
+            app.Tap(navigateToItem2Button);
         }
     }
 }

--- a/e2e/Forms/tests/HelloWorld.UITests/Test.cs
+++ b/e2e/Forms/tests/HelloWorld.UITests/Test.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using HelloWorld.UITests.Pages;
 using NUnit.Framework;
 using Xamarin.UITest;
@@ -41,6 +37,26 @@ namespace HelloWorld.UITests
             new ViewA().NavigateToViewB();
 
             new ViewB();
+        }
+
+        [Test]
+        public void NavigateToItemList_ItemDetail_Id2()
+        {
+            new ViewA().NavigateToItem2();
+
+            var itemDetailPage = new ItemDetailPage();
+            var result = itemDetailPage.GetItemIdLabelValue();
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void NavigateToItemList_ItemDetail_Id2_Xaml()
+        {
+            new ViewA().NavigateToItem2();
+
+            var itemDetailPage = new ItemDetailPage();
+            var result = itemDetailPage.GetItemIdLabelValue();
+            Assert.AreEqual(2, result);
         }
     }
 }

--- a/src/Forms/Prism.Forms/Navigation/NavigationException.cs
+++ b/src/Forms/Prism.Forms/Navigation/NavigationException.cs
@@ -12,6 +12,7 @@ namespace Prism.Navigation
         public const string IConfirmNavigationReturnedFalse = "IConfirmNavigation returned false";
         public const string NoPageIsRegistered = "No Page has been registered with the provided key";
         public const string ErrorCreatingPage = "An error occurred while resolving the page. This is most likely the result of invalid XAML or other type initialization exception";
+        public const string AmbiguousSelectedTab = "The requested selected tab matches more than one child page";
         public const string UnknownException = "An unknown error occurred. You may need to specify whether to Use Modal Navigation or not.";
 
         public NavigationException()
@@ -28,5 +29,15 @@ namespace Prism.Navigation
         }
 
         public Page Page { get; }
+    }
+
+    public class AmbiguousPathException : Exception
+    {
+        public string Name { get; }
+
+        public AmbiguousPathException(string name)
+        {
+            Name = name;
+        }
     }
 }

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -885,7 +885,8 @@ namespace Prism.Navigation
                         {
                             var navigationPageChild = await CreatePageFromSegment(tabSegements[1]);
 
-                            navigationPage.PushAsync(navigationPageChild);
+                            // previously this was not awaited, was there a reason for that?
+                            await navigationPage.PushAsync(navigationPageChild);
 
                             //when creating a NavigationPage w/ DI, a blank Page object is injected into the ctor. Let's remove it
                             if (navigationPage.Navigation.NavigationStack.Count > 1)

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -535,7 +535,7 @@ namespace Prism.Navigation
                     if (nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                     {
                         var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                        await SelectPageTab(topPage, segmentParams);
+                        await SelectPageTab(topPage, segmentParams, nextSegment);
                     }
                 });
             }
@@ -639,7 +639,7 @@ namespace Prism.Navigation
                      if (detail is TabbedPage && nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                      {
                          var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                         await SelectPageTab(detail, segmentParams);
+                         await SelectPageTab(detail, segmentParams, nextSegment);
                      }
 
                      currentPage.IsPresented = isPresented;
@@ -906,7 +906,7 @@ namespace Prism.Navigation
                 }
             }
 
-            await TabbedPageSelectTab(tabbedPage, parameters);
+            await TabbedPageSelectTab(tabbedPage, parameters, segment);
         }
 
         void ConfigureCarouselPage(CarouselPage carouselPage, string segment)
@@ -921,11 +921,11 @@ namespace Prism.Navigation
             CarouselPageSelectTab(carouselPage, parameters);
         }
 
-        private async Task SelectPageTab(Page page, INavigationParameters parameters)
+        private async Task SelectPageTab(Page page, INavigationParameters parameters, string segment)
         {
             if (page is TabbedPage tabbedPage)
             {
-                await TabbedPageSelectTab(tabbedPage, parameters);
+                await TabbedPageSelectTab(tabbedPage, parameters, segment);
             }
             else if (page is CarouselPage carouselPage)
             {
@@ -933,7 +933,7 @@ namespace Prism.Navigation
             }
         }
 
-        private async Task TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
+        private async Task TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters, string segment)
         {
             var selectedTab = parameters?.GetValue<string>(KnownNavigationParameters.SelectedTab);
             if (!string.IsNullOrWhiteSpace(selectedTab))

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -535,7 +535,7 @@ namespace Prism.Navigation
                     if (nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                     {
                         var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                        SelectPageTab(topPage, segmentParams, nextSegment);
+                        SelectPageTab(topPage, segmentParams);
                     }
                 });
             }
@@ -639,7 +639,7 @@ namespace Prism.Navigation
                      if (detail is TabbedPage && nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                      {
                          var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                         SelectPageTab(detail, segmentParams, nextSegment);
+                         SelectPageTab(detail, segmentParams);
                      }
 
                      currentPage.IsPresented = isPresented;
@@ -906,7 +906,7 @@ namespace Prism.Navigation
                 }
             }
 
-            TabbedPageSelectTab(tabbedPage, parameters, segment);
+            TabbedPageSelectTab(tabbedPage, parameters);
         }
 
         void ConfigureCarouselPage(CarouselPage carouselPage, string segment)
@@ -921,11 +921,11 @@ namespace Prism.Navigation
             CarouselPageSelectTab(carouselPage, parameters);
         }
 
-        private static void SelectPageTab(Page page, INavigationParameters parameters, string segment)
+        private static void SelectPageTab(Page page, INavigationParameters parameters)
         {
             if (page is TabbedPage tabbedPage)
             {
-                TabbedPageSelectTab(tabbedPage, parameters, segment);
+                TabbedPageSelectTab(tabbedPage, parameters);
             }
             else if (page is CarouselPage carouselPage)
             {
@@ -933,14 +933,13 @@ namespace Prism.Navigation
             }
         }
 
-        private static void TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters, string segment)
+        private static void TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
         {
             var selectedTab = parameters?.GetValue<string>(KnownNavigationParameters.SelectedTab);
             if (!string.IsNullOrWhiteSpace(selectedTab))
             {
                 var selectedTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTab));
 
-                var childFound = false;
                 foreach (var child in tabbedPage.Children)
                 {
                     if (child.GetType() == selectedTabType)
@@ -959,11 +958,6 @@ namespace Prism.Navigation
                         tabbedPage.CurrentPage = child;
                         break;
                     }
-                }
-
-                // TODO: Enhancement #2038 https://github.com/PrismLibrary/Prism/issues/2038
-                if (childFound)
-                {
                 }
             }
         }

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -459,7 +459,7 @@ namespace Prism.Navigation
 
         protected virtual async Task ProcessNavigationForRootPage(string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
-            var nextPage = CreatePageFromSegment(nextSegment);
+            var nextPage = await CreatePageFromSegment(nextSegment);
 
             await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
 
@@ -481,7 +481,7 @@ namespace Prism.Navigation
             bool useReverse = UseReverseNavigation(currentPage, nextPageType) && !(useModalNavigation.HasValue && useModalNavigation.Value);
             if (!useReverse)
             {
-                var nextPage = CreatePageFromSegment(nextSegment);
+                var nextPage = await CreatePageFromSegment(nextSegment);
 
                 await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
 
@@ -530,12 +530,12 @@ namespace Prism.Navigation
                 if (segments.Count > 0)
                     await UseReverseNavigation(topPage, segments.Dequeue(), segments, parameters, false, animated);
 
-                await DoNavigateAction(topPage, nextSegment, topPage, parameters, onNavigationActionCompleted: (p) =>
+                await DoNavigateAction(topPage, nextSegment, topPage, parameters, onNavigationActionCompleted: async (p) =>
                 {
                     if (nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                     {
                         var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                        SelectPageTab(topPage, segmentParams);
+                        await SelectPageTab(topPage, segmentParams);
                     }
                 });
             }
@@ -555,7 +555,7 @@ namespace Prism.Navigation
 
         protected virtual async Task ProcessNavigationForTabbedPage(TabbedPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
-            var nextPage = CreatePageFromSegment(nextSegment);
+            var nextPage = await CreatePageFromSegment(nextSegment);
             await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
             await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
             {
@@ -565,7 +565,7 @@ namespace Prism.Navigation
 
         protected virtual async Task ProcessNavigationForCarouselPage(CarouselPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
-            var nextPage = CreatePageFromSegment(nextSegment);
+            var nextPage = await CreatePageFromSegment(nextSegment);
             await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
             await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
             {
@@ -580,7 +580,7 @@ namespace Prism.Navigation
             var detail = currentPage.Detail;
             if (detail == null)
             {
-                var newDetail = CreatePageFromSegment(nextSegment);
+                var newDetail = await CreatePageFromSegment(nextSegment);
                 await ProcessNavigation(newDetail, segments, parameters, useModalNavigation, animated);
                 await DoNavigateAction(null, nextSegment, newDetail, parameters, onNavigationActionCompleted: (p) =>
                 {
@@ -592,7 +592,7 @@ namespace Prism.Navigation
 
             if (useModalNavigation.HasValue && useModalNavigation.Value)
             {
-                var nextPage = CreatePageFromSegment(nextSegment);
+                var nextPage = await CreatePageFromSegment(nextSegment);
                 await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
                 await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
                 {
@@ -634,12 +634,12 @@ namespace Prism.Navigation
             if ((detailIsNavPage && reuseNavPage) || (!detailIsNavPage && detail.GetType() == nextSegmentType))
             {
                 await ProcessNavigation(detail, segments, parameters, useModalNavigation, animated);
-                await DoNavigateAction(null, nextSegment, detail, parameters, onNavigationActionCompleted: (p) =>
+                await DoNavigateAction(null, nextSegment, detail, parameters, onNavigationActionCompleted: async (p) =>
                  {
                      if (detail is TabbedPage && nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                      {
                          var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                         SelectPageTab(detail, segmentParams);
+                         await SelectPageTab(detail, segmentParams);
                      }
 
                      currentPage.IsPresented = isPresented;
@@ -648,7 +648,7 @@ namespace Prism.Navigation
             }
             else
             {
-                var newDetail = CreatePageFromSegment(nextSegment);
+                var newDetail = await CreatePageFromSegment(nextSegment);
                 await ProcessNavigation(newDetail, segments, parameters, newDetail is NavigationPage ? false : true, animated);
                 await DoNavigateAction(detail, nextSegment, newDetail, parameters, onNavigationActionCompleted: (p) =>
                 {
@@ -798,7 +798,7 @@ namespace Prism.Navigation
             }
         }
 
-        protected virtual Page CreatePageFromSegment(string segment)
+        protected virtual async Task<Page> CreatePageFromSegment(string segment)
         {
             string segmentName = null;
             try
@@ -813,7 +813,7 @@ namespace Prism.Navigation
 
                 PageUtilities.SetAutowireViewModelOnPage(page);
                 _pageBehaviorFactory.ApplyPageBehaviors(page);
-                ConfigurePages(page, segment);
+                await ConfigurePages(page, segment);
 
                 return page;
             }
@@ -844,11 +844,11 @@ namespace Prism.Navigation
             return page;
         }
 
-        void ConfigurePages(Page page, string segment)
+        async Task ConfigurePages(Page page, string segment)
         {
             if (page is TabbedPage)
             {
-                ConfigureTabbedPage((TabbedPage)page, segment);
+                await ConfigureTabbedPage((TabbedPage)page, segment);
             }
             else if (page is CarouselPage)
             {
@@ -856,7 +856,7 @@ namespace Prism.Navigation
             }
         }
 
-        void ConfigureTabbedPage(TabbedPage tabbedPage, string segment)
+        async Task ConfigureTabbedPage(TabbedPage tabbedPage, string segment)
         {
             foreach (var child in tabbedPage.Children)
             {
@@ -880,10 +880,10 @@ namespace Prism.Navigation
                     var tabSegements = tabToCreate.Split('|');
                     if (tabSegements.Length > 1)
                     {
-                        var navigationPage = CreatePageFromSegment(tabSegements[0]) as NavigationPage;
+                        var navigationPage = await CreatePageFromSegment(tabSegements[0]) as NavigationPage;
                         if (navigationPage != null)
                         {
-                            var navigationPageChild = CreatePageFromSegment(tabSegements[1]);
+                            var navigationPageChild = await CreatePageFromSegment(tabSegements[1]);
 
                             navigationPage.PushAsync(navigationPageChild);
 
@@ -900,13 +900,13 @@ namespace Prism.Navigation
                     }
                     else
                     {
-                        var tab = CreatePageFromSegment(tabToCreate);
+                        var tab = await CreatePageFromSegment(tabToCreate);
                         tabbedPage.Children.Add(tab);
                     }
                 }
             }
 
-            TabbedPageSelectTab(tabbedPage, parameters);
+            await TabbedPageSelectTab(tabbedPage, parameters);
         }
 
         void ConfigureCarouselPage(CarouselPage carouselPage, string segment)
@@ -921,11 +921,11 @@ namespace Prism.Navigation
             CarouselPageSelectTab(carouselPage, parameters);
         }
 
-        private static void SelectPageTab(Page page, INavigationParameters parameters)
+        private async Task SelectPageTab(Page page, INavigationParameters parameters)
         {
             if (page is TabbedPage tabbedPage)
             {
-                TabbedPageSelectTab(tabbedPage, parameters);
+                await TabbedPageSelectTab(tabbedPage, parameters);
             }
             else if (page is CarouselPage carouselPage)
             {
@@ -933,12 +933,25 @@ namespace Prism.Navigation
             }
         }
 
-        private static void TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
+        private async Task TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
         {
             var selectedTab = parameters?.GetValue<string>(KnownNavigationParameters.SelectedTab);
             if (!string.IsNullOrWhiteSpace(selectedTab))
             {
-                var selectedTabType = PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTab));
+                string segment;
+                Queue<string> tabSegements = null;
+                if (selectedTab.Contains('|'))
+                {
+                    tabSegements = new Queue<string>(selectedTab.Split('|'));
+                    segment = tabSegements.Dequeue();
+                }
+                else
+                {
+                    segment = selectedTab;
+                }
+                
+                var selectedTabType =
+                    PageNavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(segment));
 
                 foreach (var child in tabbedPage.Children)
                 {
@@ -951,11 +964,12 @@ namespace Prism.Navigation
                             (navPage.CurrentPage.GetType() == selectedTabType 
                              || navPage.RootPage.GetType() == selectedTabType))
                     {
-                        if (tabbedPage.Children.Count(x => x.GetType() == selectedTabType) > 1)
-                            throw new NavigationException(NavigationException.AmbiguousSelectedTab, tabbedPage,
-                                new AmbiguousPathException(selectedTabType.Name));
-            
                         tabbedPage.CurrentPage = child;
+
+                        if (tabSegements?.Any() == true)
+                        {
+                            await ProcessNavigation(navPage.CurrentPage, tabSegements, parameters, false, false);
+                        }
                         break;
                     }
                 }
@@ -1037,7 +1051,7 @@ namespace Prism.Navigation
             while (navigationStack.Count > 0)
             {
                 var segment = navigationStack.Pop();
-                var nextPage = CreatePageFromSegment(segment);
+                var nextPage = await CreatePageFromSegment(segment);
                 await DoNavigateAction(onNavigatedFromTarget, segment, nextPage, parameters, async () =>
                 {
                     await DoPush(currentPage, nextPage, useModalNavigation, animated, insertBefore, pageOffset);
@@ -1076,11 +1090,6 @@ namespace Prism.Navigation
                     }
                     else
                     {
-                        if (currentPage is TabbedPage tabbedPage
-                            && tabbedPage.CurrentPage is NavigationPage navigationPage)
-                        {
-                            return navigationPage.Navigation.PushAsync(page, animated);
-                        }
                         return currentPage.Navigation.PushAsync(page, animated);
                     }
                 }
@@ -1115,8 +1124,7 @@ namespace Prism.Navigation
 
             if (useModalNavigationDefault.HasValue)
                 useModalNavigation = useModalNavigationDefault.Value;
-            else if (currentPage is NavigationPage
-                        || (currentPage is TabbedPage tabbedPage && tabbedPage.CurrentPage is NavigationPage))
+            else if (currentPage is NavigationPage)
                 useModalNavigation = false;
             else
                 useModalNavigation = !PageUtilities.HasNavigationPageParent(currentPage);

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -535,7 +535,7 @@ namespace Prism.Navigation
                     if (nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                     {
                         var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                        await SelectPageTab(topPage, segmentParams, nextSegment);
+                        await SelectPageTab(topPage, segmentParams);
                     }
                 });
             }
@@ -639,7 +639,7 @@ namespace Prism.Navigation
                      if (detail is TabbedPage && nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                      {
                          var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                         await SelectPageTab(detail, segmentParams, nextSegment);
+                         await SelectPageTab(detail, segmentParams);
                      }
 
                      currentPage.IsPresented = isPresented;
@@ -906,7 +906,7 @@ namespace Prism.Navigation
                 }
             }
 
-            await TabbedPageSelectTab(tabbedPage, parameters, segment);
+            await TabbedPageSelectTab(tabbedPage, parameters);
         }
 
         void ConfigureCarouselPage(CarouselPage carouselPage, string segment)
@@ -921,11 +921,11 @@ namespace Prism.Navigation
             CarouselPageSelectTab(carouselPage, parameters);
         }
 
-        private async Task SelectPageTab(Page page, INavigationParameters parameters, string segment)
+        private async Task SelectPageTab(Page page, INavigationParameters parameters)
         {
             if (page is TabbedPage tabbedPage)
             {
-                await TabbedPageSelectTab(tabbedPage, parameters, segment);
+                await TabbedPageSelectTab(tabbedPage, parameters);
             }
             else if (page is CarouselPage carouselPage)
             {
@@ -933,7 +933,7 @@ namespace Prism.Navigation
             }
         }
 
-        private async Task TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters, string segment)
+        private async Task TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
         {
             var selectedTab = parameters?.GetValue<string>(KnownNavigationParameters.SelectedTab);
             if (!string.IsNullOrWhiteSpace(selectedTab))

--- a/tests/Forms/Prism.Forms.Tests/Mocks/PageNavigationEventRecorder.cs
+++ b/tests/Forms/Prism.Forms.Tests/Mocks/PageNavigationEventRecorder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Prism.Navigation;
 
 namespace Prism.Forms.Tests.Mocks
 {
@@ -26,9 +27,11 @@ namespace Prism.Forms.Tests.Mocks
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="pageNavigationEvent"></param>
-        public void Record(object sender, PageNavigationEvent pageNavigationEvent)
+        public void Record(object sender, 
+            PageNavigationEvent pageNavigationEvent,
+            INavigationParameters navigationParameters = null)
         {
-            _records.Enqueue(new PageNavigationRecord(sender, pageNavigationEvent));
+            _records.Enqueue(new PageNavigationRecord(sender, pageNavigationEvent, navigationParameters));
         }
 
         public PageNavigationRecord TakeFirst()

--- a/tests/Forms/Prism.Forms.Tests/Mocks/PageNavigationRecord.cs
+++ b/tests/Forms/Prism.Forms.Tests/Mocks/PageNavigationRecord.cs
@@ -1,14 +1,20 @@
-﻿namespace Prism.Forms.Tests.Mocks
+﻿using Prism.Navigation;
+
+namespace Prism.Forms.Tests.Mocks
 {
     public class PageNavigationRecord
     {
         public object Sender { get; }
         public PageNavigationEvent Event { get; }
+        public INavigationParameters NavigationParameters { get; }
 
-        public PageNavigationRecord(object sender, PageNavigationEvent @event)
+        public PageNavigationRecord(object sender, 
+            PageNavigationEvent @event, 
+            INavigationParameters navigationParameters = null)
         {
             Sender = sender;
             Event = @event;
+            NavigationParameters = navigationParameters;
         }
 
         public override string ToString()

--- a/tests/Forms/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
+++ b/tests/Forms/Prism.Forms.Tests/Mocks/PageNavigationServiceMock.cs
@@ -25,7 +25,10 @@ namespace Prism.Forms.Tests.Mocks
 
             PageUtilities.InvokeViewAndViewModelAction<IPageNavigationEventRecordable>(
                 page, 
-                x => x.PageNavigationEventRecorder = _recorder);
+                x =>
+                {
+                    if (_recorder != null) x.PageNavigationEventRecorder = _recorder;
+                });
 
             return page;
         }

--- a/tests/Forms/Prism.Forms.Tests/Mocks/Views/ContentPageMock.cs
+++ b/tests/Forms/Prism.Forms.Tests/Mocks/Views/ContentPageMock.cs
@@ -34,25 +34,25 @@ namespace Prism.Forms.Tests.Mocks.Views
         public void OnNavigatedFrom(INavigationParameters parameters)
         {
             OnNavigatedFromCalled = true;
-            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedFrom);
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedFrom, parameters);
         }
 
         public void OnNavigatedTo(INavigationParameters parameters)
         {
             OnNavigatedToCalled = true;
-            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedTo);
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnNavigatedTo, parameters);
         }
 
         public void Initialize(INavigationParameters parameters)
         {
             InitializeCalled = true;
-            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnInitialized);
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnInitialized, parameters);
         }
 
         public Task InitializeAsync(INavigationParameters parameters)
         {
             InitializeAsyncCalled = true;
-            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnInitializedAsync);
+            PageNavigationEventRecorder?.Record(this, PageNavigationEvent.OnInitializedAsync, parameters);
             return Task.CompletedTask;
         }
 
@@ -78,7 +78,7 @@ namespace Prism.Forms.Tests.Mocks.Views
 
     public class SecondContentPageMock : ContentPageMock
     {
-        public SecondContentPageMock()
+        public SecondContentPageMock() : base(new PageNavigationEventRecorder())
         {
         }
 

--- a/tests/Forms/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/tests/Forms/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -36,7 +36,7 @@ namespace Prism.Forms.Tests.Navigation
             _container.Register(typeof(ContentPageMockViewModel).FullName, typeof(ContentPageMock));
             _container.Register(typeof(ContentPageMock1ViewModel).FullName, typeof(ContentPageMock1));
 
-            _container.Register("SecondContentPageMock", typeof(SecondContentPageMock));
+            _container.Register("SecondContentPage", typeof(SecondContentPageMock));
 
             _container.Register("NavigationPage", typeof(NavigationPageMock));
             _container.Register("NavigationPage-Empty", typeof(NavigationPageEmptyMock));
@@ -627,7 +627,7 @@ namespace Prism.Forms.Tests.Navigation
 
             // Navigate to Page2
             ((IPageAware)navigationService).Page = contentPageMock;
-            await navigationService.NavigateAsync("SecondContentPageMock");
+            await navigationService.NavigateAsync("SecondContentPage");
 
             Assert.Equal(0, navigationPage.Navigation.ModalStack.Count);
             Assert.Equal(2, navigationPage.Navigation.NavigationStack.Count);
@@ -683,7 +683,7 @@ namespace Prism.Forms.Tests.Navigation
 
             // Navigate to Page2
             ((IPageAware)navigationService).Page = contentPageMock;
-            await navigationService.NavigateAsync("SecondContentPageMock");
+            await navigationService.NavigateAsync("SecondContentPage");
 
             var secondContentPage = navigationPage.Navigation.NavigationStack.Last();
             var secondContentPageViewModel = secondContentPage.BindingContext;
@@ -878,13 +878,13 @@ namespace Prism.Forms.Tests.Navigation
 
             // Navigate to Page2
             ((IPageAware)navigationService).Page = contentPageMock;
-            await navigationService.NavigateAsync("SecondContentPageMock");
+            await navigationService.NavigateAsync("SecondContentPage");
 
             var secondContentPage = navigationPage.Navigation.NavigationStack.Last();
 
             recorder.Clear();
             ((IPageAware)navigationService).Page = navigationPage;
-            await navigationService.NavigateAsync("SecondContentPageMock");
+            await navigationService.NavigateAsync("SecondContentPage");
 
             Assert.Equal(0, navigationPage.Navigation.ModalStack.Count);
             Assert.Equal(2, navigationPage.Navigation.NavigationStack.Count);
@@ -1558,8 +1558,28 @@ namespace Prism.Forms.Tests.Navigation
             Assert.IsType<ContentPageMock>(navPage.CurrentPage);
         }
 
+        //[Fact(Skip = "WIP Enhancement #2038 https://github.com/PrismLibrary/Prism/issues/2038")]
         [Fact]
         public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+            
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=ContentPage/SecondContentPage");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+
+            var navPage = tabbedPage.CurrentPage as NavigationPageMock;
+            
+            Assert.NotNull(navPage);
+            Assert.IsType<SecondContentPageMock>(navPage.CurrentPage);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_ToContentPage_Modal()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new ContentPage();
@@ -1577,7 +1597,7 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void Navigate_FromNavigationPage_ToTabbedPage_SelectedTab_ToContentPage()
+        public async void Navigate_FromNavigationPage_ToTabbedPage_SelectedTab_ToContentPage_Modal()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.NavigationPage();
@@ -1597,7 +1617,7 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void Navigate_FromNavigationPage_ToTabbedPage_SelectedTab_NavigationPage_ToContentPage()
+        public async void Navigate_FromNavigationPage_ToTabbedPage_SelectedTab_NavigationPage_ToContentPage_Modal()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.NavigationPage();
@@ -1621,7 +1641,7 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_ToContentPage()
+        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_ToContentPage_Modal()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.MasterDetailPage();
@@ -1657,7 +1677,7 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_SelectedTab_ToContentPage()
+        public async void Navigate_FromMasterDetailPage_ToNavigationPage_ToTabbedPage_SelectedTab_ToContentPage_Modal()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new Xamarin.Forms.MasterDetailPage();

--- a/tests/Forms/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/tests/Forms/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -1558,7 +1558,6 @@ namespace Prism.Forms.Tests.Navigation
             Assert.IsType<ContentPageMock>(navPage.CurrentPage);
         }
 
-        //[Fact(Skip = "WIP Enhancement #2038 https://github.com/PrismLibrary/Prism/issues/2038")]
         [Fact]
         public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_ToContentPage()
         {
@@ -1579,7 +1578,7 @@ namespace Prism.Forms.Tests.Navigation
         }
 
         [Fact]
-        public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_ToContentPage_Modal()
+        public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_NotNavigationPage_ToContentPage_ImplicitModal()
         {
             var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
             var rootPage = new ContentPage();
@@ -1768,6 +1767,28 @@ namespace Prism.Forms.Tests.Navigation
             var navPage = tabbedPage.Children[1] as NavigationPageMock;
             Assert.IsType<NavigationPageMock>(navPage);
             Assert.IsType<Tab2Mock>(navPage.CurrentPage);
+            
+            Assert.IsType<Tab3Mock>(tabbedPage.Children[2]);
+        }
+
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_CreateTabs_WithNavigationPage_SelectTab_ToContentPage()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _applicationProvider, _loggerFacade);
+            var rootPage = new ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=Tab1&{KnownNavigationParameters.CreateTab}=NavigationPage|Tab2&{KnownNavigationParameters.CreateTab}=Tab3&{KnownNavigationParameters.SelectedTab}=Tab2|SecondContentPage/AnotherPage");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageEmptyMock;
+            Assert.NotNull(tabbedPage);
+            Assert.Equal(3, tabbedPage.Children.Count());
+
+            Assert.IsType<Tab1Mock>(tabbedPage.Children[0]);
+
+            var navPage = tabbedPage.Children[1] as NavigationPageMock;
+            Assert.IsType<NavigationPageMock>(navPage);
+            Assert.IsType<SecondContentPageMock>(navPage.CurrentPage);
             
             Assert.IsType<Tab3Mock>(tabbedPage.Children[2]);
         }

--- a/tests/Forms/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
+++ b/tests/Forms/Prism.Forms.Tests/Navigation/PageNavigationServiceFixture.cs
@@ -1565,7 +1565,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
             
-            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=ContentPage/SecondContentPage");
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=ContentPage|SecondContentPage");
 
             var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
             Assert.NotNull(tabbedPage);
@@ -1778,7 +1778,7 @@ namespace Prism.Forms.Tests.Navigation
             var rootPage = new ContentPage();
             ((IPageAware)navigationService).Page = rootPage;
 
-            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=Tab1&{KnownNavigationParameters.CreateTab}=NavigationPage|Tab2&{KnownNavigationParameters.CreateTab}=Tab3&{KnownNavigationParameters.SelectedTab}=Tab2|SecondContentPage/AnotherPage");
+            await navigationService.NavigateAsync($"TabbedPage-Empty?{KnownNavigationParameters.CreateTab}=Tab1&{KnownNavigationParameters.CreateTab}=NavigationPage|Tab2&{KnownNavigationParameters.CreateTab}=Tab3&{KnownNavigationParameters.SelectedTab}=Tab2|SecondContentPage");
 
             var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageEmptyMock;
             Assert.NotNull(tabbedPage);


### PR DESCRIPTION
﻿## Description of Change

Support for Navigation into sub-pages of TabbedPage.CurrentPage using selectedTab
```
TabbedPage?selectedTab=Tab2|ViewA|ViewB|ViewC
```

### Bugs Fixed

#2038 

### API Changes

The signature of multiple internal methods of `PageNavigationService` were changed to `async Task` and call sites were awaited.

### Behavioral Changes

`PageNavigationService` will now parse the `selectedTab` portion of the string/Uri and split it based on the pipe. These changes were concentrated within the `TabbedPageSelectTab` method.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard