### PR TITLE
Fixed RegisterMany* for Unity container and removed !UNITY condition …

### DIFF
--- a/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
+++ b/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
@@ -145,7 +145,7 @@ namespace Prism.Unity
         public IContainerRegistry RegisterManySingleton(Type type, params Type[] serviceTypes)
         {
             Instance.RegisterSingleton(type);
-            return this;
+            return RegisterManyInternal(type, serviceTypes);
         }
 
         private IContainerRegistry RegisterManyInternal(Type implementingType, Type[] serviceTypes)
@@ -222,7 +222,7 @@ namespace Prism.Unity
         public IContainerRegistry RegisterMany(Type type, params Type[] serviceTypes)
         {
             Instance.RegisterType(type);
-            return this;
+            return RegisterManyInternal(type, serviceTypes);
         }
 
         /// <summary>

--- a/tests/Containers/Prism.Container.Shared/Tests/ContainerFixture.cs
+++ b/tests/Containers/Prism.Container.Shared/Tests/ContainerFixture.cs
@@ -155,8 +155,6 @@ namespace Prism.Ioc.Tests
             Assert.NotSame(resolved, resolved2);
         }
 
-#if !UNITY
-
         [Fact]
         public void RegisterManyRegistersAllInterfacesByDefault()
         {
@@ -187,8 +185,6 @@ namespace Prism.Ioc.Tests
             Setup.Registry.RegisterMany<CompositeService>();
             Assert.NotSame(container.Resolve<IServiceA>(), container.Resolve<IServiceA>());
         }
-
-#endif
 
         [Fact]
         public void RegisterSupportsLazyInjection()
@@ -288,8 +284,6 @@ namespace Prism.Ioc.Tests
             Assert.Same(resolved, resolved2);
         }
 
-#if !UNITY
-
         [Fact]
         public void RegisterManySingletonRegistersAllInterfacesByDefault()
         {
@@ -326,8 +320,6 @@ namespace Prism.Ioc.Tests
             Assert.Same(serviceA, serviceB);
             Assert.Same(serviceB, serviceC);
         }
-
-#endif
 
         [Fact]
         public void RegisterSingletonSupportsLazyInjection()


### PR DESCRIPTION
﻿## Description of Change

Fixed container extension methods `RegisterMany` and `RegisterManySingleton` for the Unity container.

### Bugs Fixed

- Fixed bug #2245 


### API Changes

None.

### Behavioral Changes

None.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard