### PR TITLE
Update SelectorItemsSourceSyncBehavior.cs

### DIFF
--- a/src/Wpf/Prism.Wpf/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Windows;
 using Prism.Properties;
 
 #if HAS_WINUI


### PR DESCRIPTION
﻿## Description of Change

Removed unused `using System.Windows`

### Bugs Fixed

Removes `warning CS0105: The using directive for 'System.Windows' appeared previously in this namespace` when building Prism.Wpf

### API Changes

N/A

### Behavioral Changes

N/A

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard