### PR TITLE
Normalize ViewModelLocator.AutowireViewModel property name for Uno Platform

### DIFF
--- a/e2e/Uno/HelloUnoWorld.Shared/Dialogs/ConfirmationDialog.xaml
+++ b/e2e/Uno/HelloUnoWorld.Shared/Dialogs/ConfirmationDialog.xaml
@@ -2,7 +2,7 @@
                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:prismVM="using:Prism.Mvvm"
-               prismVM:ViewModelLocator.AutoWireViewModel="True"
+               prismVM:ViewModelLocator.AutowireViewModel="True"
                Width="300"
                Height="150">
 

--- a/e2e/Uno/HelloUnoWorld.Shared/Dialogs/NotificationDialog.xaml
+++ b/e2e/Uno/HelloUnoWorld.Shared/Dialogs/NotificationDialog.xaml
@@ -2,7 +2,7 @@
                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:prismVM="using:Prism.Mvvm"
-               prismVM:ViewModelLocator.AutoWireViewModel="True"
+               prismVM:ViewModelLocator.AutowireViewModel="True"
                Width="300"
                Height="150">
 

--- a/e2e/Uno/HelloUnoWorld.Shared/Views/ModulesPage.xaml
+++ b/e2e/Uno/HelloUnoWorld.Shared/Views/ModulesPage.xaml
@@ -8,7 +8,7 @@
       xmlns:modularity="using:Prism.Modularity"
       xmlns:prismMvvm="using:Prism.Mvvm"
       xmlns:prismI="using:Prism.Interactivity"
-      prismMvvm:ViewModelLocator.AutoWireViewModel="True"
+      prismMvvm:ViewModelLocator.AutowireViewModel="True"
       mc:Ignorable="d"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/e2e/Uno/HelloUnoWorld.Shared/Views/Shell.xaml
+++ b/e2e/Uno/HelloUnoWorld.Shared/Views/Shell.xaml
@@ -4,7 +4,7 @@
                 xmlns:prism="using:Prism"
                 xmlns:prismMvvm="using:Prism.Mvvm"
                 xmlns:prismRegions="using:Prism.Regions"
-                prismMvvm:ViewModelLocator.AutoWireViewModel="True"
+                prismMvvm:ViewModelLocator.AutowireViewModel="True"
                 xmlns:toolkit="using:Uno.UI.Toolkit"
                 xmlns:local="clr-namespace:HelloWorld">
 

--- a/src/Uno/Prism.Uno/Mvvm/ViewModelLocator.cs
+++ b/src/Uno/Prism.Uno/Mvvm/ViewModelLocator.cs
@@ -1,0 +1,55 @@
+﻿using Windows.UI.Xaml;
+
+namespace Prism.Mvvm
+{
+    /// <summary>
+    /// This class defines the attached property and related change handler that calls the ViewModelLocator in Prism.Mvvm.
+    /// </summary>
+    public static class ViewModelLocator
+    {
+        /// <summary>
+        /// The AutowireViewModel attached property.
+        /// </summary>
+        public static DependencyProperty AutowireViewModelProperty = DependencyProperty.RegisterAttached("AutowireViewModel", typeof(bool?), typeof(ViewModelLocator), new PropertyMetadata(defaultValue: null, propertyChangedCallback: AutowireViewModelChanged));
+
+        /// <summary>
+        /// Gets the value for the <see cref="AutowireViewModelProperty"/> attached property.
+        /// </summary>
+        /// <param name="obj">The target element.</param>
+        /// <returns>The <see cref="AutowireViewModelProperty"/> attached to the <paramref name="obj"/> element.</returns>
+        public static bool? GetAutowireViewModel(DependencyObject obj)
+        {
+            return (bool?)obj.GetValue(AutowireViewModelProperty);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="AutowireViewModelProperty"/> attached property.
+        /// </summary>
+        /// <param name="obj">The target element.</param>
+        /// <param name="value">The value to attach.</param>
+        public static void SetAutowireViewModel(DependencyObject obj, bool? value)
+        {
+            obj.SetValue(AutowireViewModelProperty, value);
+        }
+
+        private static void AutowireViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var value = (bool?)e.NewValue;
+            if (value.HasValue && value.Value)
+            {
+                ViewModelLocationProvider.AutoWireViewModelChanged(d, Bind);
+            }
+        }
+
+        /// <summary>
+        /// Sets the DataContext of a View.
+        /// </summary>
+        /// <param name="view">The View to set the DataContext on.</param>
+        /// <param name="viewModel">The object to use as the DataContext for the View.</param>
+        static void Bind(object view, object viewModel)
+        {
+            if (view is FrameworkElement element)
+                element.DataContext = viewModel;
+        }
+    }
+}

--- a/src/Uno/Prism.Uno/Prism.Uno.csproj
+++ b/src/Uno/Prism.Uno/Prism.Uno.csproj
@@ -45,6 +45,7 @@ Prism for Uno Platform helps you more easily design and build rich, flexible, an
     <Compile Remove="..\..\Wpf\Prism.Wpf\Bootstrapper.cs" />
     <Compile Remove="..\..\Wpf\Prism.Wpf\Interactivity\InvokeCommandAction.cs" />
     <Compile Remove="..\..\Wpf\Prism.Wpf\Ioc\ContainerProviderExtension.cs" />
+    <Compile Remove="..\..\Wpf\Prism.Wpf\Mvvm\ViewModelLocator.cs" />
     <Compile Remove="..\..\Wpf\Prism.Wpf\PrismApplicationBase.cs" />
     <Compile Remove="..\..\Wpf\Prism.Wpf\PrismBootstrapperBase.cs" />
     <Compile Remove="..\..\Wpf\Prism.Wpf\Properties\AssemblyInfo.cs" />

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -15,6 +15,15 @@ namespace Prism.Common
     /// </summary>
     public static class MvvmHelpers
     {
+#if HAS_WINUI
+        internal static void AutowireViewModel(object viewOrViewModel)
+        {
+            if (viewOrViewModel is FrameworkElement view && view.DataContext is null && ViewModelLocator.GetAutowireViewModel(view) is null)
+            {
+                ViewModelLocator.SetAutowireViewModel(view, true);
+            }
+        }
+#else
         internal static void AutowireViewModel(object viewOrViewModel)
         {
             if (viewOrViewModel is FrameworkElement view && view.DataContext is null && ViewModelLocator.GetAutoWireViewModel(view) is null)
@@ -22,6 +31,7 @@ namespace Prism.Common
                 ViewModelLocator.SetAutoWireViewModel(view, true);
             }
         }
+#endif
 
         /// <summary>
         /// Perform an <see cref="Action{T}"/> on a view and viewmodel.


### PR DESCRIPTION
﻿## Description of Change

Prism.Wpf had the Autowire improperly cased as AutoWire. This has been fixed for Prism.Uno. We will address a solution for Prism.Wpf in Prism 8.1

### API Changes

Changed:

This change applies only to Prism.Uno

- ViewModelLocator.AutoWireViewModel -> ViewModelLocator.AutowireViewModel

### Behavioral Changes

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard