### PR TITLE
add ModuleInfo collection to IModuleManager

### DIFF
--- a/src/Forms/Prism.Forms/Modularity/IModuleCatalogExtensions.cs
+++ b/src/Forms/Prism.Forms/Modularity/IModuleCatalogExtensions.cs
@@ -20,6 +20,13 @@ namespace Prism.Modularity
             where T : IModule =>
             catalog.AddModule<T>(typeof(T).Name, mode);
 
+        /// <summary>
+        /// Adds the module.
+        /// </summary>
+        /// <returns>The module.</returns>
+        /// <param name="catalog">Catalog.</param>
+        /// <param name="name">Name.</param>
+        /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
         public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name)
             where T : IModule =>
             catalog.AddModule<T>(name, InitializationMode.WhenAvailable);

--- a/src/Forms/Prism.Forms/Modularity/ModuleManager.cs
+++ b/src/Forms/Prism.Forms/Modularity/ModuleManager.cs
@@ -18,6 +18,11 @@ namespace Prism.Modularity
         protected IModuleCatalog ModuleCatalog { get; }
 
         /// <summary>
+        /// Gets all the <see cref="IModuleInfo"/> classes that are in the <see cref="IModuleCatalog"/>.
+        /// </summary>
+        public IEnumerable<IModuleInfo> Modules => ModuleCatalog.Modules;
+
+        /// <summary>
         /// Raised when a module is loaded or fails to load.
         /// </summary>
         public event EventHandler<LoadModuleCompletedEventArgs> LoadModuleCompleted;
@@ -56,7 +61,7 @@ namespace Prism.Modularity
         }
 
         /// <summary>
-        /// Loads and initializes the module in the <see cref="ModuleCatalog"/> with the name <paramref name="moduleName"/>.
+        /// Loads and initializes the module in the <see cref="IModuleCatalog"/> with the name <paramref name="moduleName"/>.
         /// </summary>
         /// <param name="moduleName">Name of the module requested for initialization.</param>
         public void LoadModule(string moduleName)

--- a/src/Prism.Core/Modularity/IModuleCatalogCoreExtensions.cs
+++ b/src/Prism.Core/Modularity/IModuleCatalogCoreExtensions.cs
@@ -27,6 +27,25 @@ namespace Prism.Modularity
             catalog.Modules.Any(module => module.ModuleName == name);
 
         /// <summary>
+        /// Gets the current <see cref="ModuleState"/> of the <see cref="IModule"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="IModule"/> to check.</typeparam>
+        /// <param name="catalog">Catalog.</param>
+        /// <returns></returns>
+        public static ModuleState GetModuleState<T>(this IModuleCatalog catalog)
+            where T : IModule =>
+            catalog.Modules.FirstOrDefault(mi => mi.ModuleType == typeof(T).AssemblyQualifiedName).State;
+
+        /// <summary>
+        /// Gets the current <see cref="ModuleState"/> of the <see cref="IModule"/>.
+        /// </summary>
+        /// <param name="catalog">Catalog.</param>
+        /// <param name="name">Name.</param>
+        /// <returns></returns>
+        public static ModuleState GetModuleState(this IModuleCatalog catalog, string name) =>
+            catalog.Modules.FirstOrDefault(module => module.ModuleName == name).State;
+
+        /// <summary>
         /// Checks to see if the <see cref="IModule"/> is already initialized. 
         /// </summary>
         /// <returns><c>true</c>, if initialized, <c>false</c> otherwise.</returns>

--- a/src/Prism.Core/Modularity/IModuleManager.cs
+++ b/src/Prism.Core/Modularity/IModuleManager.cs
@@ -1,6 +1,5 @@
-
-
 using System;
+using System.Collections.Generic;
 
 namespace Prism.Modularity
 {
@@ -9,6 +8,11 @@ namespace Prism.Modularity
     /// </summary>
     public interface IModuleManager
     {
+        /// <summary>
+        /// Gets all the <see cref="IModuleInfo"/> classes that are in the <see cref="IModuleCatalog"/>.
+        /// </summary>
+        IEnumerable<IModuleInfo> Modules { get; }
+
         /// <summary>
         /// Initializes the modules marked as <see cref="InitializationMode.WhenAvailable"/> on the <see cref="IModuleCatalog"/>.
         /// </summary>

--- a/src/Prism.Core/Modularity/IModuleManagerExtensions.cs
+++ b/src/Prism.Core/Modularity/IModuleManagerExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System.Linq;
+
+namespace Prism.Modularity
+{
+    /// <summary>
+    /// Common extensions for the <see cref="IModuleManager"/>
+    /// </summary>
+    public static class IModuleManagerExtensions
+    {
+        /// <summary>
+        /// Checks to see if the <see cref="IModule"/> exists in the <see cref="IModuleCatalog.Modules"/>  
+        /// </summary>
+        /// <returns><c>true</c> if the Module exists.</returns>
+        /// <param name="manager">The <see cref="IModuleManager"/>.</param>
+        /// <typeparam name="T">The <see cref="IModule"/> to check for.</typeparam>
+        public static bool ModuleExists<T>(this IModuleManager manager)
+            where T : IModule =>
+            manager.Modules.Any(mi => mi.ModuleType == typeof(T).AssemblyQualifiedName);
+
+        /// <summary>
+        /// Exists the specified catalog and name.
+        /// </summary>
+        /// <returns><c>true</c> if the Module exists.</returns>
+        /// <param name="catalog">Catalog.</param>
+        /// <param name="name">Name.</param>
+        public static bool ModuleExists(this IModuleManager catalog, string name) =>
+            catalog.Modules.Any(module => module.ModuleName == name);
+
+        /// <summary>
+        /// Gets the current <see cref="ModuleState"/> of the <see cref="IModule"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="IModule"/> to check.</typeparam>
+        /// <param name="manager">The <see cref="IModuleManager"/>.</param>
+        /// <returns></returns>
+        public static ModuleState GetModuleState<T>(this IModuleManager manager)
+            where T : IModule =>
+            manager.Modules.FirstOrDefault(mi => mi.ModuleType == typeof(T).AssemblyQualifiedName).State;
+
+        /// <summary>
+        /// Gets the current <see cref="ModuleState"/> of the <see cref="IModule"/>.
+        /// </summary>
+        /// <param name="manager">The <see cref="IModuleManager"/>.</param>
+        /// <param name="name">Name.</param>
+        /// <returns></returns>
+        public static ModuleState GetModuleState(this IModuleManager manager, string name) =>
+            manager.Modules.FirstOrDefault(module => module.ModuleName == name).State;
+
+        /// <summary>
+        /// Checks to see if the <see cref="IModule"/> is already initialized. 
+        /// </summary>
+        /// <returns><c>true</c>, if initialized, <c>false</c> otherwise.</returns>
+        /// <param name="manager">The <see cref="IModuleManager"/>.</param>
+        /// <typeparam name="T">The <see cref="IModule"/> to check.</typeparam>
+        public static bool IsModuleInitialized<T>(this IModuleManager manager)
+            where T : IModule =>
+            manager.Modules.FirstOrDefault(mi => mi.ModuleType == typeof(T).AssemblyQualifiedName)?.State == ModuleState.Initialized;
+
+        /// <summary>
+        /// Checks to see if the <see cref="IModule"/> is already initialized. 
+        /// </summary>
+        /// <returns><c>true</c>, if initialized, <c>false</c> otherwise.</returns>
+        /// <param name="manager">The <see cref="IModuleManager"/>.</param>
+        /// <param name="name">Name.</param>
+        public static bool IsModuleInitialized(this IModuleManager manager, string name) =>
+            manager.Modules.FirstOrDefault(module => module.ModuleName == name)?.State == ModuleState.Initialized;
+
+        /// <summary>
+        /// Loads and initializes the module in the <see cref="IModuleCatalog"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="IModule"/> to load.</typeparam>
+        /// <param name="manager">The <see cref="IModuleManager"/>.</param>
+        public static void LoadModule<T>(this IModuleManager manager)
+            where T : IModule =>
+            manager.LoadModule(typeof(T).Name);
+    }
+}

--- a/src/Wpf/Prism.Wpf/Modularity/ModuleManager.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/ModuleManager.cs
@@ -32,6 +32,11 @@ namespace Prism.Modularity
         protected IModuleCatalog ModuleCatalog { get; }
 
         /// <summary>
+        /// Gets all the <see cref="IModuleInfo"/> classes that are in the <see cref="IModuleCatalog"/>.
+        /// </summary>
+        public IEnumerable<IModuleInfo> Modules => ModuleCatalog.Modules;
+
+        /// <summary>
         /// Raised repeatedly to provide progress as modules are loaded in the background.
         /// </summary>
         public event EventHandler<ModuleDownloadProgressChangedEventArgs> ModuleDownloadProgressChanged;
@@ -68,7 +73,7 @@ namespace Prism.Modularity
 
 
         /// <summary>
-        /// Loads and initializes the module on the <see cref="ModuleCatalog"/> with the name <paramref name="moduleName"/>.
+        /// Loads and initializes the module on the <see cref="IModuleCatalog"/> with the name <paramref name="moduleName"/>.
         /// </summary>
         /// <param name="moduleName">Name of the module requested for initialization.</param>
         public void LoadModule(string moduleName)

--- a/tests/Forms/Prism.Forms.Tests/Modularity/ModuleManagerExtensionsFixture.cs
+++ b/tests/Forms/Prism.Forms.Tests/Modularity/ModuleManagerExtensionsFixture.cs
@@ -1,0 +1,88 @@
+﻿using Moq;
+using Prism.Forms.Tests.Mocks.Modules;
+using Prism.Modularity;
+using Xunit;
+
+namespace Prism.Forms.Tests.Modularity
+{
+    public class ModuleManagerExtensionsFixture
+    {
+        [Fact]
+        public void ModuleManagerExposesIModuleCatalogModules()
+        {
+            var modules = new[]
+            {
+                new ModuleInfo(typeof(ModuleA))
+            };
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(modules);
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.Same(modules, manager.Modules);
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectModuleStateWithGeneric()
+        {
+            IModuleInfo moduleInfo = new ModuleInfo(typeof(ModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.Equal(moduleInfo.State, manager.GetModuleState<ModuleA>());
+            moduleInfo.State = ModuleState.LoadingTypes;
+            Assert.Equal(moduleInfo.State, manager.GetModuleState<ModuleA>());
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectModuleStateWithName()
+        {
+            IModuleInfo moduleInfo = new ModuleInfo(typeof(ModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.Equal(moduleInfo.State, manager.GetModuleState(nameof(ModuleA)));
+            moduleInfo.State = ModuleState.LoadingTypes;
+            Assert.Equal(moduleInfo.State, manager.GetModuleState(nameof(ModuleA)));
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectInitializationStateWithGeneric()
+        {
+            IModuleInfo moduleInfo = new ModuleInfo(typeof(ModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.False(manager.IsModuleInitialized<ModuleA>());
+            moduleInfo.State = ModuleState.Initializing;
+            Assert.False(manager.IsModuleInitialized<ModuleA>());
+            moduleInfo.State = ModuleState.Initialized;
+            Assert.True(manager.IsModuleInitialized<ModuleA>());
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectInitializationStateWithName()
+        {
+            IModuleInfo moduleInfo = new ModuleInfo(typeof(ModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.False(manager.IsModuleInitialized(nameof(ModuleA)));
+            moduleInfo.State = ModuleState.Initializing;
+            Assert.False(manager.IsModuleInitialized(nameof(ModuleA)));
+            moduleInfo.State = ModuleState.Initialized;
+            Assert.True(manager.IsModuleInitialized(nameof(ModuleA)));
+        }
+
+        [Fact]
+        public void ModuleManagerLoadModuleGeneric_CallsLoadModuleWithName()
+        {
+            var managerMock = new Mock<IModuleManager>();
+            managerMock.Object.LoadModule<ModuleA>();
+            managerMock.Verify(m => m.LoadModule(nameof(ModuleA)));
+        }
+    }
+}

--- a/tests/Wpf/Prism.Wpf.Tests/Modularity/ModuleManagerExtensionsFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Modularity/ModuleManagerExtensionsFixture.cs
@@ -1,0 +1,88 @@
+﻿using Moq;
+using Prism.Modularity;
+using Prism.Wpf.Tests.Mocks.Modules;
+using Xunit;
+
+namespace Prism.Wpf.Tests.Modularity
+{
+    public class ModuleManagerExtensionsFixture
+    {
+        [Fact]
+        public void ModuleManagerExposesIModuleCatalogModules()
+        {
+            var modules = new[]
+            {
+                new ModuleInfo(typeof(MockModuleA))
+            };
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(modules);
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.Same(modules, manager.Modules);
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectModuleStateWithGeneric()
+        {
+            var moduleInfo = new ModuleInfo(typeof(MockModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.Equal(moduleInfo.State, manager.GetModuleState<MockModuleA>());
+            moduleInfo.State = ModuleState.LoadingTypes;
+            Assert.Equal(moduleInfo.State, manager.GetModuleState<MockModuleA>());
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectModuleStateWithName()
+        {
+            var moduleInfo = new ModuleInfo(typeof(MockModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.Equal(moduleInfo.State, manager.GetModuleState(nameof(MockModuleA)));
+            moduleInfo.State = ModuleState.LoadingTypes;
+            Assert.Equal(moduleInfo.State, manager.GetModuleState(nameof(MockModuleA)));
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectInitializationStateWithGeneric()
+        {
+            var moduleInfo = new ModuleInfo(typeof(MockModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.False(manager.IsModuleInitialized<MockModuleA>());
+            moduleInfo.State = ModuleState.Initializing;
+            Assert.False(manager.IsModuleInitialized<MockModuleA>());
+            moduleInfo.State = ModuleState.Initialized; 
+            Assert.True(manager.IsModuleInitialized<MockModuleA>());
+        }
+
+        [Fact]
+        public void ModuleManagerReturnsCorrectInitializationStateWithName()
+        {
+            var moduleInfo = new ModuleInfo(typeof(MockModuleA));
+            var moduleCatalogMock = new Mock<IModuleCatalog>();
+            moduleCatalogMock.Setup(c => c.Modules).Returns(new[] { moduleInfo });
+            IModuleManager manager = new ModuleManager(Mock.Of<IModuleInitializer>(), moduleCatalogMock.Object);
+
+            Assert.False(manager.IsModuleInitialized(nameof(MockModuleA)));
+            moduleInfo.State = ModuleState.Initializing;
+            Assert.False(manager.IsModuleInitialized(nameof(MockModuleA)));
+            moduleInfo.State = ModuleState.Initialized;
+            Assert.True(manager.IsModuleInitialized(nameof(MockModuleA)));
+        }
+
+        [Fact]
+        public void ModuleManagerLoadModuleGeneric_CallsLoadModuleWithName()
+        {
+            var managerMock = new Mock<IModuleManager>();
+            managerMock.Object.LoadModule<MockModuleA>();
+            managerMock.Verify(m => m.LoadModule(nameof(MockModuleA)));
+        }
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

Prism previously introduced a number of great extensions off of the IModuleCatalog to check if a Module exists, or is initialized, however in order to validate the current state of a module you must inject both the IModuleManager and IModuleCatalog.

In this scenario it is extremely unlikely that you care at all about the IModuleCatalog and that you only want to be able to load an uninitialized Module. These changes simplify the dependencies you need to handle this simple task.

### Linked Issues

- resolves #2179

### API Changes

Added:

- IEnumerable<IModuleInfo> IModuleManager.Modules { get; }

IModuleManager Extensions

- bool ModuleExists&lt;T&gt;()
- bool ModuleExists(string name)
- ModuleState GetModuleState&lt;T&gt;()
- ModuleState GetModuleState(string name)
- bool IsModuleInitialized&lt;T&gt;()
- bool IsModuleInitialized(string name)
- void LoadModule&lt;T&gt;()

IModuleCatalog Extensions

- ModuleState GetModuleState&lt;T&gt;()
- ModuleState GetModuleState(string name)

### Behavioral Changes

none

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard