### PR TITLE
bump v8.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,17 +45,7 @@
 
   <!-- Versioning -->
   <PropertyGroup>
-    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">8.0.0</VersionPrefix>
-    <VersionSuffix>ci</VersionSuffix>
-    <!-- This will create CI builds as 7.0.0.1234-ci -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
-    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_PREVIEW)' ">pre</VersionSuffix>
-    <VersionSuffix Condition=" '$(PRISM_RELEASE)' == '' And '$(IS_RELEASE)' "></VersionSuffix>
-    <PackageReleaseNotes Condition=" '$(VersionSuffix)' == 'pre' ">https://github.com/PrismLibrary/Prism/releases/tag/v$(VersionPrefix)-pre</PackageReleaseNotes>
-    <PackageReleaseNotes Condition=" '$(VersionSuffix)' == '' ">https://github.com/PrismLibrary/Prism/releases/tag/v$(VersionPrefix)</PackageReleaseNotes>
-    <PackageReleaseNotes Condition=" '$(Version)' != '' ">https://github.com/PrismLibrary/Prism/releases/tag/v$(Version)</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/PrismLibrary/Prism/releases/tag/v$(Version)</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">

--- a/Packages.props
+++ b/Packages.props
@@ -59,8 +59,13 @@
                             Version="1.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" $(DISABLE_GITVERSIONING) != 'true' ">
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.3.37"
+                            Condition=" !$(MSBuildProjectDirectory.Contains('e2e')) "/>
+  </ItemGroup>
+
   <ItemGroup Condition=" $(IsPackable) ">
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub"
-                      Version="1.1.0-beta-20204-02" />
+                            Version="1.1.0-beta-20204-02" />
   </ItemGroup>
 </Project>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -142,7 +142,7 @@ stages:
 
 - stage: deploy
   displayName: CI Deploy Artifacts
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/rel')))
   jobs:
   - deployment: SponsorConnect
     displayName: SponsorConnect.dev
@@ -164,14 +164,13 @@ stages:
               nuGetFeedType: external
               publishFeedCredentials: 'SponsorConnect'
 
-- stage: nuGetDeploy
+- stage: nugetDeploy
   displayName: NuGet.org Deploy
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/rel'), eq(variables['system.pullrequest.isfork'], false))
   jobs:
   - deployment: NuGet
     displayName: NuGet.org
     environment: NuGet
-    condition: and(succeeded(),or(eq(variables['IS_PREVIEW'], true), eq(variables['IS_RELEASE'], true)))
     strategy:
       runOnce:
         deploy:

--- a/build/scripts/wasm-uitest-run.sh
+++ b/build/scripts/wasm-uitest-run.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 cd $BUILD_SOURCESDIRECTORY
 
 msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.UITests/HelloUnoWorld.UITests.csproj
-msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.Wasm/HelloUnoWorld.Wasm.csproj
+msbuild /r /p:Configuration=Release /p:DISABLE_GITVERSIONING=true $BUILD_SOURCESDIRECTORY/e2e/Uno/HelloUnoWorld.Wasm/HelloUnoWorld.Wasm.csproj
 
 cd $BUILD_SOURCESDIRECTORY/build
 

--- a/e2e/Wpf/HelloWorld.Bootstraper/HelloWorld.Bootstrapper.csproj
+++ b/e2e/Wpf/HelloWorld.Bootstraper/HelloWorld.Bootstrapper.csproj
@@ -5,11 +5,6 @@
     <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>HelloWorld</RootNamespace>
-    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">8.0.0</VersionPrefix>
-    <!-- This will create CI builds as 7.0.0.1234-ci -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
     <ApplicationIcon>..\HelloWorld\prism-sandbox.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/e2e/Wpf/HelloWorld/HelloWorld.csproj
+++ b/e2e/Wpf/HelloWorld/HelloWorld.csproj
@@ -6,11 +6,6 @@
     <UseWPF>true</UseWPF>
     <RootNamespace>HelloWorld</RootNamespace>
     <AssemblyName>HelloWorld</AssemblyName>
-    <Version Condition=" '$(PRISM_RELEASE)' != '' ">$(PRISM_RELEASE)</Version>
-    <!-- Update this version when incrementing Library Versions i.e. 7.1.0, 7.2.0 -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' ">8.0.0</VersionPrefix>
-    <!-- This will create CI builds as 7.0.0.1234-ci -->
-    <VersionPrefix Condition=" '$(PRISM_RELEASE)' == '' And '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
     <ApplicationIcon>prism-sandbox.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/Forms/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
+++ b/src/Forms/Prism.DryIoc.Forms/Prism.DryIoc.Forms.csproj
@@ -7,7 +7,6 @@
     <!--<Summary>DryIoc extensions for Prism for Xamarin.Forms.</Summary>-->
     <Description>Use these extensions to build Xamarin.Forms applications with Prism and DryIoc.</Description>
     <PackageTags>prism;xamarin;xamarin.forms;dryioc;dependency injection</PackageTags>
-    <Version Condition=" '$(PRISM_DRYIOC_FORMS_VERSION)' != '' ">$(PRISM_DRYIOC_FORMS_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Forms/Prism.Forms/Prism.Forms.csproj
+++ b/src/Forms/Prism.Forms/Prism.Forms.csproj
@@ -10,7 +10,6 @@
 
 Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications. This library provides user interface composition as well as modularity support.</Description>
     <PackageTags>prism;xamarin;xamarin.forms;mvvm;uwp;ios;android;xaml</PackageTags>
-    <Version Condition=" '$(PRISM_FORMS_VERSION)' != '' ">$(PRISM_FORMS_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Forms/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/src/Forms/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -8,7 +8,6 @@
     <!--<Summary>Unity extensions for Prism for Xamarin.Forms.</Summary>-->
     <Description>Use these extensions to build Xamarin.Forms applications with Prism and Unity.</Description>
     <PackageTags>prism;xamarin;xamarin.forms;ninject;dependency injection</PackageTags>
-    <Version Condition=" '$(PRISM_UNITY_FORMS_VERSION)' != '' ">$(PRISM_UNITY_FORMS_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Prism.Core/Prism.Core.csproj
+++ b/src/Prism.Core/Prism.Core.csproj
@@ -9,7 +9,6 @@
     <!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
     <Description>Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices.  Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared code base in a Portable Class Library targeting these platforms; WPF, and Xamarin Forms. Features that need to be platform specific are implemented in the respective libraries for the target platform.</Description>
     <PackageTags>prism;wpf;xamarin;mvvm;xaml</PackageTags>
-    <Version Condition=" '$(PRISM_CORE_VERSION)' != '' ">$(PRISM_CORE_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework) == 'net45' ">

--- a/src/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
+++ b/src/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
@@ -9,7 +9,6 @@
     <!--<Summary>DryIoc extensions for Prism.</Summary>-->
     <Description>Use these extensions to build Prism applications based on DryIoc.</Description>
     <PackageTags>prism;dryioc;mvvm;wpf;xaml</PackageTags>
-    <Version Condition=" '$(PRISM_DRYIOC_WPF_VERSION)' != '' ">$(PRISM_DRYIOC_WPF_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
+++ b/src/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
@@ -9,7 +9,6 @@
     <!--<Summary>Unity extensions for Prism.</Summary>-->
     <Description>Use these extensions to build Prism applications based on Unity.</Description>
     <PackageTags>prism;unity;mvvm;wpf;xaml</PackageTags>
-    <Version Condition=" '$(PRISM_UNITY_WPF_VERSION)' != '' ">$(PRISM_UNITY_WPF_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/src/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -11,7 +11,6 @@
 
 Prism.Wpf helps you more easily design and build rich, flexible, and easy to maintain Windows Presentation Foundation (WPF) desktop applications. This library provides user interface composition as well as modularity support.</Description>
     <PackageTags>prism;mvvm;xaml;wpf</PackageTags>
-    <Version Condition=" '$(PRISM_WPF_VERSION)' != '' ">$(PRISM_WPF_VERSION)</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "8.1-pre",
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/rel$"
+  ]
+}


### PR DESCRIPTION
﻿## Description of Change

Updates build to bump to 8.1 and use Nerdbank GitVersioning moving forward.

### Behavioral Changes

Changes are to the package and the build versioning & build/release only and not anything in code.

Versioning will no longer be based on the CI Platform Build number. We are moving from {major}.{minor}.{revision}.{build} to {major}.{minor}.{git height} where the git height is the number of commits from the last version bump.

Also note that all CI builds on Sponsor Connect will be flagged pre.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard