### PR TITLE
Autowire update

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,7 @@ Each supported IoC container has its own package assisting in the setup and usag
 |---------|-------|-------|
 | [Prism.DryIoc.Forms][DryIocFormsNuGet] | [![DryIocFormsNuGetShield]][DryIocFormsNuGet] | [![DryIocFormsMyGetShield]][DryIocFormsMyGet] |
 | [Prism.Unity.Forms][UnityFormsNuGet] | [![UnityFormsNuGetShield]][UnityFormsNuGet] | [![UnityFormsMyGetShield]][UnityFormsMyGet] |
-
-#### Package Notices
-
-- For developers using Unity with Prism 6, take note that the new Unity maintainer has made major breaking changes. This includes changing namespaces and the package structure. These changes were NOT made by the Prism team nor do we have any control over it. When upgrading to Prism 7 you will need to uninstall the existing Unity package as we now reference the Unity.Container NuGet.
+| [Prism.Forms.Regions][PrismFormsRegionsNuget] | [![PrismFormsRegionsNuGetShield]][PrismFormsRegionsNuGet] | [![PrismFormsRegionsMyGetShield]][PrismFormsRegionsMyGet] |
 
 ![NuGet package tree](images/NuGetPackageTree.png)
 
@@ -149,6 +146,11 @@ This project is part of the [.NET Foundation](http://www.dotnetfoundation.org/pr
 [WpfNuGet]: https://www.nuget.org/packages/Prism.Wpf/
 [FormsNuGet]: https://www.nuget.org/packages/Prism.Forms/
 [UnoNuGet]: https://www.nuget.org/packages/Prism.Uno/
+
+[PrismFormsRegionsNuGet]: https://www.nuget.org/packages/Prism.Forms.Regions/
+[PrismFormsRegionsMyGet]: https://myget.org/feed/prism/package/nuget/Prism.Forms.Regions
+[PrismFormsRegionsNuGetShield]: https://img.shields.io/nuget/vpre/Prism.Forms.Regions.svg
+[PrismFormsRegionsMyGetShield]: https://img.shields.io/myget/prism/vpre/Prism.Forms.Regions.svg
 
 [DryIocWpfNuGet]: https://www.nuget.org/packages/Prism.DryIoc/
 [UnityWpfNuGet]: https://www.nuget.org/packages/Prism.Unity/

--- a/e2e/Wpf/global.json
+++ b/e2e/Wpf/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "3.1.401",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "3.1.300",
+    "version": "3.1.401",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   },
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "2.0.54"
+    "MSBuild.Sdk.Extras": "2.1.2"
   }
 }

--- a/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
+++ b/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Prism.Regions.Navigation;
 using Xamarin.Forms;
 

--- a/src/Forms/Prism.Forms.Regions/Prism.Forms.Regions.csproj
+++ b/src/Forms/Prism.Forms.Regions/Prism.Forms.Regions.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Prism</RootNamespace>
+    <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices. Prism provides an implementation of a collection of design patterns that are helpful in writing well structured, maintainable, and testable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared library targeting the .NET Framework and .NET Standard. Features that need to be platform specific are implemented in the respective libraries for the target platform (WPF, Uno Platform, and Xamarin Forms).
+
+Prism.Forms.Regions helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications by bringing class WPF Regions to Xamarin.Forms. This library provides the IRegion and RegionManager. While we support a number of standard Xamarin.Forms controls like StackLayout &amp; ContentView, you can provide custom RegionAdapters to make Regions work with any control that you like.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
@@ -85,8 +85,7 @@ namespace Prism.Regions.Navigation
             {
                 var view = _container.Resolve<object>(candidateTargetContract) as VisualElement;
 
-                if (ViewModelLocator.GetAutowireViewModel(view) is null)
-                    ViewModelLocator.SetAutowireViewModel(view, true);
+                PageUtilities.SetAutowireViewModel(view);
 
                 newRegionItem = view;
             }

--- a/src/Forms/Prism.Forms/Common/PageUtilities.cs
+++ b/src/Forms/Prism.Forms/Common/PageUtilities.cs
@@ -3,6 +3,7 @@ using Prism.Mvvm;
 using Prism.Navigation;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -307,11 +308,16 @@ namespace Prism.Common
                    || potentialDescendant == potentialBase;
         }
 
-        internal static void SetAutowireViewModelOnPage(Page page)
+        /// <summary>
+        /// Sets the AutowireViewModel property on the View to <c>true</c> if there is currently
+        /// no BindingContext and the AutowireViewModel property has not been set.
+        /// </summary>
+        /// <param name="element">The View typically a <see cref="Page"/> or <see cref="View"/>.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetAutowireViewModel(VisualElement element)
         {
-            var vmlResult = Mvvm.ViewModelLocator.GetAutowireViewModel(page);
-            if (vmlResult == null)
-                Mvvm.ViewModelLocator.SetAutowireViewModel(page, true);
+            if (element.BindingContext is null && ViewModelLocator.GetAutowireViewModel(element) is null)
+                ViewModelLocator.SetAutowireViewModel(element, true);
         }
     }
 }

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -852,7 +852,7 @@ namespace Prism.Navigation
                 throw new NavigationException(NavigationException.NoPageIsRegistered, _page, innerException);
             }
 
-            PageUtilities.SetAutowireViewModelOnPage(page);
+            PageUtilities.SetAutowireViewModel(page);
             _pageBehaviorFactory.ApplyPageBehaviors(page);
             ConfigurePages(page, segment);
 
@@ -891,11 +891,11 @@ namespace Prism.Navigation
         {
             foreach (var child in tabbedPage.Children)
             {
-                PageUtilities.SetAutowireViewModelOnPage(child);
+                PageUtilities.SetAutowireViewModel(child);
                 _pageBehaviorFactory.ApplyPageBehaviors(child);
                 if (child is NavigationPage navPage)
                 {
-                    PageUtilities.SetAutowireViewModelOnPage(navPage.CurrentPage);
+                    PageUtilities.SetAutowireViewModel(navPage.CurrentPage);
                     _pageBehaviorFactory.ApplyPageBehaviors(navPage.CurrentPage);
                 }
             }
@@ -944,7 +944,7 @@ namespace Prism.Navigation
         {
             foreach (var child in carouselPage.Children)
             {
-                PageUtilities.SetAutowireViewModelOnPage(child);
+                PageUtilities.SetAutowireViewModel(child);
             }
 
             var parameters = UriParsingHelper.GetSegmentParameters(segment);

--- a/src/Forms/Prism.Forms/Services/Dialogs/DialogService.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/DialogService.cs
@@ -137,11 +137,7 @@ namespace Prism.Services.Dialogs
         private View CreateViewFor(string name)
         {
             var view = (View)_containerExtension.Resolve<object>(name);
-
-            if (ViewModelLocator.GetAutowireViewModel(view) is null)
-            {
-                ViewModelLocator.SetAutowireViewModel(view, true);
-            }
+            PageUtilities.SetAutowireViewModel(view);
 
             return view;
         }

--- a/src/Prism.Core/Prism.Core.csproj
+++ b/src/Prism.Core/Prism.Core.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Prism</AssemblyName>
     <PackageId>Prism.Core</PackageId>
     <RootNamespace>Prism</RootNamespace>
-    <DebugType>pdbonly</DebugType>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
     <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.</Description>


### PR DESCRIPTION
﻿## Description of Change

Aligns the Xamarin.Forms AutowireViewModel behavior with WPF. There is now only a single reference to SetAutowireViewModel in the PageUtilities. This call has been updated to work with all VisualElements instead of just a Page. We now validate that the BindingContext is null AND that the AutowireViewModel Property is null before setting the AutowireViewModel Property.

Additionally adds missing description to the Prism.Forms.Regions package and updates the build SDKs

### Bugs Fixed

- n/a

### API Changes

n/a

### Behavioral Changes

See Description. We now have an additional check before setting the AutowireViewModel property. This potentially could reduce issues where a ViewModel is being created twice if someone was injecting it into the ctor and setting the BindingContext.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard