### PR TITLE
Renamed IDestructibleRegionBehavior to DestructibleRegionBehavior

### DIFF
--- a/src/Wpf/Prism.Wpf/Bootstrapper.cs
+++ b/src/Wpf/Prism.Wpf/Bootstrapper.cs
@@ -166,7 +166,7 @@ namespace Prism
                 defaultRegionBehaviorTypesDictionary.AddIfMissing(AutoPopulateRegionBehavior.BehaviorKey,
                                                   typeof(AutoPopulateRegionBehavior));
 
-                defaultRegionBehaviorTypesDictionary.AddIfMissing(IDestructibleRegionBehavior.BehaviorKey, typeof(IDestructibleRegionBehavior));
+                defaultRegionBehaviorTypesDictionary.AddIfMissing(DestructibleRegionBehavior.BehaviorKey, typeof(DestructibleRegionBehavior));
             }
 
             return defaultRegionBehaviorTypesDictionary;

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -55,7 +55,7 @@ namespace Prism
             regionBehaviors.AddIfMissing<RegionMemberLifetimeBehavior>(RegionMemberLifetimeBehavior.BehaviorKey);
             regionBehaviors.AddIfMissing<ClearChildViewsRegionBehavior>(ClearChildViewsRegionBehavior.BehaviorKey);
             regionBehaviors.AddIfMissing<AutoPopulateRegionBehavior>(AutoPopulateRegionBehavior.BehaviorKey);
-            regionBehaviors.AddIfMissing<IDestructibleRegionBehavior>(IDestructibleRegionBehavior.BehaviorKey);
+            regionBehaviors.AddIfMissing<DestructibleRegionBehavior>(DestructibleRegionBehavior.BehaviorKey);
         }
 
         internal static void RegisterDefaultRegionAdapterMappings(this RegionAdapterMappings regionAdapterMappings)

--- a/src/Wpf/Prism.Wpf/Regions/Behaviors/DestructibleRegionBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Regions/Behaviors/DestructibleRegionBehavior.cs
@@ -5,7 +5,7 @@ using System.Collections.Specialized;
 
 namespace Prism.Regions.Behaviors
 {
-    public class IDestructibleRegionBehavior : RegionBehavior
+    public class DestructibleRegionBehavior : RegionBehavior
     {
         public const string BehaviorKey = "IDestructibleRegionBehavior";
 


### PR DESCRIPTION
﻿## Description of Change

Renamed IDestructibleRegionBehavior to DestructibleRegionBehavior to match standard C# Naming-conventions (this is a class, not an interface)

I left the BehaviorKey unchanged (there seems to be not clear rule at least 
ClearChildViewsRegionBehavior and IDestructibleRegionBehavior don't share the same one and as far as I understand it, it is not of highest importance). let me know, if you want these values aligned, too.

### Bugs Fixed

https://github.com/PrismLibrary/Prism/issues/2134

### API Changes

List all API changes here (or just put None), example:

Renamed:

public class IDestructibleRegionBehavior -> public class DestructibleRegionBehavior 

### Behavioral Changes

None 