### PR TITLE
Fixed a bunch of typos

### DIFF
--- a/src/Forms/Prism.Forms.Regions/Ioc/RegionRegistrationExtensions.cs
+++ b/src/Forms/Prism.Forms.Regions/Ioc/RegionRegistrationExtensions.cs
@@ -27,7 +27,7 @@ namespace Prism.Ioc
                 configureAdapters?.Invoke(regionAdapterMappings);
 
                 regionAdapterMappings.RegisterDefaultMapping<CarouselView, CarouselViewRegionAdapter>();
-                // TODO: CollectionView is buggy with only last View showing dispite multiple Active Views
+                // TODO: CollectionView is buggy with only last View showing despite multiple Active Views
                 // BUG: iOS Crash with CollectionView https://github.com/xamarin/Xamarin.Forms/issues/9970
                 //regionAdapterMappings.RegisterDefaultMapping<CollectionView, CollectionViewRegionAdapter>();
                 regionAdapterMappings.RegisterDefaultMapping<Layout<View>, LayoutViewRegionAdapter>();

--- a/src/Forms/Prism.Forms.Regions/Regions/AllActiveRegion.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/AllActiveRegion.cs
@@ -16,7 +16,7 @@ namespace Prism.Regions
         public override IViewsCollection ActiveViews => Views;
 
         /// <summary>
-        /// Deactive is not valid in this Region. This method will always throw <see cref="InvalidOperationException"/>.
+        /// Deactivate is not valid in this Region. This method will always throw <see cref="InvalidOperationException"/>.
         /// </summary>
         /// <param name="view">The view to deactivate.</param>
         /// <exception cref="InvalidOperationException">Every time this method is called.</exception>

--- a/src/Forms/Prism.Forms.Regions/Regions/Behaviors/DestructibleRegionBehavior.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Behaviors/DestructibleRegionBehavior.cs
@@ -5,7 +5,7 @@ using Prism.Navigation;
 namespace Prism.Regions.Behaviors
 {
     /// <summary>
-    /// Provides a Behavior to Destory the View/ViewModel when the View is removed from the Region's Views
+    /// Provides a Behavior to Destroy the View/ViewModel when the View is removed from the Region's Views
     /// </summary>
     public class DestructibleRegionBehavior : RegionBehavior
     {

--- a/src/Forms/Prism.Forms.Regions/Regions/Behaviors/IRegionBehaviorFactory.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Behaviors/IRegionBehaviorFactory.cs
@@ -27,7 +27,7 @@ namespace Prism.Regions.Behaviors
         bool ContainsKey(string behaviorKey);
 
         /// <summary>
-        /// Creates an instance of the Behaviortype that's registered using the specified key.
+        /// Creates an instance of the BehaviorType that's registered using the specified key.
         /// </summary>
         /// <param name="key">The key that's used to register a behavior type.</param>
         /// <returns>The created behavior. </returns>

--- a/src/Forms/Prism.Forms.Regions/Regions/DefaultRegionManagerAccessor.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/DefaultRegionManagerAccessor.cs
@@ -7,7 +7,7 @@ namespace Prism.Regions
     internal class DefaultRegionManagerAccessor : IRegionManagerAccessor
     {
         /// <summary>
-        /// Notification used by attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notification used by attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>This event uses weak references to the event handler to prevent this static event of keeping the
         /// target element longer than expected.</remarks>

--- a/src/Forms/Prism.Forms.Regions/Regions/IRegion.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/IRegion.cs
@@ -30,7 +30,7 @@ namespace Prism.Regions
         object Context { get; set; }
 
         /// <summary>
-        /// Gets the name of the region that uniequely identifies the region within a <see cref="IRegionManager"/>.
+        /// Gets the name of the region that uniquely identifies the region within a <see cref="IRegionManager"/>.
         /// </summary>
         /// <value>The name of the region.</value>
         string Name { get; set; }
@@ -84,7 +84,7 @@ namespace Prism.Regions
         /// </summary>
         /// <value>The <see cref="IRegionManager"/> where this <see cref="IRegion"/> is registered.</value>
         /// <remarks>This is usually used by implementations of <see cref="IRegionManager"/> and should not be
-        /// used by the developer explicitely.</remarks>
+        /// used by the developer explicitly.</remarks>
         IRegionManager RegionManager { get; set; }
 
         /// <summary>

--- a/src/Forms/Prism.Forms.Regions/Regions/IRegionCollection.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/IRegionCollection.cs
@@ -38,10 +38,10 @@ namespace Prism.Regions
         bool ContainsRegionWithName(string regionName);
 
         /// <summary>
-        /// Adds a region to the regionmanager with the name received as argument.
+        /// Adds a region to the <see cref="RegionManager"/> with the name received as argument.
         /// </summary>
         /// <param name="regionName">The name to be given to the region.</param>
-        /// <param name="region">The region to be added to the regionmanager.</param>
+        /// <param name="region">The region to be added to the <see cref="RegionManager"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="region"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="regionName"/> and <paramref name="region"/>'s name do not match and the <paramref name="region"/> <see cref="IRegion.Name"/> is not <see langword="null"/>.</exception>
         void Add(string regionName, IRegion region);

--- a/src/Forms/Prism.Forms.Regions/Regions/IRegionManagerAccessor.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/IRegionManagerAccessor.cs
@@ -9,7 +9,7 @@ namespace Prism.Regions
     public interface IRegionManagerAccessor
     {
         /// <summary>
-        /// Notification used by attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notification used by attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>This event uses weak references to the event handler to prevent this static event of keeping the
         /// target element longer than expected.</remarks>

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/IJournalAware.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/IJournalAware.cs
@@ -6,7 +6,7 @@
     public interface IJournalAware
     {
         /// <summary>
-        /// Determines if the current obect is going to be added to the navigation journal's backstack.
+        /// Determines if the current object is going to be added to the navigation journal's backstack.
         /// </summary>
         /// <returns>True, add to backstack. False, remove from backstack.</returns>
         bool PersistInHistory();

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
@@ -117,7 +117,7 @@ namespace Prism.Regions.Navigation
         }
 
         /// <summary>
-        /// Returns the set of candidates that may satisfiy this navigation request.
+        /// Returns the set of candidates that may satisfy this navigation request.
         /// </summary>
         /// <param name="region">The region containing items that may satisfy the navigation request.</param>
         /// <param name="candidateNavigationContract">The candidate navigation target as determined by <see cref="GetContractFromNavigationContext"/></param>

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationService.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationService.cs
@@ -214,12 +214,12 @@ namespace Prism.Regions.Navigation
 
                 var view = (VisualElement)_regionNavigationContentLoader.LoadContent(Region, navigationContext);
 
-                // Raise the navigating event just before activing the view.
+                // Raise the navigating event just before activating the view.
                 RaiseNavigating(navigationContext);
 
                 Region.Activate(view);
 
-                // Update the navigation journal before notifying others of navigaton
+                // Update the navigation journal before notifying others of navigation
                 IRegionNavigationJournalEntry journalEntry = _container.Resolve<IRegionNavigationJournalEntry>();
                 journalEntry.Uri = navigationContext.Uri;
                 journalEntry.Parameters = navigationContext.Parameters;

--- a/src/Forms/Prism.Forms.Regions/Regions/Region.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Region.cs
@@ -103,7 +103,7 @@ namespace Prism.Regions
 
         private string _name;
         /// <summary>
-        /// Gets the name of the region that uniequely identifies the region within a <see cref="IRegionManager"/>.
+        /// Gets the name of the region that uniquely identifies the region within a <see cref="IRegionManager"/>.
         /// </summary>
         /// <value>The name of the region.</value>
         public string Name
@@ -154,7 +154,7 @@ namespace Prism.Regions
         /// </summary>
         /// <value>The <see cref="IRegionManager"/> where this <see cref="IRegion"/> is registered.</value>
         /// <remarks>This is usually used by implementations of <see cref="IRegionManager"/> and should not be
-        /// used by the developer explicitely.</remarks>
+        /// used by the developer explicitly.</remarks>
         public IRegionManager RegionManager
         {
             get => _regionManager;

--- a/src/Forms/Prism.Forms.Regions/Regions/RegionCollection.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/RegionCollection.cs
@@ -98,10 +98,10 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Adds a region to the regionmanager with the name received as argument.
+        /// Adds a region to the <see cref="RegionManager"/> with the name received as argument.
         /// </summary>
         /// <param name="regionName">The name to be given to the region.</param>
-        /// <param name="region">The region to be added to the regionmanager.</param>
+        /// <param name="region">The region to be added to the <see cref="RegionManager"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="region"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="regionName"/> and <paramref name="region"/>'s name do not match and the <paramref name="region"/> <see cref="IRegion.Name"/> is not <see langword="null"/>.</exception>
         public void Add(string regionName, IRegion region)

--- a/src/Forms/Prism.Forms.Regions/Regions/RegionContext.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/RegionContext.cs
@@ -26,7 +26,7 @@ namespace Prism.Regions
         /// notify when the value is set for the first time.
         /// </summary>
         /// <param name="view">Any view that hold the RegionContext value. </param>
-        /// <returns>Wrapper around the Regioncontext value. </returns>
+        /// <returns>Wrapper around the <see cref="RegionContext"/> value. </returns>
         public static ObservableObject<object> GetObservableContext(VisualElement view)
         {
             if (view == null)

--- a/src/Forms/Prism.Forms.Regions/Regions/ViewsCollection.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/ViewsCollection.cs
@@ -134,7 +134,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Adds handler to monitor the MetadatItem and adds it to our monitoring list.
+        /// Adds handler to monitor the MetadataItem and adds it to our monitoring list.
         /// </summary>
         /// <param name="itemMetadata"></param>
         /// <param name="isInList"></param>

--- a/src/Forms/Prism.Forms.Regions/Regions/Xaml/RegionManager.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Xaml/RegionManager.cs
@@ -182,7 +182,7 @@ namespace Prism.Regions.Xaml
         }
 
         /// <summary>
-        /// Notification used by attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notification used by attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>This event uses weak references to the event handler to prevent this static event of keeping the
         /// target element longer than expected.</remarks>
@@ -193,7 +193,7 @@ namespace Prism.Regions.Xaml
         }
 
         /// <summary>
-        /// Notifies attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notifies attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>
         /// This method is normally called internally, and there is usually no need to call this from user code.

--- a/src/Forms/Prism.Forms/Behaviors/EventToCommandBehavior.cs
+++ b/src/Forms/Prism.Forms/Behaviors/EventToCommandBehavior.cs
@@ -94,7 +94,7 @@ namespace Prism.Behaviors
         }
 
         /// <summary>
-        /// Name of the event that will be forwared to <see cref="Command" />
+        /// Name of the event that will be forwarded to <see cref="Command" />
         /// </summary>
         /// <remarks>
         /// An event that is invalid for the attached <see cref="View" /> will result in <see cref="ArgumentException" /> thrown.

--- a/src/Forms/Prism.Forms/Ioc/ContainerProvider.cs
+++ b/src/Forms/Prism.Forms/Ioc/ContainerProvider.cs
@@ -28,7 +28,7 @@
     ///     }
     /// }
     /// </code>
-    /// We can then simply use our ValueConveter or other class directly in XAML
+    /// We can then simply use our ValueConverter or other class directly in XAML
     /// <![CDATA[
     /// <ContentPage xmlns:prism="clr-namespace:Prism.Ioc;assembly=Prism.Forms">
     ///     <ContentPage.Resources>

--- a/src/Forms/Prism.Forms/Navigation/INavigationParametersInternal.cs
+++ b/src/Forms/Prism.Forms/Navigation/INavigationParametersInternal.cs
@@ -13,7 +13,7 @@
         void Add(string key, object value);
 
         /// <summary>
-        /// Checks collection for presense of key
+        /// Checks collection for presence of key
         /// </summary>
         /// <param name="key">The key to check in the Collection</param>
         /// <returns><c>true</c> if key exists; else returns <c>false</c>.</returns>

--- a/src/Forms/Prism.Forms/Navigation/INavigationServiceExtensions.cs
+++ b/src/Forms/Prism.Forms/Navigation/INavigationServiceExtensions.cs
@@ -30,7 +30,7 @@ namespace Prism.Navigation
         /// <summary>
         /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
         /// </summary>
-        /// <param name="navigationService">The INavigatinService instance</param>
+        /// <param name="navigationService">The INavigationService instance</param>
         /// <param name="parameters">The navigation parameters</param>
         /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
         /// <remarks>Only works when called from a View within a NavigationPage</remarks>

--- a/src/Forms/Prism.Forms/Navigation/KnownNavigationParameters.cs
+++ b/src/Forms/Prism.Forms/Navigation/KnownNavigationParameters.cs
@@ -8,7 +8,7 @@
         public const string CreateTab = "createTab";
 
         /// <summary>
-        /// Used to select an existing Tab when navigating to a Tabbedpage.
+        /// Used to select an existing Tab when navigating to a TabbedPage.
         /// </summary>
         public const string SelectedTab = "selectedTab";
 

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -374,7 +374,7 @@ namespace Prism.Navigation
         /// Processes the Navigation for the Queued navigation segments
         /// </summary>
         /// <param name="currentPage">The Current <see cref="Page"/> that we are navigating from.</param>
-        /// <param name="segments">The Navigation <see cref="Uri"/> segmenets.</param>
+        /// <param name="segments">The Navigation <see cref="Uri"/> segments.</param>
         /// <param name="parameters">The <see cref="INavigationParameters"/>.</param>
         /// <param name="useModalNavigation"><see cref="Nullable{Boolean}"/> flag if we should force Modal Navigation.</param>
         /// <param name="animated">If <c>true</c>, the navigation will be animated.</param>
@@ -496,7 +496,13 @@ namespace Prism.Navigation
             }
         }
 
+        [Obsolete("Renamed to 'ProcessNavigationForAbsoluteUri'")]
         protected virtual Task ProcessNavigationForAbsoulteUri(Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+        {
+            return ProcessNavigationForAbsoluteUri(segments, parameters, useModalNavigation, animated);
+        }
+        
+        protected virtual Task ProcessNavigationForAbsoluteUri(Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
         {
             return ProcessNavigation(null, segments, parameters, useModalNavigation, animated);
         }
@@ -904,13 +910,13 @@ namespace Prism.Navigation
                 foreach (var tabToCreate in tabsToCreate)
                 {
                     //created tab can be a single view or a view nested in a NavigationPage with the syntax "NavigationPage|ViewToCreate"
-                    var tabSegements = tabToCreate.Split('|');
-                    if (tabSegements.Length > 1)
+                    var tabSegments = tabToCreate.Split('|');
+                    if (tabSegments.Length > 1)
                     {
-                        var navigationPage = CreatePageFromSegment(tabSegements[0]) as NavigationPage;
+                        var navigationPage = CreatePageFromSegment(tabSegments[0]) as NavigationPage;
                         if (navigationPage != null)
                         {
-                            var navigationPageChild = CreatePageFromSegment(tabSegements[1]);
+                            var navigationPageChild = CreatePageFromSegment(tabSegments[1]);
 
                             navigationPage.PushAsync(navigationPageChild);
 

--- a/src/Forms/Prism.Forms/Services/PageDialogService/IPageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/IPageDialogService.cs
@@ -61,7 +61,7 @@ namespace Prism.Services
         Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection);
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <param name="title">Title to display in view.</param>
         /// <param name="cancelButton">Text for the cancel button.</param>
@@ -71,7 +71,7 @@ namespace Prism.Services
         Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons);
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <param name="title">Title to display in view.</param>
         /// <param name="cancelButton">Text for the cancel button.</param>
@@ -82,7 +82,7 @@ namespace Prism.Services
         Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons);
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <para>
         /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
@@ -94,7 +94,7 @@ namespace Prism.Services
         Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons);
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <para>
         /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
@@ -107,7 +107,7 @@ namespace Prism.Services
         Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons);
 
         /// <summary>
-        /// Displays a native platform promt, allowing the application user to enter a string.
+        /// Displays a native platform prompt, allowing the application user to enter a string.
         /// </summary>
         /// <param name="title">Title to display</param>
         /// <param name="message">Message to display</param>

--- a/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -98,7 +98,7 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <param name="title">Title to display in view.</param>
         /// <param name="cancelButton">Text for the cancel button.</param>
@@ -111,7 +111,7 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <param name="title">Title to display in view.</param>
         /// <param name="cancelButton">Text for the cancel button.</param>
@@ -125,7 +125,7 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <para>
         /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
@@ -140,7 +140,7 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from serveral buttons.
+        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
         /// </summary>
         /// <para>
         /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
@@ -169,7 +169,7 @@ namespace Prism.Services
         }
 
         /// <summary>
-        /// Displays a native platform promt, allowing the application user to enter a string.
+        /// Displays a native platform prompt, allowing the application user to enter a string.
         /// </summary>
         /// <param name="title">Title to display</param>
         /// <param name="message">Message to display</param>

--- a/src/Prism.Core/Commands/DelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/DelegateCommand{T}.cs
@@ -116,7 +116,7 @@ namespace Prism.Commands
         /// <summary>
         /// Observes a property that implements INotifyPropertyChanged, and automatically calls DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
         /// </summary>
-        /// <typeparam name="TType">The type of the return value of the method that this delegate encapulates</typeparam>
+        /// <typeparam name="TType">The type of the return value of the method that this delegate encapsulates</typeparam>
         /// <param name="propertyExpression">The property expression. Example: ObservesProperty(() => PropertyName).</param>
         /// <returns>The current instance of DelegateCommand</returns>
         public DelegateCommand<T> ObservesProperty<TType>(Expression<Func<TType>> propertyExpression)

--- a/src/Prism.Core/Commands/PropertyObserver.cs
+++ b/src/Prism.Core/Commands/PropertyObserver.cs
@@ -56,7 +56,7 @@ namespace Prism.Commands
         /// property changed notifications. The given expression must be in this form: "() => Prop.NestedProp.PropToObserve".
         /// </summary>
         /// <param name="propertyExpression">Expression representing property to be observed. Ex.: "() => Prop.NestedProp.PropToObserve".</param>
-        /// <param name="action">Action to be invoked when PropertyChanged event occours.</param>
+        /// <param name="action">Action to be invoked when PropertyChanged event occurs.</param>
         internal static PropertyObserver Observes<T>(Expression<Func<T>> propertyExpression, Action action)
         {
             return new PropertyObserver(propertyExpression.Body, action);

--- a/src/Prism.Core/Common/ParametersBase.cs
+++ b/src/Prism.Core/Common/ParametersBase.cs
@@ -70,7 +70,7 @@ namespace Prism.Common
 
         /// <summary>
         /// Searches Parameter collection and returns value if Collection contains key.
-        /// Otherswise returns null.
+        /// Otherwise returns null.
         /// </summary>
         /// <param name="key">The key for the value to be returned.</param>
         /// <returns>The value of the parameter referenced by the key; otherwise <c>null</c>.</returns>

--- a/src/Prism.Core/Common/ParametersExtensions.cs
+++ b/src/Prism.Core/Common/ParametersExtensions.cs
@@ -80,7 +80,7 @@ namespace Prism.Common
         /// <typeparam name="T">The type of the parameter to return</typeparam>
         /// <param name="parameters">A collection of parameters to search</param>
         /// <param name="key">The key of the parameter to find</param>
-        /// <returns>An IEnumberable{T} of all the values referenced by key</returns>
+        /// <returns>An IEnumerable{T} of all the values referenced by key</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key)
         {
@@ -144,7 +144,7 @@ namespace Prism.Common
         /// <summary>
         /// Checks to see if key exists in parameter collection
         /// </summary>
-        /// <param name="parameters">IEnumberable to search</param>
+        /// <param name="parameters">IEnumerable to search</param>
         /// <param name="key">The key to search the <paramref name="parameters"/> for existence</param>
         /// <returns><c>true</c> if key exists; <c>false</c> otherwise</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Prism.Core/Events/EventAggregator.cs
+++ b/src/Prism.Core/Events/EventAggregator.cs
@@ -13,7 +13,7 @@ namespace Prism.Events
     {
         private readonly Dictionary<Type, EventBase> events = new Dictionary<Type, EventBase>();
         // Captures the sync context for the UI thread when constructed on the UI thread 
-        // in a platform agnositc way so it can be used for UI thread dispatching
+        // in a platform agnostic way so it can be used for UI thread dispatching
         private readonly SynchronizationContext syncContext = SynchronizationContext.Current;
 
         /// <summary>

--- a/src/Prism.Core/Events/SubscriptionToken.cs
+++ b/src/Prism.Core/Events/SubscriptionToken.cs
@@ -5,7 +5,7 @@ namespace Prism.Events
     /// <summary>
     /// Subscription token returned from <see cref="EventBase"/> on subscribe.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Should never have a need for a finalizer, hence no need for Dispole(bool)")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Should never have a need for a finalizer, hence no need for Dispose(bool)")]
     public class SubscriptionToken : IEquatable<SubscriptionToken>, IDisposable
     {
         private readonly Guid _token;

--- a/src/Prism.Core/Extensions/ExceptionExtensions.cs
+++ b/src/Prism.Core/Extensions/ExceptionExtensions.cs
@@ -47,7 +47,7 @@ namespace System
         /// It should not be used to replace the Inner Exception stack of an exception, because this might hide required exception
         /// information. 
         /// </remarks>
-        /// <param name="exception">The exception that will provide the list of inner exeptions to examine.</param>
+        /// <param name="exception">The exception that will provide the list of inner exceptions to examine.</param>
         /// <returns>
         /// The exception that most likely caused the exception to occur. If it can't find the root exception, it will return the 
         /// <paramref name="exception"/> value itself.

--- a/src/Prism.Core/GlobalSuppressions.cs
+++ b/src/Prism.Core/GlobalSuppressions.cs
@@ -1,6 +1,6 @@
 ﻿// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
+// Project-level suppression either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/Prism.Core/Ioc/ContainerResolutionException.cs
+++ b/src/Prism.Core/Ioc/ContainerResolutionException.cs
@@ -24,7 +24,7 @@ namespace Prism.Ioc
         public const string CannotResolveAbstractType = "The Implementing Type is abstract.";
 
         /// <summary>
-        /// The message provided by <see cref="ContainerResolutionException"/> when mulptiple constructors were found in the implementing type
+        /// The message provided by <see cref="ContainerResolutionException"/> when multiple constructors were found in the implementing type
         /// </summary>
         public const string MultipleConstructors = "The Implementing Type has multiple constructors which may not be resolvable";
 
@@ -213,7 +213,7 @@ namespace Prism.Ioc
 
             try
             {
-                // We generally expect some sort of InvokationException Exception here...
+                // We generally expect some sort of InvocationException Exception here...
                 ctor.Invoke(parameterInstances.ToArray());
 
                 // If we managed to create an instance for every parameter and the

--- a/src/Prism.Core/Modularity/ModuleCatalogBase.cs
+++ b/src/Prism.Core/Modularity/ModuleCatalogBase.cs
@@ -188,7 +188,7 @@ namespace Prism.Modularity
         }
 
         /// <summary>
-        /// Checks for cyclic dependencies, by calling the dependencysolver.
+        /// Checks for cyclic dependencies, by calling the dependency solver.
         /// </summary>
         /// <param name="modules">the.</param>
         /// <returns></returns>
@@ -332,7 +332,7 @@ namespace Prism.Modularity
         }
 
         /// <summary>
-        /// Returns the <see cref="IModuleInfo"/> on which the received module dependens on.
+        /// Returns the <see cref="IModuleInfo"/> on which the received module depends on.
         /// </summary>
         /// <param name="moduleInfo">Module whose dependant modules are requested.</param>
         /// <returns>Collection of <see cref="IModuleInfo"/> dependants of <paramref name="moduleInfo"/>.</returns>

--- a/src/Prism.Core/Modularity/ModuleDependencySolver.cs
+++ b/src/Prism.Core/Modularity/ModuleDependencySolver.cs
@@ -72,7 +72,7 @@ namespace Prism.Modularity
         /// </summary>
         /// <returns>The resulting ordered list of modules.</returns>
         /// <exception cref="CyclicDependencyFoundException">This exception is thrown
-        /// when a cycle is found in the defined depedency graph.</exception>
+        /// when a cycle is found in the defined dependency graph.</exception>
         public string[] Solve()
         {
             List<string> skip = new List<string>();

--- a/src/Prism.Core/Modularity/ModuleDownloadProgressChangedEventArgs.cs
+++ b/src/Prism.Core/Modularity/ModuleDownloadProgressChangedEventArgs.cs
@@ -23,7 +23,7 @@ namespace Prism.Modularity
         }
 
         /// <summary>
-        /// Getsthe module info.
+        /// Gets the module info.
         /// </summary>
         /// <value>The module info.</value>
         public IModuleInfo ModuleInfo { get; }

--- a/src/Prism.Core/Mvvm/ViewModelLocationProvider.cs
+++ b/src/Prism.Core/Mvvm/ViewModelLocationProvider.cs
@@ -35,7 +35,7 @@ namespace Prism.Mvvm
         static Func<Type, object> _defaultViewModelFactory = type => Activator.CreateInstance(type);
 
         /// <summary>
-        /// ViewModelfactory that provides the View instance and ViewModel type as parameters.
+        /// ViewModelFactory that provides the View instance and ViewModel type as parameters.
         /// </summary>
         static Func<object, Type, object> _defaultViewModelFactoryWithViewParameter;
 

--- a/src/Uno/Prism.Uno/Interactivity/InvokeCommandAction.cs
+++ b/src/Uno/Prism.Uno/Interactivity/InvokeCommandAction.cs
@@ -17,14 +17,14 @@ namespace Prism.Interactivity
         private ExecutableCommandBehavior _commandBehavior;
 
         /// <summary>
-        /// Dependency property identifying if the associated element should automaticlaly be enabled or disabled based on the result of the Command's CanExecute
+        /// Dependency property identifying if the associated element should automatically be enabled or disabled based on the result of the Command's CanExecute
         /// </summary>
         public static readonly DependencyProperty AutoEnableProperty =
             DependencyProperty.Register("AutoEnable", typeof(bool), typeof(InvokeCommandAction),
                 new PropertyMetadata(true));
 
         /// <summary>
-        /// Gets or sets whther or not the associated element will automatically be enabled or disabled based on the result of the commands CanExecute
+        /// Gets or sets whether or not the associated element will automatically be enabled or disabled based on the result of the commands CanExecute
         /// </summary>
         public bool AutoEnable
         {

--- a/src/Uno/Prism.Uno/PrismApplicationBase.cs
+++ b/src/Uno/Prism.Uno/PrismApplicationBase.cs
@@ -77,8 +77,8 @@ namespace Prism
 
             ConfigureModuleCatalog(_moduleCatalog);
 
-            var regionAdapterMappins = _containerExtension.Resolve<RegionAdapterMappings>();
-            ConfigureRegionAdapterMappings(regionAdapterMappins);
+            var regionAdapterMappings = _containerExtension.Resolve<RegionAdapterMappings>();
+            ConfigureRegionAdapterMappings(regionAdapterMappings);
 
             var defaultRegionBehaviors = _containerExtension.Resolve<IRegionBehaviorFactory>();
             ConfigureDefaultRegionBehaviors(defaultRegionBehaviors);

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -58,7 +58,7 @@ namespace Prism.Common
         /// </summary>
         /// <remarks>
         /// If the view implements <typeparamref name="T"/> it will be returned.
-        /// Otherwise if the view's datacontext implements <typeparamref name="T"/> it will be returned instead.
+        /// Otherwise if the view's <see cref="FrameworkElement.DataContext"/> implements <typeparamref name="T"/> it will be returned instead.
         /// </remarks>
         /// <typeparam name="T">The implementer type to get.</typeparam>
         /// <param name="view">The view to get <typeparamref name="T"/> from.</param>

--- a/src/Wpf/Prism.Wpf/Interactivity/InvokeCommandAction.cs
+++ b/src/Wpf/Prism.Wpf/Interactivity/InvokeCommandAction.cs
@@ -14,14 +14,14 @@ namespace Prism.Interactivity
         private ExecutableCommandBehavior _commandBehavior;
 
         /// <summary>
-        /// Dependency property identifying if the associated element should automaticlaly be enabled or disabled based on the result of the Command's CanExecute
+        /// Dependency property identifying if the associated element should automatically be enabled or disabled based on the result of the Command's CanExecute
         /// </summary>
         public static readonly DependencyProperty AutoEnableProperty =
             DependencyProperty.Register("AutoEnable", typeof(bool), typeof(InvokeCommandAction),
                 new PropertyMetadata(true, (d, e) => ((InvokeCommandAction)d).OnAllowDisableChanged((bool)e.NewValue)));
 
         /// <summary>
-        /// Gets or sets whther or not the associated element will automatically be enabled or disabled based on the result of the commands CanExecute
+        /// Gets or sets whether or not the associated element will automatically be enabled or disabled based on the result of the commands CanExecute
         /// </summary>
         public bool AutoEnable
         {

--- a/src/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
@@ -57,7 +57,7 @@ namespace Prism.Ioc
         /// </summary>
         /// <param name="containerRegistry"></param>
         /// <param name="type">The type of object to register</param>
-        /// <param name="name">The unique name to register with the obect.</param>
+        /// <param name="name">The unique name to register with the object.</param>
         public static void RegisterForNavigation(this IContainerRegistry containerRegistry, Type type, string name)
         {
             containerRegistry.Register(typeof(object), type, name);

--- a/src/Wpf/Prism.Wpf/Modularity/AssemblyResolver.Desktop.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/AssemblyResolver.Desktop.cs
@@ -22,7 +22,7 @@ namespace Prism.Modularity
         /// <summary>
         /// Registers the specified assembly and resolves the types in it when the AppDomain requests for it.
         /// </summary>
-        /// <param name="assemblyFilePath">The path to the assemly to load in the LoadFrom context.</param>
+        /// <param name="assemblyFilePath">The path to the assembly to load in the LoadFrom context.</param>
         /// <remarks>This method does not load the assembly immediately, but lazily until someone requests a <see cref="Type"/>
         /// declared in the assembly.</remarks>
         public void LoadAssemblyFrom(string assemblyFilePath)

--- a/src/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.netcore.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/DirectoryModuleCatalog.netcore.cs
@@ -10,7 +10,7 @@ using Prism.Properties;
 namespace Prism.Modularity
 {
     /// <summary>
-    /// Represets a catalog created from a directory on disk.
+    /// Represents a catalog created from a directory on disk.
     /// </summary>
     /// <remarks>
     /// The directory catalog will scan the contents of a directory, locating classes that implement
@@ -18,7 +18,7 @@ namespace Prism.Modularity
     /// Assemblies are loaded into a new application domain with ReflectionOnlyLoad.  The application domain is destroyed
     /// once the assemblies have been discovered.
     ///
-    /// The diretory catalog does not continue to monitor the directory after it has created the initialze catalog.
+    /// The directory catalog does not continue to monitor the directory after it has created the initialize catalog.
     /// </remarks>
     public class DirectoryModuleCatalog : ModuleCatalog
     {

--- a/src/Wpf/Prism.Wpf/Modularity/ModuleAttribute.Desktop.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/ModuleAttribute.Desktop.cs
@@ -21,7 +21,7 @@ namespace Prism.Modularity
         /// Gets or sets the value indicating whether the module should be loaded OnDemand.
         /// </summary>
         /// When <see langword="false"/> (default value), it indicates the module should be loaded as soon as it's dependencies are satisfied.
-        /// Otherwise you should explicitily load this module via the <see cref="ModuleManager"/>.
+        /// Otherwise you should explicitly load this module via the <see cref="ModuleManager"/>.
         public bool OnDemand { get; set; }
     }
 }

--- a/src/Wpf/Prism.Wpf/Modularity/ModuleDependencyConfigurationElement.Desktop.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/ModuleDependencyConfigurationElement.Desktop.cs
@@ -26,9 +26,9 @@ namespace Prism.Modularity
         }
 
         /// <summary>
-        /// Gets or sets the name of a module antoher module depends on.
+        /// Gets or sets the name of a module another module depends on.
         /// </summary>
-        /// <value>The name of a module antoher module depends on.</value>
+        /// <value>The name of a module another module depends on.</value>
         [ConfigurationProperty("moduleName", IsRequired = true, IsKey = true)]
         public string ModuleName
         {

--- a/src/Wpf/Prism.Wpf/Modularity/ModuleInitializer.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/ModuleInitializer.cs
@@ -53,7 +53,7 @@ namespace Prism.Modularity
         /// Handles any exception occurred in the module Initialization process,
         /// This method can be overridden to provide a different behavior.
         /// </summary>
-        /// <param name="moduleInfo">The module metadata where the error happenened.</param>
+        /// <param name="moduleInfo">The module metadata where the error happened.</param>
         /// <param name="assemblyName">The assembly name.</param>
         /// <param name="exception">The exception thrown that is the cause of the current error.</param>
         /// <exception cref="ModuleInitializeException"></exception>

--- a/src/Wpf/Prism.Wpf/Modularity/ModuleManager.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/ModuleManager.cs
@@ -151,7 +151,7 @@ namespace Prism.Modularity
         }
 
         /// <summary>
-        /// Loads the modules that are not intialized and have their dependencies loaded.
+        /// Loads the modules that are not initialized and have their dependencies loaded.
         /// </summary>
         protected virtual void LoadModulesThatAreReadyForLoad()
         {
@@ -180,7 +180,7 @@ namespace Prism.Modularity
             IModuleTypeLoader moduleTypeLoader = this.GetTypeLoaderForModule(moduleInfoToLoadType);
             moduleInfoToLoadType.State = ModuleState.LoadingTypes;
 
-            // Delegate += works differently betweem SL and WPF.
+            // Delegate += works differently between SL and WPF.
             // We only want to subscribe to each instance once.
             if (!this.subscribedToModuleTypeLoaders.Contains(moduleTypeLoader))
             {
@@ -228,7 +228,7 @@ namespace Prism.Modularity
         /// and throws a <see cref="ModuleTypeLoadingException"/>.
         /// This method can be overridden to provide a different behavior.
         /// </summary>
-        /// <param name="moduleInfo">The module metadata where the error happenened.</param>
+        /// <param name="moduleInfo">The module metadata where the error happened.</param>
         /// <param name="exception">The exception thrown that is the cause of the current error.</param>
         /// <exception cref="ModuleTypeLoadingException"></exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "1")]

--- a/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismApplicationBase.cs
@@ -65,8 +65,8 @@ namespace Prism
 
             ConfigureModuleCatalog(_moduleCatalog);
 
-            var regionAdapterMappins = _containerExtension.Resolve<RegionAdapterMappings>();
-            ConfigureRegionAdapterMappings(regionAdapterMappins);
+            var regionAdapterMappings = _containerExtension.Resolve<RegionAdapterMappings>();
+            ConfigureRegionAdapterMappings(regionAdapterMappings);
 
             var defaultRegionBehaviors = _containerExtension.Resolve<IRegionBehaviorFactory>();
             ConfigureDefaultRegionBehaviors(defaultRegionBehaviors);

--- a/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
+++ b/src/Wpf/Prism.Wpf/PrismBootstrapperBase.cs
@@ -62,8 +62,8 @@ namespace Prism
 
             ConfigureModuleCatalog(_moduleCatalog);
 
-            var regionAdapterMappins = _containerExtension.Resolve<RegionAdapterMappings>();
-            ConfigureRegionAdapterMappings(regionAdapterMappins);
+            var regionAdapterMappings = _containerExtension.Resolve<RegionAdapterMappings>();
+            ConfigureRegionAdapterMappings(regionAdapterMappings);
 
             var defaultRegionBehaviors = _containerExtension.Resolve<IRegionBehaviorFactory>();
             ConfigureDefaultRegionBehaviors(defaultRegionBehaviors);

--- a/src/Wpf/Prism.Wpf/Regions/AllActiveRegion.cs
+++ b/src/Wpf/Prism.Wpf/Regions/AllActiveRegion.cs
@@ -15,7 +15,7 @@ namespace Prism.Regions
         public override IViewsCollection ActiveViews => Views;
 
         /// <summary>
-        /// Deactive is not valid in this Region. This method will always throw <see cref="InvalidOperationException"/>.
+        /// Deactivate is not valid in this Region. This method will always throw <see cref="InvalidOperationException"/>.
         /// </summary>
         /// <param name="view">The view to deactivate.</param>
         /// <exception cref="InvalidOperationException">Every time this method is called.</exception>

--- a/src/Wpf/Prism.Wpf/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
@@ -59,7 +59,7 @@ namespace Prism.Regions.Behaviors
         }
 
         /// <summary>
-        /// Starts to monitor the <see cref="IRegion"/> to keep it in synch with the items of the <see cref="HostControl"/>.
+        /// Starts to monitor the <see cref="IRegion"/> to keep it in sync with the items of the <see cref="HostControl"/>.
         /// </summary>
         protected override void OnAttach()
         {

--- a/src/Wpf/Prism.Wpf/Regions/DefaultRegionManagerAccessor.cs
+++ b/src/Wpf/Prism.Wpf/Regions/DefaultRegionManagerAccessor.cs
@@ -1,5 +1,3 @@
-
-
 using System;
 
 #if HAS_WINUI
@@ -13,7 +11,7 @@ namespace Prism.Regions
     internal class DefaultRegionManagerAccessor : IRegionManagerAccessor
     {
         /// <summary>
-        /// Notification used by attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notification used by attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>This event uses weak references to the event handler to prevent this static event of keeping the
         /// target element longer than expected.</remarks>

--- a/src/Wpf/Prism.Wpf/Regions/IJournalAware.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IJournalAware.cs
@@ -6,7 +6,7 @@
     public interface IJournalAware
     {
         /// <summary>
-        /// Determines if the current obect is going to be added to the navigation journal's backstack.
+        /// Determines if the current object is going to be added to the navigation journal's backstack.
         /// </summary>
         /// <returns>True, add to backstack. False, remove from backstack.</returns>
         bool PersistInHistory();

--- a/src/Wpf/Prism.Wpf/Regions/IRegion.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegion.cs
@@ -35,7 +35,7 @@ namespace Prism.Regions
         object Context { get; set; }
 
         /// <summary>
-        /// Gets the name of the region that uniequely identifies the region within a <see cref="IRegionManager"/>.
+        /// Gets the name of the region that uniquely identifies the region within a <see cref="IRegionManager"/>.
         /// </summary>
         /// <value>The name of the region.</value>
         string Name { get; set; }
@@ -106,7 +106,7 @@ namespace Prism.Regions
         /// </summary>
         /// <value>The <see cref="IRegionManager"/> where this <see cref="IRegion"/> is registered.</value>
         /// <remarks>This is usually used by implementations of <see cref="IRegionManager"/> and should not be
-        /// used by the developer explicitely.</remarks>
+        /// used by the developer explicitly.</remarks>
         IRegionManager RegionManager { get; set; }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/Regions/IRegionBehaviorFactory.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionBehaviorFactory.cs
@@ -29,7 +29,7 @@ namespace Prism.Regions
         bool ContainsKey(string behaviorKey);
 
         /// <summary>
-        /// Creates an instance of the Behaviortype that's registered using the specified key.
+        /// Creates an instance of the BehaviorType that's registered using the specified key.
         /// </summary>
         /// <param name="key">The key that's used to register a behavior type.</param>
         /// <returns>The created behavior. </returns>

--- a/src/Wpf/Prism.Wpf/Regions/IRegionBehaviorFactoryExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionBehaviorFactoryExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Prism.Regions
 {
     /// <summary>
-    /// Extention methods for the IRegionBehaviorFactory.
+    /// Extension methods for the IRegionBehaviorFactory.
     /// </summary>
     public static class IRegionBehaviorFactoryExtensions
     {

--- a/src/Wpf/Prism.Wpf/Regions/IRegionCollection.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionCollection.cs
@@ -39,10 +39,10 @@ namespace Prism.Regions
         bool ContainsRegionWithName(string regionName);
 
         /// <summary>
-        /// Adds a region to the regionmanager with the name received as argument.
+        /// Adds a region to the <see cref="RegionManager"/> with the name received as argument.
         /// </summary>
         /// <param name="regionName">The name to be given to the region.</param>
-        /// <param name="region">The region to be added to the regionmanager.</param>        
+        /// <param name="region">The region to be added to the <see cref="RegionManager"/>.</param>        
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="region"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="regionName"/> and <paramref name="region"/>'s name do not match and the <paramref name="region"/> <see cref="IRegion.Name"/> is not <see langword="null"/>.</exception>
         void Add(string regionName, IRegion region);

--- a/src/Wpf/Prism.Wpf/Regions/IRegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionManager.cs
@@ -20,7 +20,7 @@ namespace Prism.Regions
         IRegionManager CreateRegionManager();
 
         /// <summary>
-        ///     Add a view to the Views collection of a Region. Note that the region must already exist in this regionmanager. 
+        ///     Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>. 
         /// </summary>
         /// <param name="regionName">The name of the region to add a view to</param>
         /// <param name="view">The view to add to the views collection</param>
@@ -34,7 +34,7 @@ namespace Prism.Regions
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <param name="viewType">The type of the view to register with the </param>
-        /// <returns>The regionmanager, for adding several views easily</returns>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
         IRegionManager RegisterViewWithRegion(string regionName, Type viewType);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Prism.Regions
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <param name="getContentDelegate">The delegate used to resolve a concrete instance of the view.</param>
-        /// <returns>The regionmanager, for adding several views easily</returns>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
         IRegionManager RegisterViewWithRegion(string regionName, Func<object> getContentDelegate);
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/Regions/IRegionManagerAccessor.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionManagerAccessor.cs
@@ -16,7 +16,7 @@ namespace Prism.Regions
     public interface IRegionManagerAccessor
     {
         /// <summary>
-        /// Notification used by attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notification used by attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>This event uses weak references to the event handler to prevent this static event of keeping the
         /// target element longer than expected.</remarks>

--- a/src/Wpf/Prism.Wpf/Regions/IRegionMemberLifetime.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionMemberLifetime.cs
@@ -5,7 +5,7 @@ namespace Prism.Regions
     /// <summary>
     /// When implemented, allows an instance placed in a <see cref="IRegion"/>
     /// that uses a <see cref="RegionMemberLifetimeBehavior"/> to indicate
-    /// it should be removed when it transitions from an activated to deactived state.
+    /// it should be removed when it transitions from an activated to deactivated state.
     /// </summary>
     public interface IRegionMemberLifetime
     {

--- a/src/Wpf/Prism.Wpf/Regions/Region.cs
+++ b/src/Wpf/Prism.Wpf/Regions/Region.cs
@@ -73,7 +73,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Gets the name of the region that uniequely identifies the region within a <see cref="IRegionManager"/>.
+        /// Gets the name of the region that uniquely identifies the region within a <see cref="IRegionManager"/>.
         /// </summary>
         /// <value>The name of the region.</value>
         public string Name
@@ -173,7 +173,7 @@ namespace Prism.Regions
         /// </summary>
         /// <value>The <see cref="IRegionManager"/> where this <see cref="IRegion"/> is registered.</value>
         /// <remarks>This is usually used by implementations of <see cref="IRegionManager"/> and should not be
-        /// used by the developer explicitely.</remarks>
+        /// used by the developer explicitly.</remarks>
         public IRegionManager RegionManager
         {
             get => _regionManager;

--- a/src/Wpf/Prism.Wpf/Regions/RegionContext.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionContext.cs
@@ -32,7 +32,7 @@ namespace Prism.Regions
         /// notify when the value is set for the first time.
         /// </summary>
         /// <param name="view">Any view that hold the RegionContext value. </param>
-        /// <returns>Wrapper around the Regioncontext value. </returns>
+        /// <returns>Wrapper around the <see cref="RegionContext"/> value. </returns>
         public static ObservableObject<object> GetObservableContext(DependencyObject view)
         {
             if (view == null)

--- a/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -204,7 +204,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Notification used by attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notification used by attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>This event uses weak references to the event handler to prevent this static event of keeping the
         /// target element longer than expected.</remarks>
@@ -215,7 +215,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Notifies attached behaviors to update the region managers appropriatelly if needed to.
+        /// Notifies attached behaviors to update the region managers appropriately if needed to.
         /// </summary>
         /// <remarks>
         /// This method is normally called internally, and there is usually no need to call this from user code.
@@ -276,7 +276,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        ///     Add a view to the Views collection of a Region. Note that the region must already exist in this regionmanager.
+        ///     Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>.
         /// </summary>
         /// <param name="regionName">The name of the region to add a view to</param>
         /// <param name="view">The view to add to the views collection</param>
@@ -296,7 +296,7 @@ namespace Prism.Regions
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <typeparam name="T">The type of the view to register</typeparam>
-        /// <returns>The regionmanager, for adding several views easily</returns>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
         public IRegionManager RegisterViewWithRegion<T>(string regionName)
         {
             return RegisterViewWithRegion(regionName, typeof(T));
@@ -309,7 +309,7 @@ namespace Prism.Regions
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <param name="viewType">The type of the view to register with the </param>
-        /// <returns>The regionmanager, for adding several views easily</returns>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
         public IRegionManager RegisterViewWithRegion(string regionName, Type viewType)
         {
             var regionViewRegistry = ContainerLocator.Container.Resolve<IRegionViewRegistry>();
@@ -326,7 +326,7 @@ namespace Prism.Regions
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <param name="getContentDelegate">The delegate used to resolve a concrete instance of the view.</param>
-        /// <returns>The regionmanager, for adding several views easily</returns>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
         public IRegionManager RegisterViewWithRegion(string regionName, Func<object> getContentDelegate)
         {
             var regionViewRegistry = ContainerLocator.Container.Resolve<IRegionViewRegistry>();
@@ -539,10 +539,10 @@ namespace Prism.Regions
             }
 
             /// <summary>
-            /// Adds a region to the regionmanager with the name received as argument.
+            /// Adds a region to the <see cref="RegionManager"/> with the name received as argument.
             /// </summary>
             /// <param name="regionName">The name to be given to the region.</param>
-            /// <param name="region">The region to be added to the regionmanager.</param>
+            /// <param name="region">The region to be added to the <see cref="RegionManager"/>.</param>
             /// <exception cref="ArgumentNullException">Thrown if <paramref name="region"/> is <see langword="null"/>.</exception>
             /// <exception cref="ArgumentException">Thrown if <paramref name="regionName"/> and <paramref name="region"/>'s name do not match and the <paramref name="region"/> <see cref="IRegion.Name"/> is not <see langword="null"/>.</exception>
             public void Add(string regionName, IRegion region)

--- a/src/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
@@ -138,7 +138,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Returns the set of candidates that may satisfiy this navigation request.
+        /// Returns the set of candidates that may satisfy this navigation request.
         /// </summary>
         /// <param name="region">The region containing items that may satisfy the navigation request.</param>
         /// <param name="candidateNavigationContract">The candidate navigation target as determined by <see cref="GetContractFromNavigationContext"/></param>

--- a/src/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionNavigationService.cs
@@ -224,12 +224,12 @@ namespace Prism.Regions
 
                 object view = _regionNavigationContentLoader.LoadContent(Region, navigationContext);
 
-                // Raise the navigating event just before activing the view.
+                // Raise the navigating event just before activating the view.
                 RaiseNavigating(navigationContext);
 
                 Region.Activate(view);
 
-                // Update the navigation journal before notifying others of navigaton
+                // Update the navigation journal before notifying others of navigation
                 IRegionNavigationJournalEntry journalEntry = _container.Resolve<IRegionNavigationJournalEntry>();
                 journalEntry.Uri = navigationContext.Uri;
                 journalEntry.Parameters = navigationContext.Parameters;

--- a/src/Wpf/Prism.Wpf/Regions/ViewsCollection.cs
+++ b/src/Wpf/Prism.Wpf/Regions/ViewsCollection.cs
@@ -143,7 +143,7 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Adds handler to monitor the MetadatItem and adds it to our monitoring list.
+        /// Adds handler to monitor the MetadataItem and adds it to our monitoring list.
         /// </summary>
         /// <param name="itemMetadata"></param>
         /// <param name="isInList"></param>


### PR DESCRIPTION
﻿## Description of Change

This PR fixes a bunch of grammar typos.

### API Changes

- `src/Forms/Prism.Forms/Navigation/PageNavigationService`

`ProcessNavigationForAbsoulteUri` was renamed to `ProcessNavigationForAbsoluteUri`
`ProcessNavigationForAbsoulteUri` was marked obsolete.


### Behavioral Changes

`Forms` user will have to refactor the 1 method that had a typo in the name

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard