### PR TITLE
Fixed default value for WindowStartupLocation

### DIFF
--- a/src/Wpf/Prism.Wpf/Services/Dialogs/Dialog.cs
+++ b/src/Wpf/Prism.Wpf/Services/Dialogs/Dialog.cs
@@ -46,10 +46,9 @@ namespace Prism.Services.Dialogs
         /// </summary>
         /// <remarks>
         /// This attached property is used to specify the startup location of a <see cref="IDialogWindow"/>.
-        /// The default startup location is <c>WindowStartupLocation.CenterOwner</c>.
         /// </remarks>
         public static readonly DependencyProperty WindowStartupLocationProperty =
-            DependencyProperty.RegisterAttached("WindowStartupLocation", typeof(WindowStartupLocation), typeof(Dialog), new UIPropertyMetadata(WindowStartupLocation.CenterOwner, OnWindowStartupLocationChanged));
+            DependencyProperty.RegisterAttached("WindowStartupLocation", typeof(WindowStartupLocation), typeof(Dialog), new UIPropertyMetadata(OnWindowStartupLocationChanged));
 
         /// <summary>
         /// Gets the value for the <see cref="WindowStartupLocationProperty"/> attached property.


### PR DESCRIPTION
﻿## Description of Change

Removed default value for Dialog.WindowStartupLocation

### Bugs Fixed

- #2216

### Behavioral Changes

Custom Dialog WIndows can now work properly with the attached property

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard