### PR TITLE
[Uno] Fix iOS startup, restore Uno UI Tests

### DIFF
--- a/build/steps/prepare-build.yml
+++ b/build/steps/prepare-build.yml
@@ -18,3 +18,4 @@ steps:
   inputs:
     restoreSolution: ${{ parameters.solution }}
     noCache: true
+    verbosityRestore: normal

--- a/src/Uno/Prism.Uno/PrismApplicationBase.cs
+++ b/src/Uno/Prism.Uno/PrismApplicationBase.cs
@@ -204,6 +204,10 @@ namespace Prism
         protected virtual void InitializeShell(UIElement shell)
         {
             Windows.UI.Xaml.Window.Current.Content = shell;
+
+            // Activate must be called immediately in order for the Loaded event to be raised
+            // in the shell.
+            Windows.UI.Xaml.Window.Current.Activate();
         }
 
         /// <summary>
@@ -211,7 +215,6 @@ namespace Prism
         /// </summary>
         protected virtual void OnInitialized()
         {
-            Windows.UI.Xaml.Window.Current.Activate();
         }
 
         /// <summary>


### PR DESCRIPTION
﻿## Description of Change

Fixes the startup of the application on iOS, caused by the fact that the loaded event on iOS is only raised when Window.Activate() is called.

This PR also restore Uno UI Tests for android, iOS, Wasm platforms.

### API Changes

None.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard