### PR TITLE
ci: Apply temporary workaround for https://github.com/actions/virtual-environments/issues/1932

### DIFF
--- a/build/scripts/xcode-update.sh
+++ b/build/scripts/xcode-update.sh
@@ -4,3 +4,6 @@ echo "Setting Xcode Override to: $xcodeRoot"
 
 echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'$xcodeRoot
 sudo xcode-select --switch $xcodeRoot/Contents/Developer
+
+# Apply temporary workaround for https://github.com/actions/virtual-environments/issues/1932
+rm -f ${HOME}/Library/Preferences/Xamarin/Settings.plist


### PR DESCRIPTION
##  Description of Change

Apply temporary workaround for Xcode selection for Xamarin.UITest. Reverting this may be needed when running tests on Xcode 12 and later, once Xamarin.UITests supports it (https://github.com/actions/virtual-environments/issues/1932). 

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard