### PR TITLE
use ContainerLocator

### DIFF
--- a/src/Forms/Prism.Forms/Ioc/ContainerProvider.cs
+++ b/src/Forms/Prism.Forms/Ioc/ContainerProvider.cs
@@ -14,13 +14,13 @@
     ///     {
     ///         _logger = logger;
     ///     }
-    /// 
+    ///
     ///     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     ///     {
     ///         _logger.Log($"Converting {value.GetType().Name} to {targetType.Name}", Category.Debug, Priority.None);
     ///         // do stuff
     ///     }
-    /// 
+    ///
     ///     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     ///     {
     ///         _logger.Log($"Converting back from {value.GetType().Name} to {targetType.Name}", Category.Debug, Priority.None);
@@ -53,7 +53,7 @@
         /// <param name="containerProvider"></param>
         public static implicit operator T(ContainerProvider<T> containerProvider)
         {
-            var container = PrismApplicationBase.Current.Container;
+            var container = ContainerLocator.Container;
             if (container == null) return default(T);
             if (string.IsNullOrWhiteSpace(containerProvider.Name))
             {

--- a/src/Forms/Prism.Forms/Services/Dialogs/Xaml/ShowDialogExtension.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/Xaml/ShowDialogExtension.cs
@@ -13,7 +13,7 @@ namespace Prism.Services.Dialogs.Xaml
     {
         public static Lazy<IDialogService> LazyDialogService = new Lazy<IDialogService>(() =>
         {
-            return PrismApplicationBase.Current.Container.Resolve<IDialogService>();
+            return ContainerLocator.Container.Resolve<IDialogService>();
         });
 
         public string Name { get; set; }


### PR DESCRIPTION
﻿## Description of Change

Updates references to the Container to be in line with Prism 8's ContainerLocator instead of referencing the static instance of the PrismApplication

### Bugs Fixed

- None (housekeeping)

### API Changes

none

### Behavioral Changes

none

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard