### PR TITLE
Replace deprecated DryIoc configuration method call

### DIFF
--- a/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
+++ b/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
@@ -21,7 +21,7 @@ namespace Prism.DryIoc
         /// <summary>
         /// Gets the Default DryIoc Container Rules used by Prism
         /// </summary>
-        public static Rules DefaultRules => Rules.Default.WithAutoConcreteTypeResolution()
+        public static Rules DefaultRules => Rules.Default.WithConcreteTypeDynamicRegistrations()
                                                          .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
                                                          .WithFuncAndLazyWithoutRegistration()
                                                          .WithTrackingDisposableTransients()


### PR DESCRIPTION
﻿## Description of Change

Replaces deprecated method call in the DryIoc container configuration with the recommended one.

### API Changes

None

### Behavioral Changes

No changes, the new method effectively does the same.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x ] Rebased on top of master at time of PR
- [x ] Changes adhere to coding standard

### Tests
I could not find a test explicitly checking that non-registered service classes will get resolved. Other bunch of other tests break when this condition is not satisfied. Should I add a new one and if yes - where?