### PR TITLE
fix: Adjust for updated android SDK Android-28 emulator name

### DIFF
--- a/build/scripts/android-uitest-run.sh
+++ b/build/scripts/android-uitest-run.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Install AVD files
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis_playstore;x86'
 
 # Create emulator
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n xamarin_android_emulator -k 'system-images;android-28;google_apis;x86' --force
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n xamarin_android_emulator -k 'system-images;android-28;google_apis_playstore;x86' --force
 
 echo $ANDROID_HOME/emulator/emulator -list-avds
 


### PR DESCRIPTION
﻿## Description of Change

Google recently changed their SDK definitions for emulators, where `system-images;android-28;google_apis;x86` became `system-images;android-28;google_apis_playstore;x86`.

This allows for the tests to download the proper emulators.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard