### PR TITLE
fix: [UWP][WinUI] Support for `RegionManager.IsInDesignMode`

### DIFF
--- a/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -241,7 +241,7 @@ namespace Prism.Regions
         private static bool IsInDesignMode(DependencyObject element)
         {
 #if HAS_UWP || HAS_WINUI
-            return false;
+            return Windows.ApplicationModel.DesignMode.DesignModeEnabled;
 #else
             return DesignerProperties.GetIsInDesignMode(element);
 #endif


### PR DESCRIPTION
﻿## Description of Change

Implement the support for `RegionManager.IsInDesignMode`

### Bugs Fixed

- fixes #2418

### API Changes

List all API changes here (or just put None), example:

None

### Behavioral Changes

This will indicate prism to stop processing regions when hosted in the XAML designed.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard