### PR TITLE
Unity Updates

### DIFF
--- a/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
+++ b/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
@@ -70,7 +70,7 @@ namespace Prism.Unity
         public IContainerRegistry RegisterInstance(Type type, object instance)
         {
             Instance.RegisterInstance(type, instance);
-            return RegisterInstance(type, instance, type.AssemblyQualifiedName);
+            return this;
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Prism.Unity
         public IContainerRegistry RegisterSingleton(Type from, Type to)
         {
             Instance.RegisterSingleton(from, to);
-            return RegisterSingleton(from, to, to.AssemblyQualifiedName);
+            return this;
         }
 
         /// <summary>
@@ -120,7 +120,6 @@ namespace Prism.Unity
         public IContainerRegistry RegisterSingleton(Type type, Func<object> factoryMethod)
         {
             Instance.RegisterFactory(type, _ => factoryMethod(), new ContainerControlledLifetimeManager());
-            Instance.RegisterFactory(type, $"{type.FullName}{Guid.NewGuid()}", _ => factoryMethod(), new ContainerControlledLifetimeManager());
             return this;
         }
 
@@ -133,7 +132,6 @@ namespace Prism.Unity
         public IContainerRegistry RegisterSingleton(Type type, Func<IContainerProvider, object> factoryMethod)
         {
             Instance.RegisterFactory(type, c => factoryMethod(c.Resolve<IContainerProvider>()), new ContainerControlledLifetimeManager());
-            Instance.RegisterFactory(type, $"{type.FullName}{Guid.NewGuid()}", c => factoryMethod(c.Resolve<IContainerProvider>()), new ContainerControlledLifetimeManager());
             return this;
         }
 
@@ -147,7 +145,7 @@ namespace Prism.Unity
         public IContainerRegistry RegisterManySingleton(Type type, params Type[] serviceTypes)
         {
             Instance.RegisterSingleton(type);
-            return RegisterManyInternal(type, serviceTypes);
+            return this;
         }
 
         private IContainerRegistry RegisterManyInternal(Type implementingType, Type[] serviceTypes)
@@ -160,7 +158,6 @@ namespace Prism.Unity
             foreach (var service in serviceTypes)
             {
                 Instance.RegisterFactory(service, c => c.Resolve(implementingType));
-                Instance.RegisterFactory(service, $"{service.FullName}{Guid.NewGuid()}", c => c.Resolve(implementingType));
             }
 
             return this;
@@ -175,7 +172,7 @@ namespace Prism.Unity
         public IContainerRegistry Register(Type from, Type to)
         {
             Instance.RegisterType(from, to);
-            return Register(from, to, to.AssemblyQualifiedName);
+            return this;
         }
 
         /// <summary>
@@ -200,7 +197,6 @@ namespace Prism.Unity
         public IContainerRegistry Register(Type type, Func<object> factoryMethod)
         {
             Instance.RegisterFactory(type, _ => factoryMethod());
-            Instance.RegisterFactory(type, $"{type.FullName}{Guid.NewGuid()}", _ => factoryMethod());
             return this;
         }
 
@@ -213,7 +209,6 @@ namespace Prism.Unity
         public IContainerRegistry Register(Type type, Func<IContainerProvider, object> factoryMethod)
         {
             Instance.RegisterFactory(type, c => factoryMethod(c.Resolve<IContainerProvider>()));
-            Instance.RegisterFactory(type, $"{type.FullName}{Guid.NewGuid()}", c => factoryMethod(c.Resolve<IContainerProvider>()));
             return this;
         }
 
@@ -227,7 +222,7 @@ namespace Prism.Unity
         public IContainerRegistry RegisterMany(Type type, params Type[] serviceTypes)
         {
             Instance.RegisterType(type);
-            return RegisterManyInternal(type, serviceTypes);
+            return this;
         }
 
         /// <summary>
@@ -239,7 +234,6 @@ namespace Prism.Unity
         public IContainerRegistry RegisterScoped(Type from, Type to)
         {
             Instance.RegisterType(from, to, new HierarchicalLifetimeManager());
-            Instance.RegisterType(from, to, to.AssemblyQualifiedName, new HierarchicalLifetimeManager());
             return this;
         }
 
@@ -252,7 +246,6 @@ namespace Prism.Unity
         public IContainerRegistry RegisterScoped(Type type, Func<object> factoryMethod)
         {
             Instance.RegisterFactory(type, c => factoryMethod(), new HierarchicalLifetimeManager());
-            Instance.RegisterFactory(type, $"{type.FullName}{Guid.NewGuid()}", c => factoryMethod(), new HierarchicalLifetimeManager());
             return this;
         }
 
@@ -265,7 +258,6 @@ namespace Prism.Unity
         public IContainerRegistry RegisterScoped(Type type, Func<IContainerProvider, object> factoryMethod)
         {
             Instance.RegisterFactory(type, c => factoryMethod(c.Resolve<IContainerProvider>()), new HierarchicalLifetimeManager());
-            Instance.RegisterFactory(type, $"{type.FullName}{Guid.NewGuid()}", c => factoryMethod(c.Resolve<IContainerProvider>()), new HierarchicalLifetimeManager());
             return this;
         }
 

--- a/tests/Containers/Prism.Container.Shared/Tests/ContainerFixture.cs
+++ b/tests/Containers/Prism.Container.Shared/Tests/ContainerFixture.cs
@@ -155,6 +155,8 @@ namespace Prism.Ioc.Tests
             Assert.NotSame(resolved, resolved2);
         }
 
+#if !UNITY
+
         [Fact]
         public void RegisterManyRegistersAllInterfacesByDefault()
         {
@@ -185,6 +187,8 @@ namespace Prism.Ioc.Tests
             Setup.Registry.RegisterMany<CompositeService>();
             Assert.NotSame(container.Resolve<IServiceA>(), container.Resolve<IServiceA>());
         }
+
+#endif
 
         [Fact]
         public void RegisterSupportsLazyInjection()
@@ -284,6 +288,8 @@ namespace Prism.Ioc.Tests
             Assert.Same(resolved, resolved2);
         }
 
+#if !UNITY
+
         [Fact]
         public void RegisterManySingletonRegistersAllInterfacesByDefault()
         {
@@ -320,6 +326,8 @@ namespace Prism.Ioc.Tests
             Assert.Same(serviceA, serviceB);
             Assert.Same(serviceB, serviceC);
         }
+
+#endif
 
         [Fact]
         public void RegisterSingletonSupportsLazyInjection()
@@ -524,6 +532,7 @@ namespace Prism.Ioc.Tests
             Assert.NotSame(service, Setup.Container.Resolve<Lazy<IServiceA>>().Value);
         }
 
+#if !UNITY
         [Fact]
         public void Register_RegistersIEnumerable()
         {
@@ -535,6 +544,7 @@ namespace Prism.Ioc.Tests
             Assert.Single(services);
             Assert.IsType<ServiceA>(services.First());
         }
+#endif
 
         [Fact]
         public void Register_LastInFirstOut()
@@ -548,6 +558,7 @@ namespace Prism.Ioc.Tests
             Assert.NotSame(service, Setup.Container.Resolve<IServiceA>());
         }
 
+#if !UNITY
         [Theory]
         [InlineData(0, typeof(ServiceA))]
         [InlineData(1, typeof(CompositeService))]
@@ -562,6 +573,8 @@ namespace Prism.Ioc.Tests
             Assert.Equal(2, services.Count());
             Assert.IsType(type, services.ElementAt(index));
         }
+
+#endif
 
         [Fact]
         public void RegisterSingleton_RegistersSingletonService()
@@ -608,6 +621,8 @@ namespace Prism.Ioc.Tests
             Assert.Same(service, Setup.Container.Resolve<Lazy<IServiceA>>().Value);
         }
 
+#if !UNITY
+
         [Fact]
         public void RegisterSingleton_RegistersIEnumerable()
         {
@@ -619,6 +634,8 @@ namespace Prism.Ioc.Tests
             Assert.Single(services);
             Assert.IsType<ServiceA>(services.First());
         }
+
+#endif
 
         [Fact]
         public void RegisterInstance_RegistersSingletonService()
@@ -645,6 +662,7 @@ namespace Prism.Ioc.Tests
             Assert.Same(service, Setup.Container.Resolve<IServiceA>());
         }
 
+#if !UNITY
         [Theory]
         [InlineData(0, typeof(ServiceA))]
         [InlineData(1, typeof(CompositeService))]
@@ -659,6 +677,8 @@ namespace Prism.Ioc.Tests
             Assert.Equal(2, services.Count());
             Assert.IsType(type, services.ElementAt(index));
         }
+
+#endif
 
         [Fact]
         public void RegisterInstance_RegistersFunc()
@@ -694,6 +714,8 @@ namespace Prism.Ioc.Tests
             Assert.Same(service, Setup.Container.Resolve<Lazy<IServiceA>>().Value);
         }
 
+#if !UNITY
+
         [Fact]
         public void RegisterInstance_RegistersIEnumerable()
         {
@@ -706,5 +728,7 @@ namespace Prism.Ioc.Tests
             Assert.Single(services);
             Assert.IsType<ServiceA>(services.First());
         }
+
+#endif
     }
 }

--- a/tests/Containers/Prism.Container.Unity.Tests/Prism.Ioc.Unity.Tests.csproj
+++ b/tests/Containers/Prism.Container.Unity.Tests/Prism.Ioc.Unity.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);UNITY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
﻿## Description of Change

Reverts changes for Unity to provide support for ResolveAll. This feature will be unsupported on Unity until the issue is addressed in Unity. This won't be until Unity 6 as that is their current effort.

### Bugs Fixed


### API Changes

none

### Behavioral Changes

Reverts dual registration to provide keyed registration of types for ResolveAll. We will continue to only register it as expected. ResolveAll will not be supported for those using Unity.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard