### PR TITLE
Handle Android Hardware GoBack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ bld/
 
 # Visual Studio cache/options directory
 .vs/
-.vscode/
 .droidres/
 
 # DNX

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csharp",
+    "ms-azure-devops.azure-pipelines",
+    "ms-vscode.powershell",
+    "editorconfig.editorconfig",
+    "shd101wyy.markdown-preview-enhanced",
+    "streetsidesoftware.code-spell-checker",
+    "clancey.comet-debug"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "[azure-pipelines]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": false,
+      "strings": true
+    },
+    "editor.autoIndent": "full"
+  },
+  "files.associations": {
+    "**/*.yml": "azure-pipelines"
+  }
+}

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -98,35 +98,35 @@ stages:
   jobs:
   - template: jobs/prism-lib.yml
 
-- stage: appCenter
-  displayName: E2E Deploy
-  jobs:
-  - deployment: E2EAndroidDeploy
-    displayName: 'E2E Android - App Center'
-    environment: 'App Center'
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-            - template: steps/appcenter-deploy.yml
-              parameters:
-                appName: $(AppCenterDroidAppName)
-                appFile: '$(Pipeline.Workspace)/E2E-Android/com.prismlibrary.helloworld.apk'
-                distributionGroup: '88fd9e93-9e2e-4a44-bda4-e7d6bf8f7a10'
+# - stage: appCenter
+#   displayName: E2E Deploy
+#   jobs:
+#   - deployment: E2EAndroidDeploy
+#     displayName: 'E2E Android - App Center'
+#     environment: 'App Center'
+#     strategy:
+#       runOnce:
+#         deploy:
+#           steps:
+#             - template: steps/appcenter-deploy.yml
+#               parameters:
+#                 appName: $(AppCenterDroidAppName)
+#                 appFile: '$(Pipeline.Workspace)/E2E-Android/com.prismlibrary.helloworld.apk'
+#                 distributionGroup: '88fd9e93-9e2e-4a44-bda4-e7d6bf8f7a10'
 
-  - deployment: E2EiOSDeploy
-    displayName: 'E2E iOS - App Center'
-    environment: 'App Center'
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-            - template: steps/appcenter-deploy.yml
-              parameters:
-                appName: 'Sandbox.iOS'
-                appFile: '$(Pipeline.Workspace)/E2E-iOS/HelloWorld.iOS.ipa'
-                symbolsDsymFiles: '$(Pipeline.Workspace)/E2E-iOS/HelloWorld.iOS.app.dSYM'
-                distributionGroup: 'f411f43a-68b9-455e-9b58-bc702439a3d9'
+#   - deployment: E2EiOSDeploy
+#     displayName: 'E2E iOS - App Center'
+#     environment: 'App Center'
+#     strategy:
+#       runOnce:
+#         deploy:
+#           steps:
+#             - template: steps/appcenter-deploy.yml
+#               parameters:
+#                 appName: 'Sandbox.iOS'
+#                 appFile: '$(Pipeline.Workspace)/E2E-iOS/HelloWorld.iOS.ipa'
+#                 symbolsDsymFiles: '$(Pipeline.Workspace)/E2E-iOS/HelloWorld.iOS.app.dSYM'
+#                 distributionGroup: 'f411f43a-68b9-455e-9b58-bc702439a3d9'
 
   # - deployment: E2EWpfDeploy
   #   displayName: 'E2E Wpf - App Center'

--- a/build/jobs/e2e-ios.yml
+++ b/build/jobs/e2e-ios.yml
@@ -1,6 +1,10 @@
 parameters:
-  buildConfiguration: 'Debug'
-  versionName: ''
+- name: buildConfiguration
+  type: string
+  default: 'Debug'
+- name: versionName
+  type: string
+  default: ''
 
 jobs:
 - job: e2eIOS
@@ -12,17 +16,6 @@ jobs:
   workspace:
     clean: all
   steps:
-  - task: InstallAppleCertificate@2
-    displayName: 'Install an Apple certificate'
-    inputs:
-      certSecureFile: Prism.p12
-      certPwd: $(PrismAppleCertPassword)
-
-  - task: InstallAppleProvisioningProfile@1
-    displayName: 'Install an Apple provisioning profile'
-    inputs:
-      provProfileSecureFile: Prism.mobileprovision
-
   - task: ios-bundle-version@1
     displayName: 'Bump iOS Versions in Info.plist'
     inputs:
@@ -43,23 +36,24 @@ jobs:
     inputs:
       solutionFile: 'e2e/Forms/src/HelloWorld.iOS/HelloWorld.iOS.csproj'
       configuration: ${{ parameters.buildConfiguration }}
+      buildForSimulator: true
 
-  - bash: |
-     echo "Copying files to ${stagingDir}"
-     rm -rf $stagingDir/Debug
-     cp HelloWorld.iOS.ipa $stagingDir
-     cp -R HelloWorld.iOS.app.dSYM $stagingDir
-    displayName: Stage Artifacts
-    workingDirectory: 'e2e/Forms/src/HelloWorld.iOS/bin/iPhone/${{ parameters.buildConfiguration }}'
-    env:
-      stagingDir: $(Build.ArtifactStagingDirectory)
+  # - bash: |
+  #    echo "Copying files to ${stagingDir}"
+  #    rm -rf $stagingDir/Debug
+  #    cp HelloWorld.iOS.ipa $stagingDir
+  #    cp -R HelloWorld.iOS.app.dSYM $stagingDir
+  #   displayName: Stage Artifacts
+  #   workingDirectory: 'e2e/Forms/src/HelloWorld.iOS/bin/iPhone/${{ parameters.buildConfiguration }}'
+  #   env:
+  #     stagingDir: $(Build.ArtifactStagingDirectory)
 
-  - bash: rm -rf NuGet
-    displayName: Cleanup ArtifactStagingDirectory
-    workingDirectory: $(Build.ArtifactStagingDirectory)
+  # - bash: rm -rf NuGet
+  #   displayName: Cleanup ArtifactStagingDirectory
+  #   workingDirectory: $(Build.ArtifactStagingDirectory)
 
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish E2E Artifacts'
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: E2E-iOS
+  # - task: PublishPipelineArtifact@1
+  #   displayName: 'Publish E2E Artifacts'
+  #   inputs:
+  #     targetPath: '$(Build.ArtifactStagingDirectory)'
+  #     artifactName: E2E-iOS

--- a/build/nuget.config
+++ b/build/nuget.config
@@ -1,0 +1,6 @@
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/build/steps/prepare-build.yml
+++ b/build/steps/prepare-build.yml
@@ -25,3 +25,4 @@ steps:
     restoreSolution: ${{ parameters.solution }}
     noCache: true
     verbosityRestore: normal
+    nugetConfigPath: build/nuget.config

--- a/build/steps/publish-vstest-results.yml
+++ b/build/steps/publish-vstest-results.yml
@@ -5,6 +5,7 @@ parameters:
 
 steps:
 - task: PublishTestResults@2
+  condition: always()
   enabled: ${{ parameters.enabled }}
   displayName: 'Publish ${{ parameters.testRunTitle }} test results'
   inputs:

--- a/e2e/Forms/src/HelloWorld.Android/MainActivity.cs
+++ b/e2e/Forms/src/HelloWorld.Android/MainActivity.cs
@@ -1,6 +1,8 @@
-﻿using Android.App;
+﻿using System;
+using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Prism;
 
 namespace HelloWorld.Droid
 {
@@ -18,6 +20,19 @@ namespace HelloWorld.Droid
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App(new AndroidInitializer()));
+        }
+
+        public override async void OnBackPressed()
+        {
+            var result = await PrismPlatform.OnBackPressed();
+            if (!result.Success)
+            {
+                System.Diagnostics.Debugger.Break();
+                if (result.Exception != null)
+                {
+                    Console.WriteLine(result.Exception);
+                }
+            }
         }
     }
 }

--- a/e2e/Forms/src/HelloWorld.Android/MainActivity.cs
+++ b/e2e/Forms/src/HelloWorld.Android/MainActivity.cs
@@ -24,7 +24,7 @@ namespace HelloWorld.Droid
 
         public override async void OnBackPressed()
         {
-            var result = await PrismPlatform.OnBackPressed();
+            var result = await PrismPlatform.OnBackPressed(this);
             if (!result.Success)
             {
                 System.Diagnostics.Debugger.Break();

--- a/e2e/Forms/src/HelloWorld/App.xaml.cs
+++ b/e2e/Forms/src/HelloWorld/App.xaml.cs
@@ -43,7 +43,7 @@ namespace HelloWorld
     #endregion
     public sealed partial class App
     {
-        public App() 
+        public App()
             : this(null)
         {
         }
@@ -62,7 +62,8 @@ namespace HelloWorld
         {
             InitializeComponent();
 
-            NavigationService.NavigateAsync($"MyTabbedPage").OnNavigationError(OnNavigationError);
+            // DO NOT COMMIT CHANGES TO THIS!!!!
+            NavigationService.NavigateAsync($"MyMasterDetail/MyTabbedPage").OnNavigationError(OnNavigationError);
         }
 
         private void OnNavigationError(Exception ex)

--- a/src/Forms/Prism.Forms/Common/PageUtilities.cs
+++ b/src/Forms/Prism.Forms/Common/PageUtilities.cs
@@ -216,7 +216,14 @@ namespace Prism.Common
             return stackCount - 1;
         }
 
-        public static Page GetCurrentPage(Page mainPage)
+        public static Page GetCurrentPage(Page mainPage) =>
+            _getCurrentPage(mainPage);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetCurrentPageDelegate(Func<Page, Page> getCurrentPageDelegate) =>
+            _getCurrentPage = getCurrentPageDelegate;
+
+        private static Func<Page, Page> _getCurrentPage = mainPage =>
         {
             var page = mainPage;
 
@@ -225,7 +232,7 @@ namespace Prism.Common
                 page = lastModal;
 
             return GetOnNavigatedToTargetFromChild(page);
-        }
+        };
 
         public static void HandleSystemGoBack(Page previousPage, Page currentPage)
         {

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -1194,7 +1194,7 @@ namespace Prism.Navigation
                 FlyoutPage fp => IsRoot(fp.Detail, currentPage),
                 TabbedPage tp => IsRoot(tp.CurrentPage, currentPage),
                 CarouselPage cp => IsRoot(cp.CurrentPage, currentPage),
-                NavigationPage np => IsRoot(np.CurrentPage, currentPage),
+                NavigationPage np => IsRoot(np.RootPage, currentPage),
                 _ => false
             };
         }

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -93,6 +93,9 @@ namespace Prism.Navigation
                 NavigationSource = PageNavigationSource.NavigationService;
 
                 page = GetCurrentPage();
+                if (IsRoot(_applicationProvider.MainPage, page))
+                    throw new NavigationException(NavigationException.CannotPopApplicationMainPage, page);
+
                 var segmentParameters = UriParsingHelper.GetSegmentParameters(null, parameters);
                 segmentParameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
 
@@ -1179,6 +1182,21 @@ namespace Prism.Navigation
         internal static bool UseReverseNavigation(Page currentPage, Type nextPageType)
         {
             return PageUtilities.HasNavigationPageParent(currentPage) && PageUtilities.IsSameOrSubclassOf<ContentPage>(nextPageType);
+        }
+
+        protected static bool IsRoot(Page mainPage, Page currentPage)
+        {
+            if (mainPage == currentPage)
+                return true;
+
+            return mainPage switch
+            {
+                FlyoutPage fp => IsRoot(fp.Detail, currentPage),
+                TabbedPage tp => IsRoot(tp.CurrentPage, currentPage),
+                CarouselPage cp => IsRoot(cp.CurrentPage, currentPage),
+                NavigationPage np => IsRoot(np.CurrentPage, currentPage),
+                _ => false
+            };
         }
     }
 }

--- a/src/Forms/Prism.Forms/Prism.Forms.csproj
+++ b/src/Forms/Prism.Forms/Prism.Forms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;MonoAndroid10.0</TargetFrameworks>
     <Title>Prism for Xamarin.Forms</Title>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Prism for Xamarin.Forms helps you more easily design and build rich, flexible, and easy to maintain Xamarin.Forms applications.</Summary>-->
@@ -18,6 +18,12 @@ Prism for Xamarin.Forms helps you more easily design and build rich, flexible, a
 
   <ItemGroup>
     <ProjectReference Include="..\..\Prism.Core\Prism.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/src/Forms/Prism.Forms/PrismPlatform.cs
+++ b/src/Forms/Prism.Forms/PrismPlatform.cs
@@ -1,7 +1,11 @@
 ﻿#if MONOANDROID
+using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Prism.Common;
 using Prism.Ioc;
+using Prism.Navigation;
+using Prism.Services.Dialogs;
 using Xamarin.Forms;
 
 namespace Prism
@@ -15,7 +19,7 @@ namespace Prism
         /// <summary>
         /// Called when the Activity has detected the user's press of the back key
         /// </summary>
-        public static async void OnBackPressed()
+        public static async Task<IBackPressedResult> OnBackPressed()
         {
             await semaphore.WaitAsync();
             try
@@ -24,14 +28,37 @@ namespace Prism
                 var appProvider = container.Resolve<IApplicationProvider>();
 
                 Page topPage = PageUtilities.GetCurrentPage(appProvider.MainPage);
+                if (topPage is IDialogContainer dc)
+                {
+
+                }
+
                 var navService = Navigation.Xaml.Navigation.GetNavigationService(topPage);
-                await navService.GoBackAsync();
+                var navResult = await navService.GoBackAsync();
+                return new BackPressedResult
+                {
+                    Success = navResult.Success,
+                    Exception = navResult.Exception
+                };
             }
             finally
             {
                 semaphore.Release();
             }
         }
+    }
+
+    internal class BackPressedResult : IBackPressedResult
+    {
+        public bool Success { get; set; }
+
+        public Exception Exception { get; set; }
+    }
+
+    public interface IBackPressedResult
+    {
+        bool Success { get; }
+        Exception Exception { get; }
     }
 }
 #endif

--- a/src/Forms/Prism.Forms/PrismPlatform.cs
+++ b/src/Forms/Prism.Forms/PrismPlatform.cs
@@ -1,0 +1,37 @@
+﻿#if MONOANDROID
+using System.Threading;
+using Prism.Common;
+using Prism.Ioc;
+using Xamarin.Forms;
+
+namespace Prism
+{
+    /// <summary>
+    /// Native helper class
+    /// </summary>
+    public static class PrismPlatform
+    {
+        private static readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
+        /// <summary>
+        /// Called when the Activity has detected the user's press of the back key
+        /// </summary>
+        public static async void OnBackPressed()
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                var container = ContainerLocator.Container;
+                var appProvider = container.Resolve<IApplicationProvider>();
+
+                Page topPage = PageUtilities.GetCurrentPage(appProvider.MainPage);
+                var navService = Navigation.Xaml.Navigation.GetNavigationService(topPage);
+                await navService.GoBackAsync();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+    }
+}
+#endif

--- a/src/Forms/Prism.Forms/PrismPlatform.cs
+++ b/src/Forms/Prism.Forms/PrismPlatform.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Prism.Common;
 using Prism.Ioc;
-using Prism.Navigation;
 using Prism.Services.Dialogs;
 using Xamarin.Forms;
 
@@ -30,7 +29,18 @@ namespace Prism
                 Page topPage = PageUtilities.GetCurrentPage(appProvider.MainPage);
                 if (topPage is IDialogContainer dc)
                 {
-
+                    var result = await dc.RequestCloseAsync();
+                    return result.Exception switch
+                    {
+                        DialogException de
+                            when de.Message == DialogException.CanCloseIsFalse
+                          => new BackPressedResult(),
+                        _ => new BackPressedResult
+                        {
+                            Success = result.Exception is null,
+                            Exception = result.Exception
+                        }
+                    };
                 }
 
                 var navService = Navigation.Xaml.Navigation.GetNavigationService(topPage);

--- a/src/Forms/Prism.Forms/PrismPlatform.cs
+++ b/src/Forms/Prism.Forms/PrismPlatform.cs
@@ -2,8 +2,10 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Android.App;
 using Prism.Common;
 using Prism.Ioc;
+using Prism.Navigation;
 using Prism.Services.Dialogs;
 using Xamarin.Forms;
 
@@ -18,7 +20,7 @@ namespace Prism
         /// <summary>
         /// Called when the Activity has detected the user's press of the back key
         /// </summary>
-        public static async Task<IBackPressedResult> OnBackPressed()
+        public static async Task<IBackPressedResult> OnBackPressed(Activity activity = null)
         {
             await semaphore.WaitAsync();
             try
@@ -45,6 +47,17 @@ namespace Prism
 
                 var navService = Navigation.Xaml.Navigation.GetNavigationService(topPage);
                 var navResult = await navService.GoBackAsync();
+                if(navResult.Exception is NavigationException ne
+                    && ne.Message == NavigationException.CannotPopApplicationMainPage
+                    && activity != null)
+                {
+                    activity.FinishAffinity();
+                    return new BackPressedResult
+                    {
+                        Success = true
+                    };
+                }
+
                 return new BackPressedResult
                 {
                     Success = navResult.Success,

--- a/src/Forms/Prism.Forms/Services/Dialogs/DialogPage.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/DialogPage.cs
@@ -1,4 +1,6 @@
-﻿using Xamarin.Forms;
+﻿using System;
+using System.Windows.Input;
+using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
@@ -14,10 +16,14 @@ namespace Prism.Services.Dialogs
         }
 
         public View DialogView { get; set; }
-    }
 
-    public interface IDialogContainer
-    {
-        View DialogView { get; }
+        public ICommand Dismiss { get; set; }
+
+        public event EventHandler<IDialogResult> DialogResult;
+
+        public void RaiseDialogResult(IDialogResult result)
+        {
+            DialogResult?.Invoke(this, result);
+        }
     }
 }

--- a/src/Forms/Prism.Forms/Services/Dialogs/DialogPage.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/DialogPage.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Prism.Services.Dialogs
 {
-    internal class DialogPage : ContentPage
+    internal class DialogPage : ContentPage, IDialogContainer
     {
         public DialogPage()
         {
@@ -14,5 +14,10 @@ namespace Prism.Services.Dialogs
         }
 
         public View DialogView { get; set; }
+    }
+
+    public interface IDialogContainer
+    {
+        View DialogView { get; }
     }
 }

--- a/src/Forms/Prism.Forms/Services/Dialogs/IDialogContainer.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/IDialogContainer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace Prism.Services.Dialogs
+{
+    public interface IDialogContainer
+    {
+        event EventHandler<IDialogResult> DialogResult;
+        View DialogView { get; }
+        void RaiseDialogResult(IDialogResult result);
+        ICommand Dismiss { get; set; }
+    }
+
+    internal static class IDialogContainerExtensions
+    {
+        public static Task<IDialogResult> RequestCloseAsync(this IDialogContainer container)
+        {
+            var tcs = new TaskCompletionSource<IDialogResult>();
+            void OnDialogResult(object sender, IDialogResult result)
+            {
+                container.DialogResult -= OnDialogResult;
+                tcs.SetResult(result);
+            }
+
+            container.DialogResult += OnDialogResult;
+            container.Dismiss.Execute(null);
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

This PR adds support to optionally handle the Android "Hardware" go back.  As there is no actual hook in Xamarin.Forms itself to handle this from an X-Plat standpoint. No tests added as this is largely platform specific, also I'm lazy and want to give Brian something to complain about while doing a live stream....

### Related Issues

- #1862

### API Changes

Added:

- Static PrismPlatform class is now available on Android only. This exposes an async OnBackPressed method that will handle either going back for Dialogs or Pages on the NavigationStack.
- IBackPressedResult - this is an annoying yet necessary layer as we have different result types for Dialogs and Navigation.
- IDialogContainer - this provides some additional surface area to allow Prism to dismiss Dialogs with the hardware back, and makes this easier to plug in for the Popup Plugin

Changed:

- PageUtilities.GetCurrentPage now can take a delegate. This will allow for better integration with the Popup Plugin which requires special logic here it introduces a new Page type separate Navigation Stack.

### Behavioral Changes

The existing GetCurrentPage is now a delegate which can be replaced if needed such as with Prism.Plugin.Popups. There is no actual change to the default behavior.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard