### PR TITLE
XML Documentation for Dryloc.Wpf, Unity.Wpf and Prism.Core

### DIFF
--- a/src/Prism.Core/Mvvm/ErrorsContainer.cs
+++ b/src/Prism.Core/Mvvm/ErrorsContainer.cs
@@ -14,19 +14,19 @@ namespace Prism.Mvvm
         private static readonly T[] noErrors = new T[0];
 
         /// <summary>
-        /// Delegate to be called when raiseErrorsChanged is invoked
+        /// Delegate to be called when raiseErrorsChanged is invoked.
         /// </summary>
         protected readonly Action<string> raiseErrorsChanged;
 
         /// <summary>
-        /// <see cref="Dictionary{string, List{T}}" /> of the errors and sources
+        /// A map from property name to a <see cref="List{T}"/> of the errors and sources.
         /// </summary>
         protected readonly Dictionary<string, List<T>> validationResults;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ErrorsContainer{T}"/> class.
         /// </summary>
-        /// <param name="raiseErrorsChanged">The action that is invoked when errors are added for an object/>
+        /// <param name="raiseErrorsChanged">The action that is invoked when errors are added for an object.</param>
         public ErrorsContainer(Action<string> raiseErrorsChanged)
         {
             if (raiseErrorsChanged == null)
@@ -50,7 +50,7 @@ namespace Prism.Mvvm
         }
 
         /// <summary>
-        /// Returns all the errors in the container
+        /// Returns all the errors in the container.
         /// </summary>
         /// <returns>The dictionary of errors per property.</returns>
         public Dictionary<string, List<T>> GetErrors()
@@ -94,7 +94,7 @@ namespace Prism.Mvvm
         /// <typeparam name="TProperty">The property type.</typeparam>
         /// <param name="propertyExpression">The expression indicating a property.</param>
         /// <example>
-        ///     container.ClearErrors(()=>SomeProperty);
+        /// container.ClearErrors(()=>SomeProperty);
         /// </example>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public void ClearErrors<TProperty>(Expression<Func<TProperty>> propertyExpression)
@@ -106,9 +106,9 @@ namespace Prism.Mvvm
         /// <summary>
         /// Clears the errors for a property.
         /// </summary>
-        /// <param name="propertyName">The name of th property for which to clear errors.</param>
+        /// <param name="propertyName">The name of the property for which to clear errors.</param>
         /// <example>
-        ///     container.ClearErrors("SomeProperty");
+        /// container.ClearErrors("SomeProperty");
         /// </example>
         public void ClearErrors(string propertyName)
         {

--- a/src/Wpf/Prism.DryIoc.Wpf/Legacy/DryIocBootstrapper.cs
+++ b/src/Wpf/Prism.DryIoc.Wpf/Legacy/DryIocBootstrapper.cs
@@ -159,6 +159,10 @@ namespace Prism.DryIoc
             return new Container(DryIocContainerExtension.DefaultRules);
         }
 
+        /// <summary>
+        /// Create a new <see cref="DryIocContainerExtension"/> used by Prism.
+        /// </summary>
+        /// <returns>A new <see cref="DryIocContainerExtension"/>.</returns>
         protected override IContainerExtension CreateContainerExtension()
         {
             return new DryIocContainerExtension(Container);

--- a/src/Wpf/Prism.DryIoc.Wpf/Legacy/DryIocExtensions.cs
+++ b/src/Wpf/Prism.DryIoc.Wpf/Legacy/DryIocExtensions.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace Prism.DryIoc
 {
+    /// <summary>
+    /// <see cref="IContainer"/> extensions.
+    /// </summary>
     public static class DryIocExtensions
     {
         /// <summary>

--- a/src/Wpf/Prism.DryIoc.Wpf/PrismApplication.cs
+++ b/src/Wpf/Prism.DryIoc.Wpf/PrismApplication.cs
@@ -5,6 +5,9 @@ using Prism.Regions;
 
 namespace Prism.DryIoc
 {
+    /// <summary>
+    /// Base application class that uses <see cref="DryIocContainerExtension"/> as it's container.
+    /// </summary>
     public abstract class PrismApplication : PrismApplicationBase
     {
         /// <summary>
@@ -13,11 +16,19 @@ namespace Prism.DryIoc
         /// <returns>An instance of <see cref="Rules" /></returns>
         protected virtual Rules CreateContainerRules() => DryIocContainerExtension.DefaultRules;
 
+        /// <summary>
+        /// Create a new <see cref="DryIocContainerExtension"/> used by Prism.
+        /// </summary>
+        /// <returns>A new <see cref="DryIocContainerExtension"/>.</returns>
         protected override IContainerExtension CreateContainerExtension()
         {
             return new DryIocContainerExtension(new Container(CreateContainerRules()));
         }
 
+        /// <summary>
+        /// Registers the <see cref="Type"/>s of the Exceptions that are not considered 
+        /// root exceptions by the <see cref="ExceptionExtensions"/>.
+        /// </summary>
         protected override void RegisterFrameworkExceptionTypes()
         {
             ExceptionExtensions.RegisterFrameworkExceptionType(typeof(ContainerException));

--- a/src/Wpf/Prism.DryIoc.Wpf/PrismBootstrapper.cs
+++ b/src/Wpf/Prism.DryIoc.Wpf/PrismBootstrapper.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace Prism.DryIoc
 {
+    /// <summary>
+    /// Base bootstrapper class that uses <see cref="DryIocContainerExtension"/> as it's container.
+    /// </summary>
     public abstract class PrismBootstrapper : PrismBootstrapperBase
     {
         /// <summary>
@@ -12,11 +15,19 @@ namespace Prism.DryIoc
         /// <returns>An instance of <see cref="Rules" /></returns>
         protected virtual Rules CreateContainerRules() => DryIocContainerExtension.DefaultRules;
 
+        /// <summary>
+        /// Create a new <see cref="DryIocContainerExtension"/> used by Prism.
+        /// </summary>
+        /// <returns>A new <see cref="DryIocContainerExtension"/>.</returns>
         protected override IContainerExtension CreateContainerExtension()
         {
             return new DryIocContainerExtension(new Container(CreateContainerRules()));
         }
 
+        /// <summary>
+        /// Registers the <see cref="Type"/>s of the Exceptions that are not considered 
+        /// root exceptions by the <see cref="ExceptionExtensions"/>.
+        /// </summary>
         protected override void RegisterFrameworkExceptionTypes()
         {
             ExceptionExtensions.RegisterFrameworkExceptionType(typeof(ContainerException));

--- a/src/Wpf/Prism.Unity.Wpf/PrismBootstrapper.cs
+++ b/src/Wpf/Prism.Unity.Wpf/PrismBootstrapper.cs
@@ -4,13 +4,24 @@ using Unity;
 
 namespace Prism.Unity
 {
+    /// <summary>
+    /// Base bootstrapper class that uses <see cref="UnityContainerExtension"/> as it's container.
+    /// </summary>
     public abstract class PrismBootstrapper : PrismBootstrapperBase
     {
+        /// <summary>
+        /// Create a new <see cref="UnityContainerExtension"/> used by Prism.
+        /// </summary>
+        /// <returns>A new <see cref="UnityContainerExtension"/>.</returns>
         protected override IContainerExtension CreateContainerExtension()
         {
             return new UnityContainerExtension();
         }
 
+        /// <summary>
+        /// Registers the <see cref="Type"/>s of the Exceptions that are not considered 
+        /// root exceptions by the <see cref="ExceptionExtensions"/>.
+        /// </summary>
         protected override void RegisterFrameworkExceptionTypes()
         {
             ExceptionExtensions.RegisterFrameworkExceptionType(typeof(ResolutionFailedException));


### PR DESCRIPTION
## Description of Change
Fixed ErrorsContainer warnings
Added closing </param> tag
Dryloc.WPF & Unity.Wpf
Added PrismApplication/PrismBootstrapper XML comments.

Prism.Wpf is almost free of warnings :)

### Bugs Fixed

Resolved Warning when using `<see cref="Dictionary{string, List{T}}" />` in an XML comment
Resolved missing `</param>` tag in ErrorsContainer constructor.

### API Changes

N/A

### Behavioral Changes

N/A

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard