### PR TITLE
Automatically apply VML to view with same binding context as parent

### DIFF
--- a/src/Forms/Prism.Forms/Common/PageUtilities.cs
+++ b/src/Forms/Prism.Forms/Common/PageUtilities.cs
@@ -287,13 +287,12 @@ namespace Prism.Common
             {
                 ViewModelLocator.SetAutowireViewModel(element, true);
             }
-            else
+            else if (element.BindingContext == element.Parent?.BindingContext)
             {
                 //if the parent binding context is the same as the element, then it was probably inherited
                 //and we don't want that. Set the VML
-                if (element.BindingContext == element.Parent?.BindingContext)
-                    ViewModelLocator.SetAutowireViewModel(element, true);
-            }
+                ViewModelLocator.SetAutowireViewModel(element, true);
+            }                
         }
     }
 }

--- a/src/Forms/Prism.Forms/Common/PageUtilities.cs
+++ b/src/Forms/Prism.Forms/Common/PageUtilities.cs
@@ -284,7 +284,16 @@ namespace Prism.Common
         public static void SetAutowireViewModel(VisualElement element)
         {
             if (element.BindingContext is null && ViewModelLocator.GetAutowireViewModel(element) is null)
+            {
                 ViewModelLocator.SetAutowireViewModel(element, true);
+            }
+            else
+            {
+                //if the parent binding context is the same as the element, then it was probably inherited
+                //and we don't want that. Set the VML
+                if (element.BindingContext == element.Parent?.BindingContext)
+                    ViewModelLocator.SetAutowireViewModel(element, true);
+            }
         }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Added a check for the VML to automatically apply to views whose binding context is the same as the parent, which indicates it was inherited.

### Bugs Fixed

- #2279

### API Changes

none

### Behavioral Changes

Views 

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard