### PR TITLE
Use the Target Element BindingContext instead of the Page VM

### DIFF
--- a/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
+++ b/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
@@ -82,9 +82,9 @@ namespace Prism.Xaml
                 }
             }
 
-            if (BindingContext == null)
+            if (BindingContext == null || !IsSet(BindingContextProperty))
             {
-                BindingContext = SourcePage.BindingContext;
+                BindingContext = _targetElement.BindingContext;
             }
         }
 

--- a/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
+++ b/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
@@ -16,6 +16,9 @@ namespace Prism.Xaml
         private IServiceProvider ServiceProvider;
 
         private Element _targetElement;
+        /// <summary>
+        /// The target element the XAML Extension is being used on.
+        /// </summary>
         protected Element TargetElement
         {
             get
@@ -30,7 +33,15 @@ namespace Prism.Xaml
             set => _targetElement = value;
         }
 
+        /// <summary>
+        /// Sets the Target BindingContext strategy
+        /// </summary>
+        public TargetBindingContext TargetBindingContext { get; set; }
+
         private Page _sourcePage;
+        /// <summary>
+        /// The parent Page of the layout where the XAML Extension is being used.
+        /// </summary>
         public Page SourcePage
         {
             protected internal get
@@ -45,12 +56,21 @@ namespace Prism.Xaml
             set => _sourcePage = value;
         }
 
+        /// <summary>
+        /// Provides the object that is created from the markup extension.
+        /// </summary>
+        /// <param name="serviceProvider">The Service Provider</param>
+        /// <returns>The object created by the markup extension.</returns>
         public T ProvideValue(IServiceProvider serviceProvider)
         {
             ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             return ProvideValue();
         }
 
+        /// <summary>
+        /// Provides the object that is created from the markup extension.
+        /// </summary>
+        /// <returns>The object created by the markup extension.</returns>
         protected abstract T ProvideValue();
 
         object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) =>
@@ -84,10 +104,17 @@ namespace Prism.Xaml
 
             if (BindingContext == null || !IsSet(BindingContextProperty))
             {
-                BindingContext = _targetElement.BindingContext;
+                BindingContext = TargetBindingContext switch
+                {
+                    TargetBindingContext.Page => SourcePage.BindingContext,
+                    _ => TargetElement.BindingContext
+                };
             }
         }
 
+        /// <summary>
+        /// Callback when the TargetElement is changed
+        /// </summary>
         protected virtual void OnTargetElementChanged()
         {
         }

--- a/src/Forms/Prism.Forms/Xaml/TargetBindingContext.cs
+++ b/src/Forms/Prism.Forms/Xaml/TargetBindingContext.cs
@@ -1,0 +1,18 @@
+﻿namespace Prism.Xaml
+{
+    /// <summary>
+    /// Target BindingContext behavior for the <see cref="ParentPageAwareExtension{T}" />
+    /// </summary>
+    public enum TargetBindingContext
+    {
+        /// <summary>
+        /// Use the Target Element's Binding Context
+        /// </summary>
+        Element = 0,
+
+        /// <summary>
+        /// Use the Parent Page's Binding Context (usually the ViewModel)
+        /// </summary>
+        Page = 1
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

Fixes bug with the Binding Context of the ParentPageAwareExtension base XAML Extension setting the BindingContext to the Parent Page's Binding Context instead of the Target Element's Binding Context.

### Bugs Fixed

- fixes #2232

### API Changes

Adds TargetBindingContext enum. To use the legacy behavior of targeting the Page's BindingContext simply set this property. By default it will use the TargetElement.

### Behavioral Changes

Navigation XAML Extensions & Dialog XAML Extension now correctly set the BindingContext of the Command / Extension to the Target Element's Binding Context instead of the Page's Binding Context. This correctly supports uses within Lists.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard