### PR TITLE
OberservesProperty support for PropertyChanged with string.empty

### DIFF
--- a/src/Prism.Core/Commands/PropertyObserverNode.cs
+++ b/src/Prism.Core/Commands/PropertyObserverNode.cs
@@ -57,10 +57,7 @@ namespace Prism.Commands
 
         private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            // Invoke action when e.PropertyName == null in order to satisfy:
-            //  - DelegateCommandFixture.GenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName
-            //  - DelegateCommandFixture.NonGenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName
-            if (e?.PropertyName == PropertyInfo.Name || e?.PropertyName == null)
+            if (e?.PropertyName == PropertyInfo.Name || string.IsNullOrEmpty(e?.PropertyName))
             {
                 _action?.Invoke();
             }

--- a/tests/Prism.Core.Tests/Commands/DelegateCommandFixture.cs
+++ b/tests/Prism.Core.Tests/Commands/DelegateCommandFixture.cs
@@ -366,7 +366,7 @@ namespace Prism.Tests.Commands
         }
 
         [Fact]
-        public void NonGenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName()
+        public void NonGenericDelegateCommandObservingPropertyShouldRaiseOnNullPropertyName()
         {
             bool canExecuteChangedRaised = false;
 
@@ -375,6 +375,20 @@ namespace Prism.Tests.Commands
             command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
 
 			RaisePropertyChanged(null);
+
+            Assert.True(canExecuteChangedRaised);
+        }
+
+        [Fact]
+        public void NonGenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName()
+        {
+            bool canExecuteChangedRaised = false;
+
+            var command = new DelegateCommand(() => { }).ObservesProperty(() => IntProperty);
+
+            command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
+
+            RaisePropertyChanged(string.Empty);
 
             Assert.True(canExecuteChangedRaised);
         }
@@ -647,7 +661,7 @@ namespace Prism.Tests.Commands
         }
 
         [Fact]
-        public void GenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName()
+        public void GenericDelegateCommandObservingPropertyShouldRaiseOnNullPropertyName()
         {
             bool canExecuteChangedRaised = false;
 
@@ -656,6 +670,20 @@ namespace Prism.Tests.Commands
             command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
 
             RaisePropertyChanged(null);
+
+            Assert.True(canExecuteChangedRaised);
+        }
+
+        [Fact]
+        public void GenericDelegateCommandObservingPropertyShouldRaiseOnEmptyPropertyName()
+        {
+            bool canExecuteChangedRaised = false;
+
+            var command = new DelegateCommand<object>((o) => { }).ObservesProperty(() => IntProperty);
+
+            command.CanExecuteChanged += delegate { canExecuteChangedRaised = true; };
+
+            RaisePropertyChanged(string.Empty);
 
             Assert.True(canExecuteChangedRaised);
         }


### PR DESCRIPTION
﻿## Description of Change

Added support for PropertyChanged events that pass `string.Empty`

### Bugs Fixed

- #2196

### API Changes

none

### Behavioral Changes

ObservesProperty will now invoke the command's CanExecute when passing `string.Empty` to the PropertyChanged event

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard