### PR TITLE
Fix for Issue 2206 (Register should specify Reuse.Transient explicitly.)

### DIFF
--- a/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
+++ b/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
@@ -21,7 +21,7 @@ namespace Prism.DryIoc
         /// <summary>
         /// Gets the Default DryIoc Container Rules used by Prism
         /// </summary>
-        public static Rules DefaultRules => Rules.Default.WithConcreteTypeDynamicRegistrations()
+        public static Rules DefaultRules => Rules.Default.WithConcreteTypeDynamicRegistrations(reuse:Reuse.Transient)
                                                          .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
                                                          .WithFuncAndLazyWithoutRegistration()
                                                          .WithTrackingDisposableTransients()
@@ -204,7 +204,7 @@ namespace Prism.DryIoc
         /// <returns>The <see cref="IContainerRegistry" /> instance</returns>
         public IContainerRegistry Register(Type from, Type to)
         {
-            Instance.Register(from, to);
+            Instance.Register(from, to, Reuse.Transient);
             return this;
         }
 
@@ -217,7 +217,7 @@ namespace Prism.DryIoc
         /// <returns>The <see cref="IContainerRegistry" /> instance</returns>
         public IContainerRegistry Register(Type from, Type to, string name)
         {
-            Instance.Register(from, to, ifAlreadyRegistered: IfAlreadyRegistered.Replace, serviceKey: name);
+            Instance.Register(from, to, Reuse.Transient, ifAlreadyRegistered: IfAlreadyRegistered.Replace, serviceKey: name);
             return this;
         }
 

--- a/tests/Containers/Prism.Container.DryIoc.Tests/ContainerSetup.cs
+++ b/tests/Containers/Prism.Container.DryIoc.Tests/ContainerSetup.cs
@@ -6,7 +6,7 @@ namespace Prism.Ioc.Tests
 {
     partial class ContainerSetup
     {
-        IContainerExtension CreateContainerInternal() => new DryIocContainerExtension();
+        protected virtual IContainerExtension CreateContainerInternal() => new DryIocContainerExtension();
 
         public Type NativeContainerType => typeof(IContainer);
     }

--- a/tests/Containers/Prism.Container.DryIoc.Tests/ContainerSetupWithDefaultSingleton.cs
+++ b/tests/Containers/Prism.Container.DryIoc.Tests/ContainerSetupWithDefaultSingleton.cs
@@ -1,0 +1,13 @@
+﻿using DryIoc;
+using Prism.DryIoc;
+using Prism.Ioc.Tests;
+
+namespace Prism.Ioc.DryIoc.Tests
+{
+    public class ContainerSetupWithDefaultSingleton : ContainerSetup
+    {
+        public static Rules RulesWithDefaultSingleton => DryIocContainerExtension.DefaultRules.WithDefaultReuse(Reuse.Singleton);
+            
+        protected override IContainerExtension CreateContainerInternal() => new DryIocContainerExtension(new Container(RulesWithDefaultSingleton));
+    }
+}

--- a/tests/Containers/Prism.Container.DryIoc.Tests/ContainerTestsWithDefaultSingleton.cs
+++ b/tests/Containers/Prism.Container.DryIoc.Tests/ContainerTestsWithDefaultSingleton.cs
@@ -1,0 +1,78 @@
+﻿using Prism.Ioc.Mocks.Services;
+using Prism.Ioc.Tests;
+using System;
+using Xunit;
+
+namespace Prism.Ioc.DryIoc.Tests
+{
+    public class ContainerTestsWithDefaultSingleton : IClassFixture<ContainerSetupWithDefaultSingleton>, IDisposable
+    {
+        private bool disposedValue;
+
+        protected ContainerSetup Setup { get; }
+
+        public ContainerTestsWithDefaultSingleton(ContainerSetupWithDefaultSingleton setup)
+        {
+            Setup = setup;
+        }
+
+        [Fact]
+        public void RegisterServiceMappingCreatesTransient()
+        {
+            var container = Setup.CreateContainer();
+            Setup.Registry.Register<IServiceA, ServiceA>();
+            var resolved1 = container.Resolve<IServiceA>();
+            var resolved2 = container.Resolve<IServiceA>();
+            Assert.NotNull(resolved1);
+            Assert.NotNull(resolved2);
+            Assert.IsType<ServiceA>(resolved1);
+            Assert.IsType<ServiceA>(resolved2);
+            Assert.NotSame(resolved1, resolved2);
+        }
+
+        [Fact]
+        public void RegisterNamedServiceMappingCreatesTransient()
+        {
+            var container = Setup.CreateContainer();
+            Setup.Registry.Register<IServiceA, ServiceA>("Test");
+            var resolved1 = container.Resolve<IServiceA>("Test");
+            var resolved2 = container.Resolve<IServiceA>("Test");
+            var ex = Record.Exception(() => container.Resolve<IServiceA>());
+            Assert.NotNull(ex);
+            Assert.NotNull(resolved1);
+            Assert.NotNull(resolved2);
+            Assert.IsType<ServiceA>(resolved1);
+            Assert.IsType<ServiceA>(resolved2);
+            Assert.NotSame(resolved1, resolved2);
+        }
+
+        [Fact]
+        public void AutomaticTransientResolutionOfConcreteType()
+        {
+            var container = Setup.CreateContainer();
+            var resolved1 = container.Resolve<ServiceA>();
+            var resolved2 = container.Resolve<ServiceA>();
+            Assert.NotNull(resolved1);
+            Assert.NotSame(resolved1, resolved2);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Setup.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/tests/Containers/Prism.Container.Shared/Tests/ContainerSetup.cs
+++ b/tests/Containers/Prism.Container.Shared/Tests/ContainerSetup.cs
@@ -4,7 +4,7 @@ using Prism.Mvvm;
 
 namespace Prism.Ioc.Tests
 {
-    public sealed partial class ContainerSetup : IDisposable
+    public partial class ContainerSetup : IDisposable
     {
         public ContainerSetup()
         {


### PR DESCRIPTION
﻿## Description of Change

Describe your changes here.

### Bugs Fixed

The current DryIoc adapter doesn't specify transient reuse scope parameters for registering type, and if containers default reuse rule is changed other than Transient, it doesn't correctly implement the target interfaces contracts.

Also automatic resolution of concrete type is also affected by container default reuse settings.
This is a fix for #2206 

### API Changes

None

### Behavioral Changes

After this fix, the containerRegistry.Register call should register type as transient irrespective of the container's default reuse setting. Also. default automatic concrete type resolution always use transient, so any non registered type such as view models are always resolved as transient object.
  
Note that only with this fix, you can use DryIoc's MefAttribute extension out of the box as it will change the default reuse setting to Singleton.
 
### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard