### PR TITLE
Fixed spelling error: GetNotAlreadyLoadedModuleInfos

### DIFF
--- a/src/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.net45.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.net45.cs
@@ -118,14 +118,14 @@ namespace Prism.Modularity
                         asm => asm.FullName == typeof(IModule).Assembly.FullName);
                 Type IModuleType = moduleReflectionOnlyAssembly.GetType(typeof(IModule).FullName);
 
-                IEnumerable<ModuleInfo> modules = GetNotAllreadyLoadedModuleInfos(directory, IModuleType);
+                IEnumerable<ModuleInfo> modules = GetNotAlreadyLoadedModuleInfos(directory, IModuleType);
 
                 var array = modules.ToArray();
                 AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve -= resolveEventHandler;
                 return array;
             }
 
-            private static IEnumerable<ModuleInfo> GetNotAllreadyLoadedModuleInfos(DirectoryInfo directory, Type IModuleType)
+            private static IEnumerable<ModuleInfo> GetNotAlreadyLoadedModuleInfos(DirectoryInfo directory, Type IModuleType)
             {
                 List<FileInfo> validAssemblies = new List<FileInfo>();
                 Assembly[] alreadyLoadedAssemblies = AppDomain.CurrentDomain.ReflectionOnlyGetAssemblies();

--- a/src/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.netcore.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.netcore.cs
@@ -87,14 +87,14 @@ namespace Prism.Modularity
                 Assembly moduleReflectionOnlyAssembly = AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.FullName == typeof(IModule).Assembly.FullName);
                 Type IModuleType = moduleReflectionOnlyAssembly.GetType(typeof(IModule).FullName);
 
-                IEnumerable<ModuleInfo> modules = GetNotAllreadyLoadedModuleInfos(directory, IModuleType);
+                IEnumerable<ModuleInfo> modules = GetNotAlreadyLoadedModuleInfos(directory, IModuleType);
 
                 var array = modules.ToArray();
                 AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve -= resolveEventHandler;
                 return array;
             }
 
-            private static IEnumerable<ModuleInfo> GetNotAllreadyLoadedModuleInfos(DirectoryInfo directory, Type IModuleType)
+            private static IEnumerable<ModuleInfo> GetNotAlreadyLoadedModuleInfos(DirectoryInfo directory, Type IModuleType)
             {
                 List<Assembly> validAssemblies = new List<Assembly>();
                 Assembly[] alreadyLoadedAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(p => !p.IsDynamic).ToArray();


### PR DESCRIPTION
﻿## Description of Change

Fixed typo in private method name GetNotAllreadyLoadedModuleInfos -> GetNotAlreadyLoadedModuleInfos

### Bugs Fixed

Typo in private method name GetNotAllreadyLoadedModuleInfos -> GetNotAlreadyLoadedModuleInfos

### API Changes

List all API changes here (or just put None), example:

Added:

None

Changed:

None

### Behavioral Changes

None

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard