### PR TITLE
Add method to display prompt on IPageDialogService

### DIFF
--- a/e2e/Forms/src/HelloPageDialog/HelloPageDialogModule.cs
+++ b/e2e/Forms/src/HelloPageDialog/HelloPageDialogModule.cs
@@ -14,9 +14,10 @@ namespace HelloPageDialog
             _pageDialogService = pageDialogService;
         }
 
-        public void OnInitialized(IContainerProvider containerProvider)
+        public async void OnInitialized(IContainerProvider containerProvider)
         {
-            _pageDialogService.DisplayAlertAsync("Hello", "You just loaded the PageDialogService Module!", "Ok");
+            var name = await _pageDialogService.DisplayPromptAsync("Hello", "What is your name?", placeholder: "Your name");
+            _pageDialogService.DisplayAlertAsync("Hello", $"{(string.IsNullOrWhiteSpace(name) ? "You" : name)} just loaded the PageDialogService Module!", "Ok");
         }
 
         public void RegisterTypes(IContainerRegistry containerRegistry)

--- a/src/Forms/Prism.Forms/Services/PageDialogService/IPageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/IPageDialogService.cs
@@ -53,5 +53,19 @@ namespace Prism.Services
         /// <param name="buttons">Buttons displayed in action sheet</param>
         /// <returns></returns>
         Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons);
+
+        /// <summary>
+        /// Displays a native platform promt, allowing the application user to enter a string.
+        /// </summary>
+        /// <param name="title">Title to display</param>
+        /// <param name="message">Message to display</param>
+        /// <param name="accept">Text for the accept button</param>
+        /// <param name="cancel">Text for the cancel button</param>
+        /// <param name="placeholder">Placeholder text to display in the prompt</param>
+        /// <param name="maxLength">Maximum length of the user response</param>
+        /// <param name="keyboard">Keyboard type to use for the user response</param>
+        /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
+        /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
+        Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, Xamarin.Forms.Keyboard keyboard = default, string initialValue = "");
     }
 }

--- a/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -90,6 +90,23 @@ namespace Prism.Services
             }
         }
 
+        /// <summary>
+        /// Displays a native platform promt, allowing the application user to enter a string.
+        /// </summary>
+        /// <param name="title">Title to display</param>
+        /// <param name="message">Message to display</param>
+        /// <param name="accept">Text for the accept button</param>
+        /// <param name="cancel">Text for the cancel button</param>
+        /// <param name="placeholder">Placeholder text to display in the prompt</param>
+        /// <param name="maxLength">Maximum length of the user response</param>
+        /// <param name="keyboard">Keyboard type to use for the user response</param>
+        /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
+        /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
+        public virtual Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, Xamarin.Forms.Keyboard keyboard = default, string initialValue = "")
+        {
+            return _applicationProvider.MainPage.DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);
+        }
+
         private Page GetCurrentPage()
         {
             Page page;


### PR DESCRIPTION
﻿## Description of Change

Added `DisplayPromptAsync` to `IPageDialogService`, along with implementation in `PageDialogService`.

### Bugs Fixed

None

### API Changes

Added:

- Task<string> IPageDialogService.DisplayPromptAsync();

### Behavioral Changes

None

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard