### PR TITLE
PageDialogService Updates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <RelativeProjectPath>$([System.Text.RegularExpressions.Regex]::Replace('$(MSBuildProjectFullPath)', '$(EscapedCurrentDirectory)', ''))</RelativeProjectPath>
     <PrismPackageIcon>$(MSBuildThisFileDirectory)images/prism-logo.png</PrismPackageIcon>
     <PrismLicenseFile>$(MSBuildThisFileDirectory)LICENSE</PrismLicenseFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/e2e/Forms/src/HelloPageDialog/HelloPageDialogModule.cs
+++ b/e2e/Forms/src/HelloPageDialog/HelloPageDialogModule.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using HelloPageDialog.ViewModels;
+using HelloPageDialog.Views;
 using Prism.Ioc;
 using Prism.Modularity;
 using Prism.Services;
+using Xamarin.Forms;
 
 namespace HelloPageDialog
 {
@@ -14,15 +16,18 @@ namespace HelloPageDialog
             _pageDialogService = pageDialogService;
         }
 
-        public async void OnInitialized(IContainerProvider containerProvider)
+        public void OnInitialized(IContainerProvider containerProvider)
         {
-            var name = await _pageDialogService.DisplayPromptAsync("Hello", "What is your name?", placeholder: "Your name");
-            _pageDialogService.DisplayAlertAsync("Hello", $"{(string.IsNullOrWhiteSpace(name) ? "You" : name)} just loaded the PageDialogService Module!", "Ok");
+            _pageDialogService.DisplayAlertAsync("Hello", "You just loaded the PageDialogService Module!", "Ok");
         }
 
         public void RegisterTypes(IContainerRegistry containerRegistry)
         {
-
+            containerRegistry.RegisterForNavigation<NavigationPage>();
+            containerRegistry.RegisterForNavigation<PageDialogTabs>();
+            containerRegistry.RegisterForNavigation<ActionSheetDemoPage, ActionSheetDemoPageViewModel>();
+            containerRegistry.RegisterForNavigation<AlertDialogDemoPage, AlertDialogDemoPageViewModel>();
+            containerRegistry.RegisterForNavigation<DisplayPromptDemoPage, DisplayPromptDemoPageViewModel>();
         }
     }
 }

--- a/e2e/Forms/src/HelloPageDialog/ViewModels/ActionSheetDemoPageViewModel.cs
+++ b/e2e/Forms/src/HelloPageDialog/ViewModels/ActionSheetDemoPageViewModel.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Prism.Commands;
+using Prism.Services;
+
+namespace HelloPageDialog.ViewModels
+{
+    public class ActionSheetDemoPageViewModel : PageDialogDemoBaseViewModel
+    {
+        public ActionSheetDemoPageViewModel(IPageDialogService pageDialogs)
+            : base(pageDialogs)
+        {
+            Actions = new ObservableCollection<string>();
+
+            ClearCommand = new DelegateCommand(OnClearCommandExecuted, () => !string.IsNullOrEmpty(Title) || Actions.Any())
+                .ObservesProperty(() => Title)
+                .ObservesProperty(() => Actions);
+            ShowActionSheetCommand = new DelegateCommand(OnShowActionSheetCommandExecuted)
+                .ObservesProperty(() => Title)
+                .ObservesProperty(() => Actions)
+                .ObservesCanExecute(() => CanExecute);
+
+            AddCommand = new DelegateCommand(OnAddCommandExecuted, () => !string.IsNullOrEmpty(Message))
+                .ObservesProperty(() => Message);
+        }
+
+        public ObservableCollection<string> Actions { get; }
+
+        public DelegateCommand ClearCommand { get; }
+
+        public DelegateCommand ShowActionSheetCommand { get; }
+
+        public DelegateCommand AddCommand { get; }
+
+        private bool CanExecute => !string.IsNullOrEmpty(Title) && Actions.Any();
+
+        private void OnAddCommandExecuted()
+        {
+            if (!string.IsNullOrEmpty(Message))
+                Actions.Add(Message);
+
+            Message = null;
+        }
+
+        private void OnClearCommandExecuted()
+        {
+            Title = null;
+            Actions.Clear();
+        }
+
+        private async void OnShowActionSheetCommandExecuted()
+        {
+            await _pageDialogs.DisplayActionSheetAsync(Title, FlowDirection, CreateButtons());
+        }
+
+        private IActionSheetButton[] CreateButtons()
+        {
+            var buttons = new List<IActionSheetButton>()
+            {
+                ActionSheetButton.CreateCancelButton("Cancel", () => Callback("Cancel")),
+                ActionSheetButton.CreateDestroyButton("Destroy", () => Callback("Destroy"))
+            };
+
+            foreach (var text in Actions)
+                buttons.Add(ActionSheetButton.CreateButton(text, () => Callback(text)));
+
+            return buttons.ToArray();
+        }
+
+        private Task Callback(string message)
+        {
+            return _pageDialogs.DisplayAlertAsync("Success", $"You clicked '{message}'.", "Ok");
+        }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/ViewModels/AlertDialogDemoPageViewModel.cs
+++ b/e2e/Forms/src/HelloPageDialog/ViewModels/AlertDialogDemoPageViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Prism.Commands;
+using Prism.Services;
+
+namespace HelloPageDialog.ViewModels
+{
+    public class AlertDialogDemoPageViewModel : PageDialogDemoBaseViewModel
+    {
+        public AlertDialogDemoPageViewModel(IPageDialogService pageDialogs) : base(pageDialogs)
+        {
+            ShowAlertCommand = new DelegateCommand(OnShowAlertCommandExecuted,
+                    () => !string.IsNullOrEmpty(Title) && !string.IsNullOrEmpty(Message))
+                .ObservesProperty(() => Title)
+                .ObservesProperty(() => Message);
+        }
+
+        public DelegateCommand ShowAlertCommand { get; }
+
+        private async void OnShowAlertCommandExecuted()
+        {
+            await _pageDialogs.DisplayAlertAsync(Title, Message, "Ok", FlowDirection);
+        }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/ViewModels/DisplayPromptDemoPageViewModel.cs
+++ b/e2e/Forms/src/HelloPageDialog/ViewModels/DisplayPromptDemoPageViewModel.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using Prism.AppModel;
+using Prism.Commands;
+using Prism.Services;
+
+namespace HelloPageDialog.ViewModels
+{
+    public class DisplayPromptDemoPageViewModel : PageDialogDemoBaseViewModel
+    {
+        public DisplayPromptDemoPageViewModel(IPageDialogService pageDialogs) : base(pageDialogs)
+        {
+            ShowPromptCommand = new DelegateCommand(OnShowPromptCommandExecuted,
+                    () => !string.IsNullOrEmpty(Title) && !string.IsNullOrEmpty(Message))
+                .ObservesProperty(() => Title)
+                .ObservesProperty(() => Message);
+
+            KeyboardTypes = new[]
+            {
+                KeyboardType.Chat,
+                KeyboardType.Default,
+                KeyboardType.Email,
+                KeyboardType.Numeric,
+                KeyboardType.Plain,
+                KeyboardType.Telephone,
+                KeyboardType.Text,
+                KeyboardType.Url
+            };
+        }
+
+        private string _placeholder;
+        public string Placeholder
+        {
+            get => _placeholder;
+            set => SetProperty(ref _placeholder, value);
+        }
+
+        private string _accept = "OK";
+        public string Accept
+        {
+            get => _accept;
+            set => SetProperty(ref _accept, value);
+        }
+
+        private string _cancel = "Cancel";
+        public string Cancel
+        {
+            get => _cancel;
+            set => SetProperty(ref _cancel, value);
+        }
+
+        private KeyboardType _keyboardType = KeyboardType.Default;
+        public KeyboardType KeyboardType
+        {
+            get => _keyboardType;
+            set => SetProperty(ref _keyboardType, value);
+        }
+
+        public IEnumerable<KeyboardType> KeyboardTypes { get; }
+
+        private int _maxLength = -1;
+        public int MaxLength
+        {
+            get => _maxLength;
+            set => SetProperty(ref _maxLength, value);
+        }
+
+        private string _initialValue;
+        public string InitialValue
+        {
+            get => _initialValue;
+            set => SetProperty(ref _initialValue, value);
+        }
+
+        public DelegateCommand ShowPromptCommand { get; }
+
+        private async void OnShowPromptCommandExecuted()
+        {
+            var value = await _pageDialogs.DisplayPromptAsync(Title, Message, Accept, Cancel, Placeholder, MaxLength, KeyboardType);
+
+            if (!string.IsNullOrEmpty(value))
+                await _pageDialogs.DisplayAlertAsync("Success", $"You entered: '{value}'.", "Ok");
+        }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/ViewModels/PageDialogDemoBaseViewModel.cs
+++ b/e2e/Forms/src/HelloPageDialog/ViewModels/PageDialogDemoBaseViewModel.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Prism.AppModel;
+using Prism.Mvvm;
+using Prism.Services;
+
+namespace HelloPageDialog.ViewModels
+{
+    public partial class PageDialogDemoBaseViewModel : BindableBase
+    {
+        protected IPageDialogService _pageDialogs { get; }
+
+        public PageDialogDemoBaseViewModel(IPageDialogService pageDialogs)
+        {
+            _pageDialogs = pageDialogs;
+            FlowDirections = new[]
+            {
+                FlowDirection.MatchParent,
+                FlowDirection.LeftToRight,
+                FlowDirection.RightToLeft
+            };
+        }
+
+        private bool _useExplicitFlow;
+        public bool UseExplicitFlow
+        {
+            get => _useExplicitFlow;
+            set => SetProperty(ref _useExplicitFlow, value);
+        }
+
+        private string _title;
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        private string _message;
+        public string Message
+        {
+            get => _message;
+            set => SetProperty(ref _message, value);
+        }
+
+        private FlowDirection _flowDirection;
+        public FlowDirection FlowDirection
+        {
+            get => _flowDirection;
+            set => SetProperty(ref _flowDirection, value);
+        }
+
+        public IEnumerable<FlowDirection> FlowDirections { get; }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/Views/ActionSheetDemoPage.xaml
+++ b/e2e/Forms/src/HelloPageDialog/Views/ActionSheetDemoPage.xaml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             prism:ViewModelLocator.AutowireViewModel="True"
+             Title="Action Sheet"
+             Padding="15"
+             x:Class="HelloPageDialog.Views.ActionSheetDemoPage">
+  <Grid RowDefinitions="Auto,*,Auto,Auto"
+        Padding="15">
+    <StackLayout>
+      <Label Text="Title" />
+      <Entry Text="{Binding Title}" />
+      <Label Text="Flow Direction" />
+      <Picker ItemsSource="{Binding FlowDirections}"
+            ItemDisplayBinding="{Binding .,StringFormat='{0}'}"
+            SelectedItem="{Binding FlowDirection}" />
+    </StackLayout>
+    <CollectionView ItemsSource="{Binding Actions}"
+                    Grid.Row="1">
+      <CollectionView.Header>
+        <StackLayout>
+          <Label Text="Add Action Button Text" />
+          <Entry Text="{Binding Message}" />
+          <Button Text="Add"
+                  Command="{Binding AddCommand}" />
+        </StackLayout>
+      </CollectionView.Header>
+      <CollectionView.EmptyView>
+        <Label Text="Please add some actions"
+               TextColor="Gray"
+               HorizontalTextAlignment="Center" />
+      </CollectionView.EmptyView>
+      <CollectionView.ItemTemplate>
+        <DataTemplate>
+          <Label Text="{Binding .}" />
+        </DataTemplate>
+      </CollectionView.ItemTemplate>
+    </CollectionView>
+    <Button Text="Clear"
+            Command="{Binding ClearCommand}"
+            Grid.Row="2" />
+    <Button Text="Diplay Action Sheet"
+            Command="{Binding ShowActionSheetCommand}"
+            Grid.Row="3" />
+  </Grid>
+</ContentPage>

--- a/e2e/Forms/src/HelloPageDialog/Views/ActionSheetDemoPage.xaml.cs
+++ b/e2e/Forms/src/HelloPageDialog/Views/ActionSheetDemoPage.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace HelloPageDialog.Views
+{
+    public partial class ActionSheetDemoPage : ContentPage
+    {
+        public ActionSheetDemoPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/Views/AlertDialogDemoPage.xaml
+++ b/e2e/Forms/src/HelloPageDialog/Views/AlertDialogDemoPage.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             prism:ViewModelLocator.AutowireViewModel="True"
+             Title="Alert Dialog"
+             x:Class="HelloPageDialog.Views.AlertDialogDemoPage">
+  <StackLayout Padding="15">
+    <Label Text="Title" />
+    <Entry Text="{Binding Title}" />
+    <Label Text="Message" />
+    <Entry Text="{Binding Message}" />
+    <Label Text="Flow Direction" />
+    <Picker ItemsSource="{Binding FlowDirections}"
+            ItemDisplayBinding="{Binding .,StringFormat='{0}'}"
+            SelectedItem="{Binding FlowDirection}" />
+    <Button Text="Show Alert"
+            Command="{Binding ShowAlertCommand}" />
+  </StackLayout>
+</ContentPage>

--- a/e2e/Forms/src/HelloPageDialog/Views/AlertDialogDemoPage.xaml.cs
+++ b/e2e/Forms/src/HelloPageDialog/Views/AlertDialogDemoPage.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace HelloPageDialog.Views
+{
+    public partial class AlertDialogDemoPage : ContentPage
+    {
+        public AlertDialogDemoPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/Views/DisplayPromptDemoPage.xaml
+++ b/e2e/Forms/src/HelloPageDialog/Views/DisplayPromptDemoPage.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             Title="Prompts"
+             ios:Page.UseSafeArea="True"
+             x:Class="HelloPageDialog.Views.DisplayPromptDemoPage">
+  <Grid RowDefinitions="*,Auto" Padding="15">
+    <TableView Intent="Form" HasUnevenRows="True">
+      <TableRoot Title="Page Dialog Service">
+        <TableSection Title="Display Prompt">
+          <EntryCell Label="Title" Text="{Binding Title}" />
+          <EntryCell Label="Message" Text="{Binding Message}" />
+          <EntryCell Label="Placeholder" Text="{Binding Placeholder}" />
+          <EntryCell Label="Initial Value" Text="{Binding InitialValue}" />
+          <EntryCell Label="Accept Button" Text="{Binding Accept}" />
+          <EntryCell Label="Cancel Button" Text="{Binding Cancel}" />
+          <EntryCell Label="Max Length" Text="{Binding MaxLength}" Keyboard="Numeric" />
+          <ViewCell>
+            <StackLayout Padding="15">
+              <Label Text="Keyboard Type" />
+              <Picker ItemsSource="{Binding KeyboardTypes}"
+                      ItemDisplayBinding="{Binding ., StringFormat='{0}'}"
+                      SelectedItem="{Binding KeyboardType}" />
+            </StackLayout>
+          </ViewCell>
+        </TableSection>
+      </TableRoot>
+    </TableView>
+    <Button Text="Display Prompt"
+            Command="{Binding ShowPromptCommand}"
+            Grid.Row="1" />
+  </Grid>
+</ContentPage>

--- a/e2e/Forms/src/HelloPageDialog/Views/DisplayPromptDemoPage.xaml.cs
+++ b/e2e/Forms/src/HelloPageDialog/Views/DisplayPromptDemoPage.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace HelloPageDialog.Views
+{
+    public partial class DisplayPromptDemoPage : ContentPage
+    {
+        public DisplayPromptDemoPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/e2e/Forms/src/HelloPageDialog/Views/PageDialogTabs.cs
+++ b/e2e/Forms/src/HelloPageDialog/Views/PageDialogTabs.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace HelloPageDialog.Views
+{
+    public class PageDialogTabs : TabbedPage
+    {
+        public PageDialogTabs()
+        {
+            SetBinding(TitleProperty, new Binding("CurrentPage.Title", source: this));
+        }
+    }
+}

--- a/e2e/Forms/src/HelloWorld/App.xaml.cs
+++ b/e2e/Forms/src/HelloWorld/App.xaml.cs
@@ -100,6 +100,24 @@ namespace HelloWorld
             moduleCatalog.AddModule(new ModuleInfo(typeof(HelloRegions.RegionDemoModule)));
         }
 
+        protected override void InitializeModules()
+        {
+            var manager = Container.Resolve<IModuleManager>();
+            manager.LoadModuleCompleted += OnLoadModuleCompleted;
+            base.InitializeModules();
+        }
+
+        private void OnLoadModuleCompleted(object sender, LoadModuleCompletedEventArgs e)
+        {
+            if (!System.Diagnostics.Debugger.IsAttached)
+                return;
+
+            if(e.Error != null || e.ModuleInfo.State != ModuleState.Initialized)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
+        }
+
         protected override void OnStart ()
         {
             // Handle when your app starts

--- a/e2e/Forms/src/HelloWorld/Views/MyMasterDetail.xaml
+++ b/e2e/Forms/src/HelloWorld/Views/MyMasterDetail.xaml
@@ -40,6 +40,8 @@
                       Command="{prism:NavigateTo 'MyNavigationPage/DialogDemoPage'}" />
               <Button Text="Show Dialog"
                       Command="{prism:ShowDialog 'DemoDialog?message=Hello%20From%20Prism%20DialogService!&amp;closeOnBackgroundTapped=true'}" />
+              <Button Text="Page Dialog Demo"
+                      Command="{prism:NavigateTo 'NavigationPage/PageDialogTabs?createTab=AlertDialogDemoPage&amp;createTab=ActionSheetDemoPage&amp;createTab=DisplayPromptDemoPage'}" />
             </controls:SectionGroup>
 
             <controls:SectionGroup Title="Regions">

--- a/src/Forms/Prism.Forms/AppModel/FlowDirection.cs
+++ b/src/Forms/Prism.Forms/AppModel/FlowDirection.cs
@@ -1,0 +1,40 @@
+﻿namespace Prism.AppModel
+{
+    /// <summary>
+    /// Enumerates values that control the layout direction for views. This maps to
+    /// the Xamarin.Forms.FlowDirection.
+    /// </summary>
+    /// <remarks>
+    /// The following contains a few important points from Right-to-Left Localization.
+    /// Developers should consult that document for more information about limitations
+    /// of right-to-left support, and for requirements to implement right-to-left support
+    /// on various target platforms.
+    /// The default value of Xamarin.Forms.FlowDirection for a visual element that has
+    /// no parent is Xamarin.Forms.FlowDirection.LeftToRight, even on platforms where
+    /// Xamarin.Forms.Device.FlowDirection is Xamarin.Forms.FlowDirection.RightToLeft.
+    /// Therefore, developers must deliberately opt in to right-to-left layout. Developers
+    /// can choose right-to-left layout by setting the Xamarin.Forms.VisualElement.FlowDirection
+    /// property of the root element to Xamarin.Forms.FlowDirection.RightToLeft to choose
+    /// right-to-left layout, or to Xamarin.Forms.FlowDirection.MatchParent to match
+    /// the device layout.
+    /// </remarks>
+    public enum FlowDirection
+    {
+        /// <summary>
+        /// Indicates that the view's layout direction will match the parent view's layout
+        /// direction.
+        /// </summary>
+        MatchParent = 0,
+
+        /// <summary>
+        /// Indicates that view will be laid out left to right. This is the default when
+        /// the view has no parent.
+        /// </summary>
+        LeftToRight = 1,
+
+        /// <summary>
+        /// Indicates that view will be laid out right to left.
+        /// </summary>
+        RightToLeft = 2,
+    }
+}

--- a/src/Forms/Prism.Forms/AppModel/IKeyboardMapper.cs
+++ b/src/Forms/Prism.Forms/AppModel/IKeyboardMapper.cs
@@ -1,0 +1,17 @@
+﻿using Xamarin.Forms;
+
+namespace Prism.AppModel
+{
+    /// <summary>
+    /// An abstraction to map <see cref="KeyboardType"/> to the <see cref="Keyboard"/>;
+    /// </summary>
+    public interface IKeyboardMapper
+    {
+        /// <summary>
+        /// Maps the <see cref="KeyboardType"/> to a <see cref="Keyboard"/>
+        /// </summary>
+        /// <param name="keyboardType">The Keyboard type.</param>
+        /// <returns>The <see cref="Keyboard"/>.</returns>
+        Keyboard Map(KeyboardType keyboardType);
+    }
+}

--- a/src/Forms/Prism.Forms/AppModel/KeyboardMapper.cs
+++ b/src/Forms/Prism.Forms/AppModel/KeyboardMapper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Prism.AppModel
+{
+    /// <summary>
+    /// The default implementation of the <see cref="IKeyboardMapper"/>.
+    /// </summary>
+    public class KeyboardMapper : IKeyboardMapper
+    {
+        /// <summary>
+        /// Maps the <see cref="KeyboardType"/> to a <see cref="Keyboard"/>
+        /// </summary>
+        /// <param name="keyboardType">The Keyboard type.</param>
+        /// <returns>The <see cref="Keyboard"/>.</returns>
+        public virtual Keyboard Map(KeyboardType keyboardType)
+        {
+            return keyboardType switch
+            {
+                KeyboardType.Chat => Keyboard.Chat,
+                KeyboardType.Default => Keyboard.Default,
+                KeyboardType.Email => Keyboard.Email,
+                KeyboardType.Numeric => Keyboard.Numeric,
+                KeyboardType.Plain => Keyboard.Plain,
+                KeyboardType.Telephone => Keyboard.Telephone,
+                KeyboardType.Text => Keyboard.Text,
+                KeyboardType.Url => Keyboard.Url,
+                _ => throw new NotImplementedException($"The Keyboard Type value {keyboardType} is not supported. Please create and register an implementation of IKeyboardMapper to support this value.")
+            };
+        }
+    }
+}

--- a/src/Forms/Prism.Forms/AppModel/KeyboardType.cs
+++ b/src/Forms/Prism.Forms/AppModel/KeyboardType.cs
@@ -1,0 +1,48 @@
+﻿namespace Prism.AppModel
+{
+    /// <summary>
+    /// Keyboard type
+    /// </summary>
+    public enum KeyboardType
+    {
+        /// <summary>
+        /// Gets an instance of type "ChatKeyboard".
+        /// </summary>
+        Chat,
+
+        /// <summary>
+        /// Gets an instance of type "Keyboard".
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Gets an instance of type "EmailKeyboard".
+        /// </summary>
+        Email,
+
+        /// <summary>
+        /// Gets an instance of type "NumericKeyboard".
+        /// </summary>
+        Numeric,
+
+        /// <summary>
+        /// Returns a new keyboard with None Xamarin.Forms.KeyboardFlags.
+        /// </summary>
+        Plain,
+
+        /// <summary>
+        /// Gets an instance of type "TelephoneKeyboard".
+        /// </summary>
+        Telephone,
+
+        /// <summary>
+        /// Gets an instance of type "TextKeyboard".
+        /// </summary>
+        Text,
+
+        /// <summary>
+        /// Gets an instance of type "UrlKeyboard".
+        /// </summary>
+        Url,
+    }
+}

--- a/src/Forms/Prism.Forms/Navigation/NavigationMode.cs
+++ b/src/Forms/Prism.Forms/Navigation/NavigationMode.cs
@@ -13,15 +13,5 @@
         /// Indicates that a new navigation operation has occured and a new page has been added to the navigation stack.
         /// </summary>
         New,
-        /// <summary>
-        /// Indicates that a forward navigation operation has occured to an existing page.
-        /// </summary>
-        /// <remarks>Not currently supported on Xamarin.Forms</remarks>
-        Forward,
-        /// <summary>
-        /// Indicates that the current page in the navigation stack has been navigated to again, or it's state has been refreshed.
-        /// </summary>
-        /// <remarks>Not currently supported on Xamarin.Forms</remarks>
-        Refresh,
     }
 }

--- a/src/Forms/Prism.Forms/Navigation/Xaml/Navigation.cs
+++ b/src/Forms/Prism.Forms/Navigation/Xaml/Navigation.cs
@@ -83,13 +83,14 @@ namespace Prism.Navigation.Xaml
         {
             if (page == null) throw new ArgumentNullException(nameof(page));
 
+            var container = ContainerLocator.Container;
             var navService = (INavigationService)page.GetValue(NavigationServiceProperty);
             if (navService is null)
             {
-                var currentScope = (IScopedProvider)page.GetValue(NavigationScopeProperty) ?? ContainerLocator.Container.CurrentScope;
+                var currentScope = (IScopedProvider)page.GetValue(NavigationScopeProperty) ?? container.CurrentScope;
 
                 if (currentScope is null)
-                    currentScope = ContainerLocator.Container.CreateScope();
+                    currentScope = container.CreateScope();
 
                 if (!currentScope.IsAttached)
                     page.SetValue(NavigationScopeProperty, currentScope);
@@ -103,6 +104,13 @@ namespace Prism.Navigation.Xaml
                 }
 
                 page.SetValue(NavigationServiceProperty, navService);
+            }
+            else if(navService is IPageAware pa && pa.Page != page)
+            {
+                var scope = container.CreateScope();
+                page.SetValue(NavigationScopeProperty, scope);
+                page.SetValue(NavigationServiceProperty, null);
+                return GetNavigationService(page);
             }
 
             return navService;

--- a/src/Forms/Prism.Forms/PrismApplicationBase.cs
+++ b/src/Forms/Prism.Forms/PrismApplicationBase.cs
@@ -171,6 +171,7 @@ namespace Prism
             containerRegistry.RegisterSingleton<IApplicationProvider, ApplicationProvider>();
             containerRegistry.RegisterSingleton<IApplicationStore, ApplicationStore>();
             containerRegistry.RegisterSingleton<IEventAggregator, EventAggregator>();
+            containerRegistry.RegisterSingleton<IKeyboardMapper, KeyboardMapper>();
             containerRegistry.RegisterSingleton<IPageDialogService, PageDialogService>();
             containerRegistry.RegisterSingleton<IDialogService, DialogService>();
             containerRegistry.RegisterSingleton<IDeviceService, DeviceService>();

--- a/src/Forms/Prism.Forms/Services/DeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/DeviceService.cs
@@ -44,31 +44,18 @@ namespace Prism.Services
         /// <summary>
         /// Gets the Platform (OS) that the application is running on. The result is an enum of type RuntimePlatform.
         /// </summary>
-        public RuntimePlatform RuntimePlatform
-        {
-            get
+        public RuntimePlatform RuntimePlatform =>
+            Device.RuntimePlatform switch
             {
-                switch (Device.RuntimePlatform)
-                {
-                    case Android:
-                        return RuntimePlatform.Android;
-                    case GTK:
-                        return RuntimePlatform.GTK;
-                    case iOS:
-                        return RuntimePlatform.iOS;
-                    case macOS:
-                        return RuntimePlatform.macOS;
-                    case Tizen:
-                        return RuntimePlatform.Tizen;
-                    case UWP:
-                        return RuntimePlatform.UWP;
-                    case WPF:
-                        return RuntimePlatform.WPF;
-                    default:
-                        return RuntimePlatform.Unknown;
-                }
-            }
-        }
+                Android => RuntimePlatform.Android,
+                GTK => RuntimePlatform.GTK,
+                iOS => RuntimePlatform.iOS,
+                macOS => RuntimePlatform.macOS,
+                Tizen => RuntimePlatform.Tizen,
+                UWP => RuntimePlatform.UWP,
+                WPF => RuntimePlatform.WPF,
+                _ => RuntimePlatform.Unknown,
+            };
 
         /// <summary>
         /// Invokes an action on the device main UI thread.
@@ -143,9 +130,9 @@ namespace Prism.Services
         /// Sets the flow direction on the device.
         /// </summary>
         /// <param name="flowDirection">The new flow direction value to set.</param>
-        public void SetFlowDirection(Xamarin.Forms.FlowDirection flowDirection)
+        public void SetFlowDirection(FlowDirection flowDirection)
         {
-            Device.SetFlowDirection(flowDirection);
+            Device.SetFlowDirection((Xamarin.Forms.FlowDirection)flowDirection);
         }
 
         /// <summary>

--- a/src/Forms/Prism.Forms/Services/DeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/DeviceService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Prism.AppModel;
 using Xamarin.Forms;
+using FlowDirection = Prism.AppModel.FlowDirection;
 
 namespace Prism.Services
 {
@@ -20,7 +21,6 @@ namespace Prism.Services
         public const string UWP = "UWP";
         public const string WPF = "WPF";
 
-
         /// <summary>
         /// Gets a list of custom flags that were set on the device before Xamarin.Forms was initialized.
         /// </summary>
@@ -29,7 +29,7 @@ namespace Prism.Services
         /// <summary>
         /// Gets the flow direction on the device.
         /// </summary>
-        public FlowDirection FlowDirection => Device.FlowDirection;
+        public FlowDirection FlowDirection => (FlowDirection)Device.FlowDirection;
 
         /// <summary>
         /// Gets the kind of device that Xamarin.Forms is currently working on.
@@ -143,7 +143,7 @@ namespace Prism.Services
         /// Sets the flow direction on the device.
         /// </summary>
         /// <param name="flowDirection">The new flow direction value to set.</param>
-        public void SetFlowDirection(FlowDirection flowDirection)
+        public void SetFlowDirection(Xamarin.Forms.FlowDirection flowDirection)
         {
             Device.SetFlowDirection(flowDirection);
         }

--- a/src/Forms/Prism.Forms/Services/IDeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/IDeviceService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Prism.AppModel;
 using Xamarin.Forms;
+using FlowDirection = Prism.AppModel.FlowDirection;
 
 namespace Prism.Services
 {
@@ -89,7 +90,7 @@ namespace Prism.Services
         /// Sets the flow direction on the device.
         /// </summary>
         /// <param name="flowDirection">The new flow direction value to set.</param>
-        void SetFlowDirection(FlowDirection flowDirection);
+        void SetFlowDirection(Xamarin.Forms.FlowDirection flowDirection);
 
         /// <summary>
         /// Starts a recurring timer using the Device clock capabilities.

--- a/src/Forms/Prism.Forms/Services/IDeviceService.cs
+++ b/src/Forms/Prism.Forms/Services/IDeviceService.cs
@@ -90,7 +90,7 @@ namespace Prism.Services
         /// Sets the flow direction on the device.
         /// </summary>
         /// <param name="flowDirection">The new flow direction value to set.</param>
-        void SetFlowDirection(Xamarin.Forms.FlowDirection flowDirection);
+        void SetFlowDirection(FlowDirection flowDirection);
 
         /// <summary>
         /// Starts a recurring timer using the Device clock capabilities.

--- a/src/Forms/Prism.Forms/Services/PageDialogService/IPageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/IPageDialogService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Prism.AppModel;
 
 namespace Prism.Services
 {
@@ -21,6 +22,20 @@ namespace Prism.Services
         Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton);
 
         /// <summary>
+        /// Presents an alert dialog to the application user with an accept and a cancel button.
+        /// </summary>
+        /// <para>
+        /// The <paramref name="message"/> can be empty.
+        /// </para>
+        /// <param name="title">Title to display.</param>
+        /// <param name="message">Message to display.</param>
+        /// <param name="acceptButton">Text for the accept button.</param>
+        /// <param name="cancelButton">Text for the cancel button.</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
+        Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection);
+
+        /// <summary>
         /// Presents an alert dialog to the application user with a single cancel button.
         /// </summary>
         /// <para>
@@ -31,6 +46,19 @@ namespace Prism.Services
         /// <param name="cancelButton">Text for the cancel button.</param>
         /// <returns></returns>
         Task DisplayAlertAsync(string title, string message, string cancelButton);
+
+        /// <summary>
+        /// Presents an alert dialog to the application user with a single cancel button.
+        /// </summary>
+        /// <para>
+        /// The <paramref name="message"/> can be empty.
+        /// </para>
+        /// <param name="title">Title to display.</param>
+        /// <param name="message">Message to display.</param>
+        /// <param name="cancelButton">Text for the cancel button.</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <returns></returns>
+        Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection);
 
         /// <summary>
         /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
@@ -45,6 +73,17 @@ namespace Prism.Services
         /// <summary>
         /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
         /// </summary>
+        /// <param name="title">Title to display in view.</param>
+        /// <param name="cancelButton">Text for the cancel button.</param>
+        /// <param name="destroyButton">Text for the ok button.</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <param name="otherButtons">Text for other buttons.</param>
+        /// <returns>Text for the pressed button</returns>
+        Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons);
+
+        /// <summary>
+        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// </summary>
         /// <para>
         /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
         /// the callback action will be executed.
@@ -55,6 +94,19 @@ namespace Prism.Services
         Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons);
 
         /// <summary>
+        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// </summary>
+        /// <para>
+        /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
+        /// the callback action will be executed.
+        /// </para>
+        /// <param name="title">Text to display in action sheet</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <param name="buttons">Buttons displayed in action sheet</param>
+        /// <returns></returns>
+        Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons);
+
+        /// <summary>
         /// Displays a native platform promt, allowing the application user to enter a string.
         /// </summary>
         /// <param name="title">Title to display</param>
@@ -63,9 +115,9 @@ namespace Prism.Services
         /// <param name="cancel">Text for the cancel button</param>
         /// <param name="placeholder">Placeholder text to display in the prompt</param>
         /// <param name="maxLength">Maximum length of the user response</param>
-        /// <param name="keyboard">Keyboard type to use for the user response</param>
+        /// <param name="keyboardType">Keyboard type to use for the user response</param>
         /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
         /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
-        Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, Xamarin.Forms.Keyboard keyboard = default, string initialValue = "");
+        Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, KeyboardType keyboardType = KeyboardType.Default, string initialValue = "");
     }
 }

--- a/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -1,21 +1,36 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Prism.AppModel;
 using Prism.Common;
-using Xamarin.Forms;
+using XFFlow = Xamarin.Forms.FlowDirection;
 
 namespace Prism.Services
 {
     /// <summary>
-    /// 
+    /// Implementation of the <see cref="IPageDialogService"/>
     /// </summary>
     public class PageDialogService : IPageDialogService
     {
-        IApplicationProvider _applicationProvider;
+        /// <summary>
+        /// Gets the <see cref="IApplicationProvider"/>.
+        /// </summary>
+        protected IApplicationProvider _applicationProvider { get; }
 
-        public PageDialogService(IApplicationProvider applicationProvider)
+        /// <summary>
+        /// Gets the <see cref="IKeyboardMapper"/>.
+        /// </summary>
+        protected IKeyboardMapper _keyboardMapper { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="IPageDialogService"/>
+        /// </summary>
+        /// <param name="applicationProvider">The <see cref="IApplicationProvider"/>.</param>
+        /// <param name="keyboardMapper">The <see cref="IKeyboardMapper"/>.</param>
+        public PageDialogService(IApplicationProvider applicationProvider, IKeyboardMapper keyboardMapper)
         {
             _applicationProvider = applicationProvider;
+            _keyboardMapper = keyboardMapper;
         }
 
         /// <summary>
@@ -31,7 +46,24 @@ namespace Prism.Services
         /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
         public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton)
         {
-            return _applicationProvider.MainPage.DisplayAlert(title, message, acceptButton, cancelButton);
+            return DisplayAlertAsync(title, message, acceptButton, cancelButton, FlowDirection.MatchParent);
+        }
+
+        /// <summary>
+        /// Presents an alert dialog to the application user with an accept and a cancel button.
+        /// </summary>
+        /// <para>
+        /// The <paramref name="message"/> can be empty.
+        /// </para>
+        /// <param name="title">Title to display.</param>
+        /// <param name="message">Message to display.</param>
+        /// <param name="acceptButton">Text for the accept button.</param>
+        /// <param name="cancelButton">Text for the cancel button.</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
+        public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection)
+        {
+            return _applicationProvider.MainPage.DisplayAlert(title, message, acceptButton, cancelButton, (XFFlow)flowDirection);
         }
 
         /// <summary>
@@ -50,6 +82,22 @@ namespace Prism.Services
         }
 
         /// <summary>
+        /// Presents an alert dialog to the application user with a single cancel button.
+        /// </summary>
+        /// <para>
+        /// The <paramref name="message"/> can be empty.
+        /// </para>
+        /// <param name="title">Title to display.</param>
+        /// <param name="message">Message to display.</param>
+        /// <param name="cancelButton">Text for the cancel button.</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <returns></returns>
+        public virtual Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection)
+        {
+            return _applicationProvider.MainPage.DisplayAlert(title, message, cancelButton, (XFFlow)flowDirection);
+        }
+
+        /// <summary>
         /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
         /// </summary>
         /// <param name="title">Title to display in view.</param>
@@ -59,7 +107,21 @@ namespace Prism.Services
         /// <returns>Text for the pressed button</returns>
         public virtual Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons)
         {
-            return GetCurrentPage().DisplayActionSheet(title, cancelButton, destroyButton, otherButtons);
+            return DisplayActionSheetAsync(title, cancelButton, destroyButton, FlowDirection.MatchParent, otherButtons);
+        }
+
+        /// <summary>
+        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// </summary>
+        /// <param name="title">Title to display in view.</param>
+        /// <param name="cancelButton">Text for the cancel button.</param>
+        /// <param name="destroyButton">Text for the ok button.</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <param name="otherButtons">Text for other buttons.</param>
+        /// <returns>Text for the pressed button</returns>
+        public virtual Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons)
+        {
+            return _applicationProvider.MainPage.DisplayActionSheet(title, cancelButton, destroyButton, (XFFlow)flowDirection, otherButtons);
         }
 
         /// <summary>
@@ -74,6 +136,22 @@ namespace Prism.Services
         /// <returns></returns>
         public virtual async Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons)
         {
+            await DisplayActionSheetAsync(title, FlowDirection.MatchParent, buttons);
+        }
+
+        /// <summary>
+        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// </summary>
+        /// <para>
+        /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
+        /// the callback action will be executed.
+        /// </para>
+        /// <param name="title">Text to display in action sheet</param>
+        /// <param name="flowDirection">The Text flow direction.</param>
+        /// <param name="buttons">Buttons displayed in action sheet</param>
+        /// <returns></returns>
+        public virtual async Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons)
+        {
             if (buttons == null || buttons.All(b => b == null))
                 throw new ArgumentException("At least one button needs to be supplied", nameof(buttons));
 
@@ -81,7 +159,7 @@ namespace Prism.Services
             var cancelButton = buttons.FirstOrDefault(button => button != null && button.IsCancel);
             var otherButtonsText = buttons.Where(button => button != null && !(button.IsDestroy || button.IsCancel)).Select(b => b.Text).ToArray();
 
-            var pressedButton = await DisplayActionSheetAsync(title, cancelButton?.Text, destroyButton?.Text, otherButtonsText);
+            var pressedButton = await DisplayActionSheetAsync(title, cancelButton?.Text, destroyButton?.Text, flowDirection, otherButtonsText);
 
             foreach (var button in buttons.Where(button => button != null && button.Text.Equals(pressedButton)))
             {
@@ -99,26 +177,13 @@ namespace Prism.Services
         /// <param name="cancel">Text for the cancel button</param>
         /// <param name="placeholder">Placeholder text to display in the prompt</param>
         /// <param name="maxLength">Maximum length of the user response</param>
-        /// <param name="keyboard">Keyboard type to use for the user response</param>
+        /// <param name="keyboardType">Keyboard type to use for the user response</param>
         /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
         /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
-        public virtual Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, Xamarin.Forms.Keyboard keyboard = default, string initialValue = "")
+        public virtual Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, KeyboardType keyboardType = KeyboardType.Default, string initialValue = "")
         {
+            var keyboard = _keyboardMapper.Map(keyboardType);
             return _applicationProvider.MainPage.DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);
-        }
-
-        private Page GetCurrentPage()
-        {
-            Page page;
-            if (_applicationProvider.MainPage.Navigation.ModalStack.Count > 0)
-                page = _applicationProvider.MainPage.Navigation.ModalStack.LastOrDefault();
-            else
-                page = _applicationProvider.MainPage.Navigation.NavigationStack.LastOrDefault();
-
-            if (page == null)
-                page = _applicationProvider.MainPage;
-
-            return page;
         }
     }
 }

--- a/tests/Forms/Prism.Forms.Tests/Mocks/PageDialogServiceMock.cs
+++ b/tests/Forms/Prism.Forms.Tests/Mocks/PageDialogServiceMock.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using Prism.AppModel;
 using Prism.Common;
@@ -28,8 +29,12 @@ namespace Prism.Forms.Tests.Mocks
             this.pressedButton = pressedButton;
         }
 
-        public override Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons)
+        public override Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons)
         {
+            foreach (var button in buttons.Where(button => button != null && button.Text.Equals(pressedButton)))
+            {
+                button.PressButton();
+            }
             return Task.FromResult(pressedButton);
         }
     }

--- a/tests/Forms/Prism.Forms.Tests/Mocks/PageDialogServiceMock.cs
+++ b/tests/Forms/Prism.Forms.Tests/Mocks/PageDialogServiceMock.cs
@@ -1,4 +1,6 @@
 ﻿using System.Threading.Tasks;
+using Moq;
+using Prism.AppModel;
 using Prism.Common;
 using Prism.Services;
 
@@ -6,6 +8,14 @@ namespace Prism.Forms.Tests.Mocks
 {
     public class PageDialogServiceMock : PageDialogService
     {
+        private static IKeyboardMapper KeyboardMapper()
+        {
+            var mock = new Mock<IKeyboardMapper>();
+            mock.Setup(x => x.Map(It.IsAny<KeyboardType>()))
+                .Returns(() => Xamarin.Forms.Keyboard.Default);
+            return mock.Object;
+        }
+
         private readonly string pressedButton;
 
         /// <summary>
@@ -13,7 +23,7 @@ namespace Prism.Forms.Tests.Mocks
         /// </summary>
         /// <param name="pressedButton"></param>
         public PageDialogServiceMock(string pressedButton, IApplicationProvider applicationProvider)
-            : base(applicationProvider)
+            : base(applicationProvider, KeyboardMapper())
         {
             this.pressedButton = pressedButton;
         }

--- a/tests/Forms/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
+++ b/tests/Forms/Prism.Forms.Tests/Services/PageDialogServiceFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Prism.Commands;
 using Prism.Common;
 using Prism.Forms.Tests.Mocks;
 using Prism.Services;
@@ -37,8 +36,8 @@ namespace Prism.Forms.Tests.Services
         public async Task DisplayActionSheetNoButtons_ShouldThrowException()
         {
             var service = new PageDialogServiceMock("cancel", _applicationProvider);
-            var argumentException = await Assert.ThrowsAsync<ArgumentException>(() => service.DisplayActionSheetAsync(null, null));
-            Assert.Equal(typeof(ArgumentException), argumentException.GetType());
+            var argumentException = await Assert.ThrowsAsync<ArgumentNullException>(() => service.DisplayActionSheetAsync(null, null));
+            Assert.Equal(typeof(ArgumentNullException), argumentException.GetType());
         }
 
         [Fact]
@@ -89,9 +88,9 @@ namespace Prism.Forms.Tests.Services
             await DisplayActionSheet_PressButton_UsingGenericAction(null);
         }
 
-        private async Task DisplayActionSheet_PressButton_UsingAction(string text)
+        private async Task DisplayActionSheet_PressButton_UsingAction(string pressedButton)
         {
-            var service = new PageDialogServiceMock(text, _applicationProvider);
+            var service = new PageDialogServiceMock(pressedButton, _applicationProvider);
             bool cancelButtonPressed = false;
             bool destroyButtonPressed = false;
             bool otherButtonPressed = false;
@@ -103,7 +102,7 @@ namespace Prism.Forms.Tests.Services
             };
             await service.DisplayActionSheetAsync(null, btns);
 
-            switch (text)
+            switch (pressedButton)
             {
                 case "other":
                     Assert.True(otherButtonPressed);
@@ -136,9 +135,9 @@ namespace Prism.Forms.Tests.Services
         private void OnButtonPressed(ButtonModel model) =>
             model.ButtonPressed = true;
 
-        private async Task DisplayActionSheet_PressButton_UsingGenericAction(string text)
+        private async Task DisplayActionSheet_PressButton_UsingGenericAction(string pressedButton)
         {
-            var service = new PageDialogServiceMock(text, _applicationProvider);
+            var service = new PageDialogServiceMock(pressedButton, _applicationProvider);
             var cancelButtonModel = new ButtonModel();
             var destroyButtonModel = new ButtonModel();
             var otherButtonModel = new ButtonModel();
@@ -150,7 +149,7 @@ namespace Prism.Forms.Tests.Services
             };
             await service.DisplayActionSheetAsync(null, btns);
 
-            switch (text)
+            switch (pressedButton)
             {
                 case "other":
                     Assert.True(otherButtonModel.ButtonPressed);


### PR DESCRIPTION
﻿## Description of Change

Updates the PageDialogService with additional newer methods that accommodate for the text FlowDirection. Updates the E2E PageDialogService Module to have various pages to explore the Alert, ActionSheet and Prompt API's.

The API's have also been updated to get rid of things in the Xamarin.Forms namespace as we don't want people breaking MVVM with references to UI in their ViewModel. Also addresses bug with TabbedNavigation as this was directly affecting the updated E2E updates.

### Bugs Fixed

- #2316
- #2218, #2295, #2317

### API Changes

List all API changes here (or just put None), example:

Added:

- IKeyboardMapper -> Keyboard Map(KeyboardType)
- KeyboardType enum
- FlowDirection
- Task<bool> IPageDialogService.DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection)
- Task IPageDialogService.DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection)
- Task<string> IPageDialogService.DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons)
- Task IPageDialogService.DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons)

Changed:

- Xamarin.Forms.FlowDirection IDeviceService.FlowDirection -> Prism.AppModel.FlowDirection IDeviceService.FlowDirection
- void IDeviceService.SetFlowDirection(Xamarin.Forms.FlowDirection) -> void IDeviceService.SetFlowDirection(Prism.AppModel.FlowDirection)
- Task<string> IPageDialogService.DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, Xamarin.Forms.Keyboard keyboard = default, string initialValue = "") -> Task<string> IPageDialogService.DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, Xamarin.Forms.Keyboard keyboard = default, string initialValue = "")

Removed:

- NavigationMode.Forward (Was only used by Prism.UWP)
- NavigationMode.Refresh (Was only used by Prism.UWP)

### Behavioral Changes

Fixes incorrect behavior experienced in Tabbed Pages where the children were hard coded or explicitly opted into the ViewModelLocator.AutowireViewModel property. This should now 

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard