### PR TITLE
Apply AutowireViewModel automatically when using RegisterVIewWithRegion

### DIFF
--- a/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
+++ b/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
@@ -6,6 +6,8 @@ namespace Prism.Common
 {
     internal static class MvvmHelpers
     {
+        public static void AutowireViewModel(object view) => PageUtilities.SetAutowireViewModel((VisualElement)view);
+
         public static void ViewAndViewModelAction<T>(object view, Action<T> action)
             where T : class
         {

--- a/src/Wpf/Prism.Wpf/Regions/RegionViewRegistry.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionViewRegistry.cs
@@ -80,7 +80,9 @@ namespace Prism.Regions
         /// <returns>Instance of the registered view.</returns>
         protected virtual object CreateInstance(Type type)
         {
-            return _container.Resolve(type);
+            var view = _container.Resolve(type);
+            MvvmHelpers.AutowireViewModel(view);
+            return view;
         }
 
         private void OnContentRegistered(ViewRegisteredEventArgs e)

--- a/tests/Wpf/Prism.Wpf.Tests/Mocks/ViewModels/MockOptOutViewModel.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Mocks/ViewModels/MockOptOutViewModel.cs
@@ -1,0 +1,8 @@
+﻿using Prism.Mvvm;
+
+namespace Prism.Wpf.Tests.Mocks.ViewModels
+{
+    public class MockOptOutViewModel : BindableBase
+    {
+    }
+}

--- a/tests/Wpf/Prism.Wpf.Tests/Mocks/Views/MockOptOut.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Mocks/Views/MockOptOut.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows;
+using Prism.Mvvm;
+
+namespace Prism.Wpf.Tests.Mocks.Views
+{
+    public class MockOptOut : FrameworkElement
+    {
+        public MockOptOut()
+        {
+            ViewModelLocator.SetAutoWireViewModel(this, false);
+        }
+    }
+}

--- a/tests/Wpf/Prism.Wpf.Tests/Mvvm/ViewModelLocatorFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Mvvm/ViewModelLocatorFixture.cs
@@ -83,7 +83,7 @@ namespace Prism.Wpf.Tests.Mvvm
             ReferenceEquals(view.DataContext, viewModel);
         }
 
-        private static void ResetViewModelLocationProvider()
+        internal static void ResetViewModelLocationProvider()
         {
             Type staticType = typeof(ViewModelLocationProvider);
             ConstructorInfo ci = staticType.TypeInitializer;


### PR DESCRIPTION
﻿## Description of Change

Automatically applies the AutowireViewModel when using RegisterViewWithRegion

### Bugs Fixed

- #2236

### API Changes
- None
### Behavioral Changes

When using RegisterVIewWithRegion, you are no longer required to use the ViewModelLocator.AutowireViewModel attached property. It is now on by default.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard