### PR TITLE
Region updates

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Update="DryIoc.dll" Version="4.7.4" />
+    <PackageReference Update="DryIoc.dll" Version="4.7.6" />
     <PackageReference Update="Unity.Container" Version="5.11.10" />
 
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
@@ -77,7 +77,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" $(DISABLE_GITVERSIONING) != 'true' ">
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.3.37"
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.4.194"
                             Condition=" !$(MSBuildProjectDirectory.Contains('e2e')) "/>
   </ItemGroup>
 

--- a/PrismLibrary.sln
+++ b/PrismLibrary.sln
@@ -95,6 +95,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Unity.Uno.WinUI", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Uno.WinUI", "src\Uno\Prism.DryIoc.Uno\Prism.DryIoc.Uno.WinUI.csproj", "{DB530D15-0556-4B6F-96B2-1497C8DF08D6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Forms.Regions.Tests", "tests\Forms\Prism.Forms.Regions.Tests\Prism.Forms.Regions.Tests.csproj", "{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Containers\Prism.DryIoc.Shared\Prism.DryIoc.Shared.projitems*{02e0ecaa-b8c6-4eab-a9ab-164b1b99af35}*SharedItemsImports = 5
@@ -416,6 +418,18 @@ Global
 		{DB530D15-0556-4B6F-96B2-1497C8DF08D6}.Release|x64.Build.0 = Release|Any CPU
 		{DB530D15-0556-4B6F-96B2-1497C8DF08D6}.Release|x86.ActiveCfg = Release|Any CPU
 		{DB530D15-0556-4B6F-96B2-1497C8DF08D6}.Release|x86.Build.0 = Release|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Debug|x64.Build.0 = Debug|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Debug|x86.Build.0 = Debug|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Release|x64.ActiveCfg = Release|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Release|x64.Build.0 = Release|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Release|x86.ActiveCfg = Release|Any CPU
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -459,6 +473,7 @@ Global
 		{E74664C1-1BB1-4920-8099-2C9125CFD00B} = {9DF4BF66-FEFA-4135-A37A-963E46B77D13}
 		{D3611B62-8FE0-4594-A4E0-1FA0C5CD8ADA} = {9DF4BF66-FEFA-4135-A37A-963E46B77D13}
 		{DB530D15-0556-4B6F-96B2-1497C8DF08D6} = {9DF4BF66-FEFA-4135-A37A-963E46B77D13}
+		{1DECC7D9-9F2A-4FF5-9FBB-A5245F1C73D7} = {F8A0FDE6-8E75-47D1-9E33-02AB8E8AB473}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7433AE2-B1A0-4C1A-887E-5CAA7AAF67A6}

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -65,13 +65,13 @@ stages:
 
   - template: jobs/e2e-uno.yml
 
-  - template: jobs/e2e-android.yml
-    parameters:
-      versionName: '8.0.$(Build.BuildId)'
+  # - template: jobs/e2e-android.yml
+  #   parameters:
+  #     versionName: '8.0.$(Build.BuildId)'
 
-  - template: jobs/e2e-ios.yml
-    parameters:
-      versionName: '8.0.$(Build.BuildId)'
+  # - template: jobs/e2e-ios.yml
+  #   parameters:
+  #     versionName: '8.0.$(Build.BuildId)'
 
   - template: jobs/uno-uitest.yml
 

--- a/e2e/Forms/src/HelloWorld/App.xaml.cs
+++ b/e2e/Forms/src/HelloWorld/App.xaml.cs
@@ -63,7 +63,7 @@ namespace HelloWorld
             InitializeComponent();
 
             // DO NOT COMMIT CHANGES TO THIS!!!!
-            NavigationService.NavigateAsync($"MyMasterDetail/MyTabbedPage").OnNavigationError(OnNavigationError);
+            NavigationService.NavigateAsync($"MyFlyout/MyTabbedPage").OnNavigationError(OnNavigationError);
         }
 
         private void OnNavigationError(Exception ex)
@@ -87,7 +87,7 @@ namespace HelloWorld
             //containerRegistry.RegisterForNavigation<MainPage, SomeOtherViewModel>(); //override viewmodel convention
             containerRegistry.RegisterForNavigation<NavigationPage>();
             containerRegistry.RegisterForNavigation<MyNavigationPage>();
-            containerRegistry.RegisterForNavigation<MyMasterDetail>();
+            containerRegistry.RegisterForNavigation<MyFlyout>();
             containerRegistry.RegisterForNavigation<ModulesPage, ModulesPageViewModel>();
 
             containerRegistry.RegisterForNavigation<ModulesPage, ModulesPageViewModel>();

--- a/e2e/Forms/src/HelloWorld/ViewModels/MyFlyoutViewModel.cs
+++ b/e2e/Forms/src/HelloWorld/ViewModels/MyFlyoutViewModel.cs
@@ -9,7 +9,7 @@ using Prism.Navigation;
 
 namespace HelloWorld.ViewModels
 {
-    public class MyMasterDetailViewModel : ViewModelBase
+    public class MyFlyoutViewModel : ViewModelBase
     {
         INavigationService _navigationService;
 
@@ -18,7 +18,7 @@ namespace HelloWorld.ViewModels
         public string Message => "Hello from MyMasterDetailViewModel";
 
         public DelegateCommand<string> NavigateCommand { get; set; }
-        public MyMasterDetailViewModel(INavigationService navigationService)
+        public MyFlyoutViewModel(INavigationService navigationService)
         {
             _navigationService = navigationService;
             NavigateCommand = new DelegateCommand<string>(Navigate);

--- a/e2e/Forms/src/HelloWorld/Views/MyFlyout.xaml
+++ b/e2e/Forms/src/HelloWorld/Views/MyFlyout.xaml
@@ -3,11 +3,22 @@
                   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                   xmlns:prism="http://prismlibrary.com"
                   xmlns:controls="clr-namespace:HelloWorld.Controls"
-                  x:Class="HelloWorld.Views.MyMasterDetail">
+                  x:Class="HelloWorld.Views.MyFlyout">
 
   <MasterDetailPage.Master>
     <ContentPage Title="Menu"
                  AutomationId="Menu">
+      <ContentPage.Resources>
+        <ResourceDictionary>
+          <Style TargetType="Button">
+            <Setter Property="CornerRadius" Value="15" />
+            <Setter Property="BorderColor" Value="#5f5f61" />
+            <Setter Property="BorderWidth" Value="2" />
+            <Setter Property="BackgroundColor" Value="#7E7D81" />
+            <Setter Property="TextColor" Value="#FFFFFF" />
+          </Style>
+        </ResourceDictionary>
+      </ContentPage.Resources>
       <StackLayout>
         <Image Source="{OnPlatform Android='icon.png', iOS='PrismLogo', UWP='prism-sandobx-logo.png'}"
                HorizontalOptions="Center"

--- a/e2e/Forms/src/HelloWorld/Views/MyFlyout.xaml.cs
+++ b/e2e/Forms/src/HelloWorld/Views/MyFlyout.xaml.cs
@@ -5,13 +5,13 @@ using Xamarin.Forms.Xaml;
 namespace HelloWorld.Views
 {
     [XamlCompilation(XamlCompilationOptions.Skip)]
-    public partial class MyMasterDetail //: IMasterDetailPageOptions
+    public partial class MyFlyout : IFlyoutPageOptions
     {
-        public MyMasterDetail()
+        public MyFlyout()
         {
             InitializeComponent();
         }
 
-        //public bool IsPresentedAfterNavigation => Device.Idiom != TargetIdiom.Phone;
+        public bool IsPresentedAfterNavigation => Device.Idiom != TargetIdiom.Phone;
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
+++ b/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
@@ -11,17 +11,12 @@ namespace Prism.Common
         public static void ViewAndViewModelAction<T>(object view, Action<T> action)
             where T : class
         {
-            var stack = new System.Diagnostics.StackTrace();
             if (view is T viewAsT)
                 action(viewAsT);
 
             if (view is BindableObject bindable && bindable.BindingContext is T vmAsT)
                 action(vmAsT);
         }
-
-        public static bool GetImplementerFromViewOrViewModel<T>(object view, out T implementer)
-            where T : class =>
-            (implementer = GetImplementerFromViewOrViewModel<T>(view)) != null;
 
         public static T GetImplementerFromViewOrViewModel<T>(object view)
             where T : class

--- a/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
+++ b/src/Forms/Prism.Forms.Regions/Common/MvvmHelpers.cs
@@ -41,16 +41,23 @@ namespace Prism.Common
 
         public static bool IsNavigationTarget(object view, INavigationContext navigationContext)
         {
-            bool isViewTarget = false;
-            bool isVMTarget = false;
-
             if (view is IRegionAware viewAsRegionAware)
-                isViewTarget = viewAsRegionAware.IsNavigationTarget(navigationContext);
+            {
+                return viewAsRegionAware.IsNavigationTarget(navigationContext);
+            }
 
             if (view is BindableObject bindable && bindable.BindingContext is IRegionAware vmAsRegionAware)
-                isVMTarget = vmAsRegionAware.IsNavigationTarget(navigationContext);
+            {
+                return vmAsRegionAware.IsNavigationTarget(navigationContext);
+            }
 
-            return isViewTarget || isVMTarget;
+            var uri = navigationContext.Uri;
+            if (!uri.IsAbsoluteUri)
+                uri = new Uri(new Uri("app://prism.regions"), uri);
+            var path = uri.LocalPath.Substring(1);
+            var viewType = view.GetType();
+
+            return path == viewType.Name || path == viewType.FullName;
         }
 
         public static void OnNavigatedFrom(object view, INavigationContext navigationContext)

--- a/src/Forms/Prism.Forms.Regions/Properties/AssemblyInfo.cs
+++ b/src/Forms/Prism.Forms.Regions/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System.Runtime.CompilerServices;
+using Xamarin.Forms;
 
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Regions.Xaml")]
+[assembly: InternalsVisibleTo("Prism.Forms.Regions.Tests")]

--- a/src/Forms/Prism.Forms.Regions/Properties/Resources.Designer.cs
+++ b/src/Forms/Prism.Forms.Regions/Properties/Resources.Designer.cs
@@ -264,6 +264,15 @@ namespace Prism.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This RegionManager does not contain a Region with the name &apos;{0}&apos;..
+        /// </summary>
+        internal static string RegionNotFound {
+            get {
+                return ResourceManager.GetString("RegionNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The region manager does not contain the {0} region..
         /// </summary>
         internal static string RegionNotInRegionManagerException {

--- a/src/Forms/Prism.Forms.Regions/Properties/Resources.resx
+++ b/src/Forms/Prism.Forms.Regions/Properties/Resources.resx
@@ -194,6 +194,9 @@
   <data name="RegionNameExistsException" xml:space="preserve">
     <value>Region with the given name is already registered: {0}</value>
   </data>
+  <data name="RegionNotFound" xml:space="preserve">
+    <value>This RegionManager does not contain a Region with the name '{0}'.</value>
+  </data>
   <data name="RegionNotInRegionManagerException" xml:space="preserve">
     <value>The region manager does not contain the {0} region.</value>
   </data>

--- a/src/Forms/Prism.Forms.Regions/Regions/Adapters/CarouselViewRegionAdapter.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Adapters/CarouselViewRegionAdapter.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Prism.Behaviors;
 using Prism.Common;
+using Prism.Ioc;
 using Prism.Navigation;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
@@ -19,13 +20,17 @@ namespace Prism.Regions.Adapters
     /// </summary>
     public class CarouselViewRegionAdapter : RegionAdapterBase<CarouselView>
     {
+        private IContainerProvider _container { get; }
+
         /// <summary>
         /// Initializes a new instance of <see cref="CarouselViewRegionAdapter"/>.
         /// </summary>
         /// <param name="regionBehaviorFactory">The factory used to create the region behaviors to attach to the created regions.</param>
-        public CarouselViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
+        /// <param name="container">The <see cref="IContainerProvider"/> used to resolve a new Region.</param>
+        public CarouselViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory, IContainerProvider container)
             : base(regionBehaviorFactory)
         {
+            _container = container;
         }
 
         /// <summary>
@@ -81,7 +86,7 @@ namespace Prism.Regions.Adapters
         /// </summary>
         /// <returns>A new instance of <see cref="SingleActiveRegion"/>.</returns>
         protected override IRegion CreateRegion() =>
-            new SingleActiveRegion();
+            _container.Resolve<SingleActiveRegion>();
 
         private class CarouselRegionBehavior : BehaviorBase<CarouselView>
         {

--- a/src/Forms/Prism.Forms.Regions/Regions/Adapters/CollectionViewRegionAdapter.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Adapters/CollectionViewRegionAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Prism.Ioc;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
 using Xamarin.Forms;
@@ -11,13 +12,17 @@ namespace Prism.Regions.Adapters
     /// </summary>
     public class CollectionViewRegionAdapter : RegionAdapterBase<CollectionView>
     {
+        private IContainerProvider _container { get; }
+
         /// <summary>
         /// Initializes a new instance of <see cref="CollectionViewRegionAdapter"/>.
         /// </summary>
         /// <param name="regionBehaviorFactory">The factory used to create the region behaviors to attach to the created regions.</param>
-        public CollectionViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
+        /// <param name="container">The <see cref="IContainerProvider"/> used to resolve a new Region.</param>
+        public CollectionViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory, IContainerProvider container)
             : base(regionBehaviorFactory)
         {
+            _container = container;
         }
 
         /// <summary>
@@ -49,6 +54,6 @@ namespace Prism.Regions.Adapters
         /// </summary>
         /// <returns>A new instance of <see cref="Region"/>.</returns>
         protected override IRegion CreateRegion() =>
-            new Region();
+            _container.Resolve<Region>();
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/Adapters/ContentViewRegionAdapter.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Adapters/ContentViewRegionAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Linq;
+using Prism.Ioc;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
 using Xamarin.Forms;
@@ -17,8 +18,9 @@ namespace Prism.Regions.Adapters
         /// Initializes a new instance of <see cref="ContentViewRegionAdapter"/>.
         /// </summary>
         /// <param name="regionBehaviorFactory">The factory used to create the region behaviors to attach to the created regions.</param>
-        public ContentViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
-            : base(regionBehaviorFactory)
+        /// <param name="container">The <see cref="IContainerProvider"/> used to resolve a new Region.</param>
+        public ContentViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory, IContainerProvider container)
+            : base(regionBehaviorFactory, container)
         {
         }
     }
@@ -30,13 +32,17 @@ namespace Prism.Regions.Adapters
     public class ContentViewRegionAdapter<TContentView> : RegionAdapterBase<TContentView>
         where TContentView : ContentView
     {
+        private IContainerProvider _container { get; }
+
         /// <summary>
         /// Initializes a new instance of <see cref="ContentViewRegionAdapter{TContentView}"/>.
         /// </summary>
         /// <param name="regionBehaviorFactory">The factory used to create the region behaviors to attach to the created regions.</param>
-        public ContentViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
+        /// <param name="container">The <see cref="IContainerProvider"/> used to resolve a new Region.</param>
+        public ContentViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory, IContainerProvider container)
             : base(regionBehaviorFactory)
         {
+            _container = container;
         }
 
         /// <summary>
@@ -74,6 +80,6 @@ namespace Prism.Regions.Adapters
         /// </summary>
         /// <returns>A new instance of <see cref="SingleActiveRegion"/>.</returns>
         protected override IRegion CreateRegion() =>
-            new SingleActiveRegion();
+            _container.Resolve<SingleActiveRegion>();
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/Adapters/LayoutViewRegionAdapter.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Adapters/LayoutViewRegionAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Prism.Ioc;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
 using Xamarin.Forms;
@@ -12,13 +13,17 @@ namespace Prism.Regions.Adapters
     /// </summary>
     public class LayoutViewRegionAdapter : RegionAdapterBase<Layout<View>>
     {
+        private IContainerProvider _container { get; }
+
         /// <summary>
         /// Initializes a new instance of <see cref="LayoutViewRegionAdapter"/>.
         /// </summary>
         /// <param name="regionBehaviorFactory">The factory used to create the region behaviors to attach to the created regions.</param>
-        public LayoutViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
+        /// <param name="container">The <see cref="IContainerProvider"/> used to resolve a new Region.</param>
+        public LayoutViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory, IContainerProvider container)
             : base(regionBehaviorFactory)
         {
+            _container = container;
         }
 
         /// <summary>
@@ -50,6 +55,6 @@ namespace Prism.Regions.Adapters
         /// </summary>
         /// <returns>A new instance of <see cref="Region"/>.</returns>
         protected override IRegion CreateRegion() =>
-            new Region();
+            _container.Resolve<Region>();
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/Adapters/ScrollViewRegionAdapter.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Adapters/ScrollViewRegionAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Linq;
+using Prism.Ioc;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
 using Xamarin.Forms;
@@ -13,13 +14,17 @@ namespace Prism.Regions.Adapters
     /// </summary>
     public class ScrollViewRegionAdapter : RegionAdapterBase<ScrollView>
     {
+        private IContainerProvider _container { get; }
+
         /// <summary>
         /// Initializes a new instance of <see cref="ScrollViewRegionAdapter"/>.
         /// </summary>
         /// <param name="regionBehaviorFactory">The factory used to create the region behaviors to attach to the created regions.</param>
-        public ScrollViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
+        /// <param name="container">The <see cref="IContainerProvider"/> used to resolve a new Region.</param>
+        public ScrollViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory, IContainerProvider container)
             : base(regionBehaviorFactory)
         {
+            _container = container;
         }
 
         /// <summary>
@@ -58,6 +63,6 @@ namespace Prism.Regions.Adapters
         /// </summary>
         /// <returns>A new instance of <see cref="Region"/>.</returns>
         protected override IRegion CreateRegion() =>
-            new Region();
+            _container.Resolve<Region>();
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/IRegion.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/IRegion.cs
@@ -50,6 +50,23 @@ namespace Prism.Regions
         IRegionManager Add(VisualElement view);
 
         /// <summary>
+        /// Adds a new view to the region.
+        /// </summary>
+        /// <param name="view">The view to add.</param>
+        /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="GetView"/>.</param>
+        /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="VisualElement"/>. It will be the current region manager when using this overload.</returns>
+        IRegionManager Add(VisualElement view, string viewName);
+
+        /// <summary>
+        /// Adds a new view to the region.
+        /// </summary>
+        /// <param name="view">The view to add.</param>
+        /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="GetView"/>.</param>
+        /// <param name="createRegionManagerScope">When <see langword="true"/>, the added view will receive a new instance of <see cref="IRegionManager"/>, otherwise it will use the current region manager for this region.</param>
+        /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="VisualElement"/>.</returns>
+        IRegionManager Add(VisualElement view, string viewName, bool createRegionManagerScope);
+
+        /// <summary>
         /// Removes the specified view from the region.
         /// </summary>
         /// <param name="view">The view to remove.</param>

--- a/src/Forms/Prism.Forms.Regions/Regions/IRegionManager.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/IRegionManager.cs
@@ -21,6 +21,34 @@ namespace Prism.Regions
         IRegionManager CreateRegionManager();
 
         /// <summary>
+        /// Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>. 
+        /// </summary>
+        /// <param name="regionName">The name of the region to add a view to</param>
+        /// <param name="targetName">The view to add to the views collection</param>
+        /// <returns>The RegionManager, to easily add several views. </returns>
+        IRegionManager AddToRegion(string regionName, string targetName);
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <param name="targetName">The type of the view to register with the </param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        IRegionManager RegisterViewWithRegion(string regionName, string targetName);
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <param name="viewType">The type of the view to register with the  <see cref="IRegion"/>.</param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        IRegionManager RegisterViewWithRegion(string regionName, Type viewType);
+
+        /// <summary>
         /// Initiates navigation to the target specified by the <see cref="Uri"/>.
         /// </summary>
         /// <param name="regionName">The name of the Region to navigate to.</param>

--- a/src/Forms/Prism.Forms.Regions/Regions/IRegionManagerExtensions.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/IRegionManagerExtensions.cs
@@ -107,5 +107,17 @@ namespace Prism.Regions
 
             regionManager.RequestNavigate(regionName, new Uri(target, UriKind.RelativeOrAbsolute), nr => { }, regionParameters);
         }
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <typeparam name="T">The type of the view to register with the  <see cref="IRegion"/>.</typeparam>
+        /// <param name="regionManager">The current <see cref="IRegionManager"/>.</param>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        public static IRegionManager RegisterViewWithRegion<T>(this IRegionManager regionManager, string regionName) =>
+            regionManager.RegisterViewWithRegion(regionName, typeof(T));
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
@@ -157,8 +157,7 @@ namespace Prism.Regions.Navigation
 
         private static bool ViewIsMatch(Type viewType, string navigationSegment)
         {
-            var names = new[] { viewType.Name, viewType.FullName };
-            return names.Any(x => x.Equals(navigationSegment, StringComparison.Ordinal));
+            return viewType.FullName == navigationSegment || viewType.Name == navigationSegment;
         }
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationContentLoader.cs
@@ -80,14 +80,13 @@ namespace Prism.Regions.Navigation
         /// <returns>An instance of an item to put into the <see cref="IRegion"/>.</returns>
         protected virtual object CreateNewRegionItem(string candidateTargetContract)
         {
-            object newRegionItem;
             try
             {
                 var view = _container.Resolve<object>(candidateTargetContract) as VisualElement;
 
                 PageUtilities.SetAutowireViewModel(view);
 
-                newRegionItem = view;
+                return view;
             }
             catch (ContainerResolutionException)
             {
@@ -99,7 +98,6 @@ namespace Prism.Regions.Navigation
                     string.Format(CultureInfo.CurrentCulture, Resources.CannotCreateNavigationTarget, candidateTargetContract),
                     e);
             }
-            return newRegionItem;
         }
 
         /// <summary>

--- a/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationService.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Navigation/RegionNavigationService.cs
@@ -131,7 +131,7 @@ namespace Prism.Regions.Navigation
         {
             if (currentViewIndex < activeViews.Length)
             {
-                if (MvvmHelpers.GetImplementerFromViewOrViewModel<IConfirmRegionNavigationRequest>(activeViews[currentViewIndex], out var vetoingView))
+                if (activeViews[currentViewIndex] is IConfirmRegionNavigationRequest vetoingView)
                 {
                     // the current active view implements IConfirmNavigationRequest, request confirmation
                     // providing a callback to resume the navigation request

--- a/src/Forms/Prism.Forms.Regions/Regions/Region.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/Region.cs
@@ -247,9 +247,25 @@ namespace Prism.Regions
         /// </summary>
         /// <param name="view">The view to add.</param>
         /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="IRegion.GetView"/>.</param>
+        /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="VisualElement"/>. It will be the current region manager when using this overload.</returns>
+        public IRegionManager Add(VisualElement view, string viewName)
+        {
+            if (string.IsNullOrEmpty(viewName))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.StringCannotBeNullOrEmpty, nameof(viewName)));
+            }
+
+            return Add(view, viewName, false);
+        }
+
+        /// <summary>
+        /// Adds a new view to the region.
+        /// </summary>
+        /// <param name="view">The view to add.</param>
+        /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="IRegion.GetView"/>.</param>
         /// <param name="createRegionManagerScope">When <see langword="true"/>, the added view will receive a new instance of <see cref="IRegionManager"/>, otherwise it will use the current region manager for this region.</param>
         /// <returns>The <see cref="IRegionManager"/> that is set on the view if it is a <see cref="VisualElement"/>.</returns>
-        private IRegionManager Add(VisualElement view, string viewName, bool createRegionManagerScope)
+        public virtual IRegionManager Add(VisualElement view, string viewName, bool createRegionManagerScope)
         {
             IRegionManager manager = createRegionManagerScope ? RegionManager.CreateRegionManager() : RegionManager;
             InnerAdd(view, viewName, manager);

--- a/src/Forms/Prism.Forms.Regions/Regions/RegionManager.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/RegionManager.cs
@@ -1,6 +1,13 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
+using Prism.Common;
+using Prism.Ioc;
+using Prism.Ioc.Internals;
 using Prism.Navigation;
+using Prism.Properties;
 using Prism.Regions.Navigation;
+using Xamarin.Forms;
 
 namespace Prism.Regions
 {
@@ -27,26 +34,124 @@ namespace Prism.Regions
         public IRegionCollection Regions { get; }
 
         /// <summary>
+        /// Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>.
+        /// </summary>
+        /// <param name="regionName">The name of the region to add a view to</param>
+        /// <param name="targetName">The view to add to the views collection</param>
+        /// <returns>The RegionManager, to easily add several views. </returns>
+        public IRegionManager AddToRegion(string regionName, string targetName)
+        {
+            if (!Regions.ContainsRegionWithName(regionName))
+                throw new ArgumentException(string.Format(Thread.CurrentThread.CurrentCulture, Resources.RegionNotFound, regionName), nameof(regionName));
+
+            var view = CreateNewRegionItem(targetName);
+
+            return Regions[regionName].Add(view);
+        }
+
+        /// <summary>
         /// Creates a new region manager.
         /// </summary>
         /// <returns>A new region manager that can be used as a different scope from the current region manager.</returns>
         public IRegionManager CreateRegionManager() =>
             new RegionManager();
 
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <param name="viewType">The type of the view to register with the </param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        public IRegionManager RegisterViewWithRegion(string regionName, Type viewType)
+        {
+            var regionViewRegistry = ContainerLocator.Container.Resolve<IRegionViewRegistry>();
+
+            regionViewRegistry.RegisterViewWithRegion(regionName, viewType);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <param name="targetName">The type of the view to register with the </param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        public IRegionManager RegisterViewWithRegion(string regionName, string targetName)
+        {
+            var viewType = ContainerLocator.Current.GetRegistrationType(targetName);
+
+            return RegisterViewWithRegion(regionName, viewType);
+        }
+
+        /// <summary>
+        /// Navigates the specified region manager.
+        /// </summary>
+        /// <param name="regionName">The name of the region to call Navigate on.</param>
+        /// <param name="target">The URI of the content to display.</param>
+        /// <param name="navigationCallback">The navigation callback.</param>
         public void RequestNavigate(string regionName, Uri target, Action<IRegionNavigationResult> navigationCallback) =>
             RequestNavigate(regionName, target, navigationCallback, null);
 
+        /// <summary>
+        /// This method allows an <see cref="IRegionManager"/> to locate a specified region and navigate in it to the specified target <see cref="Uri"/>, passing a navigation callback and an instance of <see cref="INavigationParameters"/>, which holds a collection of object parameters.
+        /// </summary>
+        /// <param name="regionName">The name of the region where the navigation will occur.</param>
+        /// <param name="target">A <see cref="Uri"/> that represents the target where the region will navigate.</param>
+        /// <param name="navigationCallback">The navigation callback that will be executed after the navigation is completed.</param>
+        /// <param name="navigationParameters">An instance of <see cref="INavigationParameters"/>, which holds a collection of object parameters.</param>
         public void RequestNavigate(string regionName, Uri target, Action<IRegionNavigationResult> navigationCallback, INavigationParameters navigationParameters)
         {
-            if (string.IsNullOrEmpty(regionName))
-                throw new ArgumentNullException(nameof(regionName));
+            try
+            {
+                if (string.IsNullOrEmpty(regionName))
+                    throw new ArgumentNullException(nameof(regionName));
 
-            var region = Regions[regionName];
+                var region = Regions[regionName];
 
-            if (region is null)
-                throw new Exception("Region not Found");
+                if (region is null)
+                    throw new Exception("Region not Found");
 
-            region.NavigationService.RequestNavigate(target, navigationCallback, navigationParameters);
+                region.NavigationService.RequestNavigate(target, navigationCallback, navigationParameters);
+            }
+            catch (Exception ex)
+            {
+                var navigationContext = new NavigationContext(null, target, navigationParameters);
+                navigationCallback?.Invoke(new RegionNavigationResult(navigationContext, ex));
+            }
+        }
+
+        /// <summary>
+        /// Provides a new item for the region based on the supplied candidate target contract name.
+        /// </summary>
+        /// <param name="candidateTargetContract">The target contract to build.</param>
+        /// <returns>An instance of an item to put into the <see cref="IRegion"/>.</returns>
+        protected virtual VisualElement CreateNewRegionItem(string candidateTargetContract)
+        {
+            VisualElement newRegionItem;
+            try
+            {
+                var view = ContainerLocator.Container.Resolve<object>(candidateTargetContract) as VisualElement;
+
+                PageUtilities.SetAutowireViewModel(view);
+
+                newRegionItem = view;
+            }
+            catch (ContainerResolutionException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException(
+                    string.Format(CultureInfo.CurrentCulture, Resources.CannotCreateNavigationTarget, candidateTargetContract),
+                    e);
+            }
+            return newRegionItem;
         }
     }
 }

--- a/src/Forms/Prism.Forms.Regions/Regions/RegionManager.cs
+++ b/src/Forms/Prism.Forms.Regions/Regions/RegionManager.cs
@@ -132,14 +132,13 @@ namespace Prism.Regions
         /// <returns>An instance of an item to put into the <see cref="IRegion"/>.</returns>
         protected virtual VisualElement CreateNewRegionItem(string candidateTargetContract)
         {
-            VisualElement newRegionItem;
             try
             {
                 var view = ContainerLocator.Container.Resolve<object>(candidateTargetContract) as VisualElement;
 
                 PageUtilities.SetAutowireViewModel(view);
 
-                newRegionItem = view;
+                return view;
             }
             catch (ContainerResolutionException)
             {
@@ -151,7 +150,6 @@ namespace Prism.Regions
                     string.Format(CultureInfo.CurrentCulture, Resources.CannotCreateNavigationTarget, candidateTargetContract),
                     e);
             }
-            return newRegionItem;
         }
     }
 }

--- a/src/Forms/Prism.Forms/Common/PageUtilities.cs
+++ b/src/Forms/Prism.Forms/Common/PageUtilities.cs
@@ -290,7 +290,12 @@ namespace Prism.Common
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void SetAutowireViewModel(VisualElement element)
         {
-            if (element.BindingContext is null && ViewModelLocator.GetAutowireViewModel(element) is null)
+            if (element.IsSet(ViewModelLocator.AutowireViewModelProperty))
+            {
+                return;
+            }
+
+            if (element.BindingContext is null)
             {
                 ViewModelLocator.SetAutowireViewModel(element, true);
             }

--- a/src/Wpf/Prism.Wpf/Regions/IRegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionManager.cs
@@ -1,5 +1,3 @@
-
-
 using System;
 namespace Prism.Regions
 {
@@ -20,7 +18,7 @@ namespace Prism.Regions
         IRegionManager CreateRegionManager();
 
         /// <summary>
-        ///     Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>. 
+        /// Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>.
         /// </summary>
         /// <param name="regionName">The name of the region to add a view to</param>
         /// <param name="view">The view to add to the views collection</param>
@@ -28,19 +26,37 @@ namespace Prism.Regions
         IRegionManager AddToRegion(string regionName, object view);
 
         /// <summary>
-        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>.
+        /// </summary>
+        /// <param name="regionName">The name of the region to add a view to</param>
+        /// <param name="viewName">The view to add to the views collection</param>
+        /// <returns>The RegionManager, to easily add several views. </returns>
+        IRegionManager AddToRegion(string regionName, string viewName);
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region gets displayed
         /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
         /// will be added to the Views collection of the region
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
-        /// <param name="viewType">The type of the view to register with the </param>
+        /// <param name="viewName">The name of the view to register with the <see cref="IRegion"/>.</param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        IRegionManager RegisterViewWithRegion(string regionName, string viewName);
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region gets displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <param name="viewType">The type of the view to register with the  <see cref="IRegion"/>.</param>
         /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
         IRegionManager RegisterViewWithRegion(string regionName, Type viewType);
 
         /// <summary>
-        /// Associate a view with a region, using a delegate to resolve a concrete instance of the view. 
-        /// When the region get's displayed, this delegate will be called and the result will be added to the
-        /// views collection of the region. 
+        /// Associate a view with a region, using a delegate to resolve a concrete instance of the view.
+        /// When the region gets displayed, this delegate will be called and the result will be added to the
+        /// views collection of the region.
         /// </summary>
         /// <param name="regionName">The name of the region to associate the view with.</param>
         /// <param name="getContentDelegate">The delegate used to resolve a concrete instance of the view.</param>

--- a/src/Wpf/Prism.Wpf/Regions/IRegionManagerExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Regions/IRegionManagerExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace Prism.Regions
+{
+    /// <summary>
+    /// Common Extensions for the RegionManager
+    /// </summary>
+    public static class IRegionManagerExtensions
+    {
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <typeparam name="T">The type of the view to register with the  <see cref="IRegion"/>.</typeparam>
+        /// <param name="regionManager">The current <see cref="IRegionManager"/>.</param>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        public static IRegionManager RegisterViewWithRegion<T>(this IRegionManager regionManager, string regionName) =>
+            regionManager.RegisterViewWithRegion(regionName, typeof(T));
+    }
+}

--- a/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -12,6 +12,7 @@ using Prism.Events;
 using Prism.Ioc;
 using Prism.Properties;
 using Prism.Regions.Behaviors;
+using Prism.Ioc.Internals;
 
 #if HAS_UWP
 using Windows.UI.Xaml;
@@ -292,16 +293,19 @@ namespace Prism.Regions
         }
 
         /// <summary>
-        /// Associate a view with a region, by registering a type. When the region get's displayed
-        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
-        /// will be added to the Views collection of the region
+        /// Add a view to the Views collection of a Region. Note that the region must already exist in this <see cref="IRegionManager"/>.
         /// </summary>
-        /// <param name="regionName">The name of the region to associate the view with.</param>
-        /// <typeparam name="T">The type of the view to register</typeparam>
-        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
-        public IRegionManager RegisterViewWithRegion<T>(string regionName)
+        /// <param name="regionName">The name of the region to add a view to</param>
+        /// <param name="targetName">The view to add to the views collection</param>
+        /// <returns>The RegionManager, to easily add several views. </returns>
+        public IRegionManager AddToRegion(string regionName, string targetName)
         {
-            return RegisterViewWithRegion(regionName, typeof(T));
+            if (!Regions.ContainsRegionWithName(regionName))
+                throw new ArgumentException(string.Format(Thread.CurrentThread.CurrentCulture, Resources.RegionNotFound, regionName), nameof(regionName));
+
+            var view = CreateNewRegionItem(targetName);
+
+            return Regions[regionName].Add(view);
         }
 
         /// <summary>
@@ -319,6 +323,21 @@ namespace Prism.Regions
             regionViewRegistry.RegisterViewWithRegion(regionName, viewType);
 
             return this;
+        }
+
+        /// <summary>
+        /// Associate a view with a region, by registering a type. When the region get's displayed
+        /// this type will be resolved using the ServiceLocator into a concrete instance. The instance
+        /// will be added to the Views collection of the region
+        /// </summary>
+        /// <param name="regionName">The name of the region to associate the view with.</param>
+        /// <param name="targetName">The type of the view to register with the </param>
+        /// <returns>The <see cref="IRegionManager"/>, for adding several views easily</returns>
+        public IRegionManager RegisterViewWithRegion(string regionName, string targetName)
+        {
+            var viewType = ContainerLocator.Current.GetRegistrationType(targetName);
+
+            return RegisterViewWithRegion(regionName, viewType);
         }
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionManager.cs
@@ -468,6 +468,33 @@ namespace Prism.Regions
             RequestNavigate(regionName, new Uri(target, UriKind.RelativeOrAbsolute), nr => { }, navigationParameters);
         }
 
+        /// <summary>
+        /// Provides a new item for the region based on the supplied candidate target contract name.
+        /// </summary>
+        /// <param name="candidateTargetContract">The target contract to build.</param>
+        /// <returns>An instance of an item to put into the <see cref="IRegion"/>.</returns>
+        protected virtual object CreateNewRegionItem(string candidateTargetContract)
+        {
+            try
+            {
+                var view = ContainerLocator.Container.Resolve<object>(candidateTargetContract);
+
+                MvvmHelpers.AutowireViewModel(view);
+
+                return view;
+            }
+            catch (ContainerResolutionException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException(
+                    string.Format(CultureInfo.CurrentCulture, Resources.CannotCreateNavigationTarget, candidateTargetContract),
+                    e);
+            }
+        }
+
         private class RegionCollection : IRegionCollection
         {
             private readonly IRegionManager regionManager;

--- a/src/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
+++ b/src/Wpf/Prism.Wpf/Regions/RegionNavigationContentLoader.cs
@@ -110,11 +110,15 @@ namespace Prism.Regions
         /// <returns>An instance of an item to put into the <see cref="IRegion"/>.</returns>
         protected virtual object CreateNewRegionItem(string candidateTargetContract)
         {
-            object newRegionItem;
             try
             {
-                newRegionItem = _container.Resolve<object>(candidateTargetContract);
+                var newRegionItem = _container.Resolve<object>(candidateTargetContract);
                 MvvmHelpers.AutowireViewModel(newRegionItem);
+                return newRegionItem;
+            }
+            catch (ContainerResolutionException)
+            {
+                throw;
             }
             catch (Exception e)
             {
@@ -122,7 +126,6 @@ namespace Prism.Regions
                     string.Format(CultureInfo.CurrentCulture, Resources.CannotCreateNavigationTarget, candidateTargetContract),
                     e);
             }
-            return newRegionItem;
         }
 
         /// <summary>

--- a/tests/Forms/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Fixtures/PrismApplicationFixture.cs
@@ -270,6 +270,7 @@ namespace Prism.Unity.Forms.Tests.Fixtures
 
             var mockB = navigationPage.CurrentPage as XamlViewMockB;
             mockB.TestButton.SendClicked();
+            await Task.Delay(150);
 
             Assert.IsType<XamlViewMockA>(navigationPage.RootPage);
             Assert.IsType<XamlViewMockA>(navigationPage.CurrentPage);

--- a/tests/Forms/Prism.DI.Forms.Tests/Fixtures/Regions/RegionFixture.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Fixtures/Regions/RegionFixture.cs
@@ -27,6 +27,11 @@ namespace Prism.DI.Forms.Tests.Fixtures.Regions
             Assert.Null(result.Exception);
             Assert.NotNull(_app.MainPage);
             Assert.IsType<Issue2415Page>(_app.MainPage);
+
+            var vm = _app.MainPage.BindingContext as Issue2415PageViewModel;
+
+            Assert.NotNull(vm.Result);
+            Assert.True(vm.Result.Result);
         }
 
         void IPlatformInitializer.RegisterTypes(IContainerRegistry containerRegistry)

--- a/tests/Forms/Prism.DI.Forms.Tests/Fixtures/Regions/RegionFixture.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Fixtures/Regions/RegionFixture.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Prism.DI.Forms.Tests.Mocks.ViewModels;
+using Prism.DI.Forms.Tests.Mocks.Views;
+using Prism.Ioc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Prism.DI.Forms.Tests.Fixtures.Regions
+{
+    public class RegionFixture : FixtureBase, IPlatformInitializer
+    {
+        private PrismApplicationMock _app;
+
+        public RegionFixture(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+            _app = new PrismApplicationMock(this);
+        }
+
+        [Fact]
+        public async Task RegionWorksWhenContentViewIsTopChild()
+        {
+            var result = await _app.NavigationService.NavigateAsync("Issue2415Page");
+            Assert.Null(result.Exception);
+            Assert.NotNull(_app.MainPage);
+            Assert.IsType<Issue2415Page>(_app.MainPage);
+        }
+
+        void IPlatformInitializer.RegisterTypes(IContainerRegistry containerRegistry)
+        {
+            containerRegistry.RegisterInstance(_testOutputHelper);
+            containerRegistry.RegisterRegionServices();
+            containerRegistry.RegisterForNavigation<Issue2415Page, Issue2415PageViewModel>();
+            containerRegistry.RegisterForRegionNavigation<Issue2415RegionView, Issue2415RegionViewModel>();
+        }
+    }
+}

--- a/tests/Forms/Prism.DI.Forms.Tests/Mocks/ViewModels/Issue2415PageViewModel.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Mocks/ViewModels/Issue2415PageViewModel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Mvvm;
+using Prism.Navigation;
+using Prism.Regions;
+using Xamarin.Forms;
+
+namespace Prism.DI.Forms.Tests.Mocks.ViewModels
+{
+    public class Issue2415PageViewModel : BindableBase, IInitialize
+    {
+        private readonly IRegionManager _regionManager;
+
+        public Issue2415PageViewModel(IRegionManager regionManager)
+        {
+            _regionManager = regionManager;
+        }
+
+        public void Initialize(INavigationParameters parameters)
+{
+            _regionManager.RequestNavigate("ContentRegion", "Issue2415RegionView");
+        }
+    }
+
+    public class Issue2415RegionViewModel
+    {
+
+    }
+}

--- a/tests/Forms/Prism.DI.Forms.Tests/Mocks/ViewModels/Issue2415PageViewModel.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Mocks/ViewModels/Issue2415PageViewModel.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Prism.Mvvm;
 using Prism.Navigation;
 using Prism.Regions;
+using Prism.Regions.Navigation;
 using Xamarin.Forms;
 
 namespace Prism.DI.Forms.Tests.Mocks.ViewModels
@@ -17,9 +18,16 @@ namespace Prism.DI.Forms.Tests.Mocks.ViewModels
             _regionManager = regionManager;
         }
 
+        public IRegionNavigationResult Result { get; private set; }
+
         public void Initialize(INavigationParameters parameters)
-{
-            _regionManager.RequestNavigate("ContentRegion", "Issue2415RegionView");
+        {
+            _regionManager.RequestNavigate("ContentRegion", "Issue2415RegionView", NavigationCallback);
+        }
+
+        private void NavigationCallback(IRegionNavigationResult result)
+        {
+            Result = result;
         }
     }
 

--- a/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415Page.xaml
+++ b/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415Page.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             x:Class="Prism.DI.Forms.Tests.Mocks.Views.Issue2415Page">
+  <ContentPage.Content>
+    <Grid RowDefinitions="*,40">
+      <!-- [Bug] Prism.Forms.Regions in xaml not working when content view in top child -->
+      <!--<Label Text="Tab 1" Grid.Row="1" VerticalTextAlignment="Center" HorizontalTextAlignment="Center"/>-->
+      <ContentView prism:RegionManager.RegionName="ContentRegion" />
+      <Label Text="Tab 1" Grid.Row="1" VerticalTextAlignment="Center" HorizontalTextAlignment="Center"/>
+    </Grid>
+  </ContentPage.Content>
+</ContentPage>

--- a/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415Page.xaml.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415Page.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Prism.DI.Forms.Tests.Mocks.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Issue2415Page : ContentPage
+    {
+        public Issue2415Page()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415RegionView.xaml
+++ b/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415RegionView.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Prism.DI.Forms.Tests.Mocks.Views.Issue2415RegionView">
+  <ContentView.Content>
+    <StackLayout>
+      <Label Text="Hello Prism Tests!" />
+    </StackLayout>
+  </ContentView.Content>
+</ContentView>

--- a/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415RegionView.xaml.cs
+++ b/tests/Forms/Prism.DI.Forms.Tests/Mocks/Views/Issue2415RegionView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Prism.DI.Forms.Tests.Mocks.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Issue2415RegionView : ContentView
+    {
+        public Issue2415RegionView ()
+        {
+            InitializeComponent ();
+        }
+    }
+}

--- a/tests/Forms/Prism.DI.Forms.Tests/Prism.DI.Forms.Tests.projitems
+++ b/tests/Forms/Prism.DI.Forms.Tests/Prism.DI.Forms.Tests.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Fixtures\Navigation\NavigationServiceFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Fixtures\Navigation\XamlNavigationFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Fixtures\PrismApplicationFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Fixtures\Regions\RegionFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Converters\MockValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Events\TestActionEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Internals\FormsLogObserver.cs" />
@@ -31,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\AutowireViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ConstructorArgumentViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\CustomNamedNavServiceViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\Issue2415PageViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\PartialViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ViewModelAMock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\ViewModels\ViewModelBMock.cs" />
@@ -43,6 +45,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\AutowireViewTablet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\ConstructorArgumentView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\CustomNamedNavService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\Issue2415Page.xaml.cs">
+      <DependentUpon>Issue2415Page.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\Issue2415RegionView.xaml.cs">
+      <DependentUpon>Issue2415RegionView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\Views\PartialView.xaml.cs">
       <DependentUpon>PartialView.xaml</DependentUpon>
     </Compile>
@@ -94,6 +104,18 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Mocks\Views\XamlMasterDetailViewMock.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Mocks\Views\Issue2415Page.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Mocks\Views\Issue2415RegionView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/tests/Forms/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
+++ b/tests/Forms/Prism.DryIoc.Forms.Tests/Prism.DryIoc.Forms.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Forms\Prism.DryIoc.Forms\Prism.DryIoc.Forms.csproj" />
+    <ProjectReference Include="..\..\..\src\Forms\Prism.Forms.Regions\Prism.Forms.Regions.csproj" />
   </ItemGroup>
 
   <Import Project="..\Prism.DI.Forms.Tests\Prism.DI.Forms.Tests.projitems" Label="Shared" />

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockPresentationRegion.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockPresentationRegion.cs
@@ -1,0 +1,134 @@
+﻿using System.ComponentModel;
+using System;
+using Prism.Regions;
+using Prism.Regions.Behaviors;
+using Prism.Regions.Navigation;
+using Xamarin.Forms;
+using Prism.Navigation;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    internal class MockPresentationRegion : IRegion
+    {
+        public MockViewsCollection MockViews = new MockViewsCollection();
+        public MockViewsCollection MockActiveViews = new MockViewsCollection();
+
+        public MockPresentationRegion()
+        {
+            Behaviors = new MockRegionBehaviorCollection();
+        }
+        public IRegionManager Add(VisualElement view)
+        {
+            MockViews.Items.Add(view);
+
+            return null;
+        }
+
+        public void Remove(VisualElement view)
+        {
+            MockViews.Items.Remove(view);
+            MockActiveViews.Items.Remove(view);
+        }
+
+        public void Activate(VisualElement view)
+        {
+            MockActiveViews.Items.Add(view);
+        }
+
+        public IRegionManager Add(VisualElement view, string viewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IRegionManager Add(VisualElement view, string viewName, bool createRegionManagerScope)
+        {
+            throw new NotImplementedException();
+        }
+
+        public VisualElement GetView(string viewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IRegionManager RegionManager { get; set; }
+
+        public IRegionBehaviorCollection Behaviors { get; set; }
+
+        public IViewsCollection Views => MockViews;
+
+        public IViewsCollection ActiveViews => MockActiveViews;
+
+        public void Deactivate(VisualElement view)
+        {
+            MockActiveViews.Items.Remove(view);
+        }
+
+        private object _context;
+        public object Context
+        {
+            get => _context;
+            set
+            {
+                _context = value;
+                OnPropertyChange("Context");
+            }
+        }
+
+        public NavigationParameters NavigationParameters
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        private string _name;
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                OnPropertyChange("Name");
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void OnPropertyChange(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public bool Navigate(Uri source)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RequestNavigate(Uri target, Action<IRegionNavigationResult> navigationCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RequestNavigate(Uri target, Action<IRegionNavigationResult> navigationCallback, INavigationParameters navigationParameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IRegionNavigationService NavigationService
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+
+        public Comparison<VisualElement> SortComparison
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegion.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegion.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Prism.Regions;
+using Prism.Regions.Behaviors;
+using Prism.Regions.Navigation;
+using Xamarin.Forms;
+using Prism.Navigation;
+using System.ComponentModel;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    internal class MockRegion : IRegion
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        public Func<string, VisualElement> GetViewStringDelegate { get; set; }
+
+        private MockViewsCollection _views = new MockViewsCollection();
+
+        public IViewsCollection Views => _views;
+
+        public IViewsCollection ActiveViews => throw new NotImplementedException();
+
+        public object Context
+        {
+            get;
+            set;
+        }
+
+        public NavigationParameters NavigationParameters
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public string Name { get; set; }
+
+        public IRegionManager Add(VisualElement view)
+        {
+            _views.Add(view);
+            return null;
+        }
+
+        public IRegionManager Add(VisualElement view, string viewName)
+        {
+            return Add(view);
+        }
+
+        public IRegionManager Add(VisualElement view, string viewName, bool createRegionManagerScope)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Remove(VisualElement view)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Activate(VisualElement view)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Deactivate(VisualElement view)
+        {
+            throw new NotImplementedException();
+        }
+
+        public VisualElement GetView(string viewName)
+        {
+            return GetViewStringDelegate(viewName);
+        }
+
+        public IRegionManager RegionManager { get; set; }
+
+        public IRegionBehaviorCollection Behaviors
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool Navigate(Uri source)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public void RequestNavigate(Uri target, Action<IRegionNavigationResult> navigationCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RequestNavigate(Uri target, Action<IRegionNavigationResult> navigationCallback, INavigationParameters navigationParameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IRegionNavigationService NavigationService
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+
+        public Comparison<VisualElement> SortComparison
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionAdapter.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionAdapter.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Prism.Regions.Adapters;
+using Prism.Regions;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    internal class MockRegionAdapter : IRegionAdapter
+    {
+        public List<string> CreatedRegions = new List<string>();
+        public MockRegionManagerAccessor Accessor;
+
+
+        public IRegion Initialize(VisualElement regionTarget, string regionName)
+        {
+            CreatedRegions.Add(regionName);
+
+            var region = new MockPresentationRegion();
+            Prism.Regions.Xaml.RegionManager.GetObservableRegion(regionTarget).Value = region;
+
+            // Fire update regions again. This also happens if a region is created and added to the regionmanager
+            if (Accessor != null)
+                Accessor.UpdateRegions();
+
+            return region;
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionBehavior.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionBehavior.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Prism.Regions;
+using Prism.Regions.Behaviors;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    public class MockRegionBehavior : IRegionBehavior
+    {
+        public IRegion Region { get; set; }
+
+        public Func<object> OnAttach;
+
+        public void Attach()
+        {
+            if (OnAttach != null)
+                OnAttach();
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionBehaviorCollection.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionBehaviorCollection.cs
@@ -1,0 +1,14 @@
+﻿using Prism.Regions.Behaviors;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    internal class MockRegionBehaviorCollection : Dictionary<string, IRegionBehavior>, IRegionBehaviorCollection
+    {
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionManagerAccessor.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockRegionManagerAccessor.cs
@@ -1,0 +1,39 @@
+﻿using Prism.Regions;
+using Xamarin.Forms;
+using System;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    internal class MockRegionManagerAccessor : IRegionManagerAccessor
+    {
+        public Func<VisualElement, string> GetRegionName;
+        public Func<VisualElement, IRegionManager> GetRegionManager;
+
+        public event EventHandler UpdatingRegions;
+
+        string IRegionManagerAccessor.GetRegionName(VisualElement element)
+        {
+            return GetRegionName(element);
+        }
+
+        IRegionManager IRegionManagerAccessor.GetRegionManager(VisualElement element)
+        {
+            if (GetRegionManager != null)
+            {
+                return GetRegionManager(element);
+            }
+
+            return null;
+        }
+
+        public void UpdateRegions()
+        {
+            UpdatingRegions?.Invoke(this, EventArgs.Empty);
+        }
+
+        public int GetSubscribersCount()
+        {
+            return UpdatingRegions != null ? UpdatingRegions.GetInvocationList().Length : 0;
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockSortableView1.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockSortableView1.cs
@@ -1,0 +1,10 @@
+﻿using Prism.Regions;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    [ViewSortHint("01")]
+    internal class MockSortableView1 : View
+    {
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockSortableView2.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockSortableView2.cs
@@ -1,0 +1,10 @@
+﻿using Prism.Regions;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    [ViewSortHint("02")]
+    internal class MockSortableView2 : View
+    {
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockSortableView3.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockSortableView3.cs
@@ -1,0 +1,10 @@
+﻿using Prism.Regions;
+using Xamarin.Forms;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    [ViewSortHint("03")]
+    internal class MockSortableView3 : View
+    {
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockViewsCollection.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Mocks/MockViewsCollection.cs
@@ -1,0 +1,40 @@
+﻿using Prism.Regions;
+using Xamarin.Forms;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Collections;
+
+namespace Prism.Forms.Regions.Mocks
+{
+    internal class MockViewsCollection : IViewsCollection
+    {
+        public ObservableCollection<VisualElement> Items = new ObservableCollection<VisualElement>();
+
+        public void Add(VisualElement view)
+        {
+            Items.Add(view);
+        }
+
+        public bool Contains(VisualElement value)
+        {
+            return Items.Contains(value);
+        }
+
+        public IEnumerator<VisualElement> GetEnumerator()
+        {
+            return Items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged
+        {
+            add => Items.CollectionChanged += value;
+            remove => Items.CollectionChanged -= value;
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Prism.Forms.Regions.Tests.csproj
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Prism.Forms.Regions.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <RootNamespace>Prism.Forms.Regions</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Xamarin.Forms.Mocks" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Forms\Prism.Forms.Regions\Prism.Forms.Regions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/AllActiveRegionFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/AllActiveRegionFixture.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Regions;
+using Xamarin.Forms;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class AllActiveRegionFixture
+    {
+        [Fact]
+        public void AddingViewsToRegionMarksThemAsActive()
+        {
+            IRegion region = new AllActiveRegion();
+            var view = new ContentView();
+
+            region.Add(view);
+
+            Assert.True(region.ActiveViews.Contains(view));
+        }
+
+        [Fact]
+        public void DeactivateThrows()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                IRegion region = new AllActiveRegion();
+                var view = new ContentView();
+                region.Add(view);
+
+                region.Deactivate(view);
+            });
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/CollectionChangedTracker.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/CollectionChangedTracker.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class CollectionChangedTracker
+    {
+        private readonly List<NotifyCollectionChangedEventArgs> eventList = new List<NotifyCollectionChangedEventArgs>();
+
+        public CollectionChangedTracker(INotifyCollectionChanged collection)
+        {
+            collection.CollectionChanged += OnCollectionChanged;
+        }
+
+        public IEnumerable<NotifyCollectionChangedAction> ActionsFired =>
+            eventList.Select(e => e.Action);
+        public IEnumerable<NotifyCollectionChangedEventArgs> NotifyEvents => eventList;
+
+        private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            eventList.Add(e);
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/ContentViewRegionAdapterFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/ContentViewRegionAdapterFixture.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Prism.Forms.Regions.Mocks;
+using Prism.Regions;
+using Prism.Regions.Adapters;
+using Xamarin.Forms;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class ContentControlRegionAdapterFixture
+    {
+        [Fact]
+        public void AdapterAssociatesSelectorWithRegionActiveViews()
+        {
+            var control = new ContentView();
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+
+            MockPresentationRegion region = (MockPresentationRegion)adapter.Initialize(control, "Region1");
+            Assert.NotNull(region);
+
+            Assert.Null(control.Content);
+            region.MockActiveViews.Items.Add(new StackLayout());
+
+            Assert.NotNull(control.Content);
+            Assert.Same(control.Content, region.ActiveViews.ElementAt(0));
+
+            region.MockActiveViews.Items.Add(new Grid());
+            Assert.Same(control.Content, region.ActiveViews.ElementAt(0));
+
+            region.MockActiveViews.Items.RemoveAt(0);
+            Assert.Same(control.Content, region.ActiveViews.ElementAt(0));
+
+            region.MockActiveViews.Items.RemoveAt(0);
+            Assert.Null(control.Content);
+        }
+
+
+        [Fact]
+        public void ControlWithExistingContentThrows()
+        {
+            var control = new ContentView() { Content = new StackLayout() };
+
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+
+            IRegion region = null;
+            var ex = Record.Exception(() => region = (MockPresentationRegion)adapter.Initialize(control, "Region1"));
+            Assert.NotNull(ex);
+            Assert.IsType<InvalidOperationException>(ex);
+            Assert.Contains("ContentView's Content property is not empty.", ex.Message);
+        }
+
+        [Fact]
+        public void ControlWithExistingBindingOnContentWithNullValueThrows()
+        {
+            var control = new ContentView();
+            var binding = new Binding("ObjectContents")
+            {
+                Source = new SimpleModel() { ObjectContents = null }
+            };
+            control.SetBinding(ContentView.ContentProperty, binding);
+
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+            IRegion region = null;
+            var ex = Record.Exception(() => region = (MockPresentationRegion)adapter.Initialize(control, "Region1"));
+            Assert.IsType<InvalidOperationException>(ex);
+            Assert.Contains("ContentView's Content property is not empty.", ex.Message);
+        }
+
+        [Fact]
+        public void AddedItemShouldBeActivated()
+        {
+            var control = new ContentView();
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+
+            MockPresentationRegion region = (MockPresentationRegion)adapter.Initialize(control, "Region1");
+
+            var mockView = new StackLayout();
+            region.Add(mockView);
+
+            Assert.Single(region.ActiveViews);
+            Assert.True(region.ActiveViews.Contains(mockView));
+        }
+
+        [Fact]
+        public void ShouldNotActivateAdditionalViewsAdded()
+        {
+            var control = new ContentView();
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+
+            MockPresentationRegion region = (MockPresentationRegion)adapter.Initialize(control, "Region1");
+
+            var mockView = new StackLayout();
+            region.Add(mockView);
+            region.Add(new Grid());
+
+            Assert.Single(region.ActiveViews);
+            Assert.True(region.ActiveViews.Contains(mockView));
+        }
+
+        [Fact]
+        public void ShouldActivateAddedViewWhenNoneIsActive()
+        {
+            var control = new ContentView();
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+
+            MockPresentationRegion region = (MockPresentationRegion)adapter.Initialize(control, "Region1");
+
+            var mockView1 = new StackLayout();
+            region.Add(mockView1);
+            region.Deactivate(mockView1);
+
+            var mockView2 = new Grid();
+            region.Add(mockView2);
+
+            Assert.Single(region.ActiveViews);
+            Assert.True(region.ActiveViews.Contains(mockView2));
+        }
+
+        [Fact]
+        public void CanRemoveViewWhenNoneActive()
+        {
+            var control = new ContentView();
+            IRegionAdapter adapter = new TestableContentControlRegionAdapter();
+
+            MockPresentationRegion region = (MockPresentationRegion)adapter.Initialize(control, "Region1");
+
+            var mockView1 = new StackLayout();
+            region.Add(mockView1);
+            region.Deactivate(mockView1);
+            region.Remove(mockView1);
+            Assert.Empty(region.ActiveViews);
+        }
+
+        class SimpleModel
+        {
+            public object ObjectContents { get; set; }
+        }
+
+        private class TestableContentControlRegionAdapter : ContentViewRegionAdapter
+        {
+            public TestableContentControlRegionAdapter() : base(null, null)
+            {
+            }
+
+            private MockPresentationRegion region = new MockPresentationRegion();
+
+            protected override IRegion CreateRegion()
+            {
+                return region;
+            }
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/LocatorNavigationTargetHandlerFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/LocatorNavigationTargetHandlerFixture.cs
@@ -1,0 +1,393 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Prism.Ioc;
+using Prism.Ioc.Internals;
+using Prism.Regions;
+using Prism.Regions.Navigation;
+using Xamarin.Forms;
+using Xunit;
+using Region = Prism.Regions.Region;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class LocatorNavigationTargetHandlerFixture
+    {
+        [Fact]
+        public void WhenViewExistsAndDoesNotImplementIRegionAware_ThenReturnsView()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var region = new Region();
+
+            var view = new TestView();
+
+            region.Add(view);
+
+            var navigationContext = new NavigationContext(null, new Uri(view.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(view, returnedView);
+        }
+
+        [Fact]
+        public void WhenRegionHasMultipleViews_ThenViewsWithMatchingTypeNameAreConsidered()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var region = new Region();
+
+            var view1 = new TestView();
+            var view2 = new Grid();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            var navigationContext = new NavigationContext(null, new Uri(view2.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(view2, returnedView);
+        }
+
+        [Fact]
+        public void WhenRegionHasMultipleViews_ThenViewsWithMatchingFullTypeNameAreConsidered()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+            //containerMock.As<IContainerInfo>()
+            //    .Setup(x => x.GetRegistrationType("Xamarin.Forms.Grid"))
+            //    .Returns(typeof(Grid));
+            
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var region = new Region();
+
+            var view1 = new TestView();
+            var view2 = new Grid();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            var navigationContext = new NavigationContext(null, new Uri(view2.GetType().FullName, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(view2, returnedView);
+        }
+
+        [Fact]
+        public void WhenViewExistsAndImplementsIRegionAware_ThenViewIsQueriedForNavigationAndIsReturnedIfAcceptsIt()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+
+            var region = new Region();
+
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IRegionAware>()
+                .Setup(v => v.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(true)
+                .Verifiable();
+
+            region.Add(viewMock.Object);
+
+            var navigationContext = new NavigationContext(null, new Uri(viewMock.Object.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(viewMock.Object, returnedView);
+            viewMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenViewExistsAndHasDataContextThatImplementsIRegionAware_ThenDataContextIsQueriedForNavigationAndIsReturnedIfAcceptsIt()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+
+            var region = new Region();
+
+            var bindingContextMock = new Mock<IRegionAware>();
+            bindingContextMock
+                .Setup(v => v.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(true)
+                .Verifiable();
+            var viewMock = new Mock<View>();
+            viewMock.Object.BindingContext = bindingContextMock.Object;
+
+            region.Add(viewMock.Object);
+
+            var navigationContext = new NavigationContext(null, new Uri(viewMock.Object.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(viewMock.Object, returnedView);
+            bindingContextMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenNoCurrentMatchingViewExists_ThenReturnsNewlyCreatedInstanceWithServiceLocatorAddedToTheRegion()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+
+            var region = new Region();
+
+            var view = new TestView();
+
+            containerMock.Setup(sl => sl.Resolve(typeof(object), view.GetType().Name)).Returns(view);
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var navigationContext = new NavigationContext(null, new Uri(view.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(view, returnedView);
+            Assert.True(region.Views.Contains(view));
+        }
+
+        [Fact]
+        public void WhenViewExistsAndImplementsIRegionAware_ThenViewIsQueriedForNavigationAndNewInstanceIsCreatedIfItRejectsIt()
+        {
+            // Arrange
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var region = new Region();
+
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IRegionAware>()
+                .Setup(v => v.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(false)
+                .Verifiable();
+
+            region.Add(viewMock.Object);
+
+            var newView = new TestView();
+
+            containerMock.Setup(sl => sl.Resolve(typeof(object), viewMock.Object.GetType().Name)).Returns(newView);
+
+            var navigationContext = new NavigationContext(null, new Uri(viewMock.Object.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            // Act
+
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+
+            // Assert
+
+            Assert.Same(newView, returnedView);
+            Assert.True(region.Views.Contains(newView));
+            viewMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenViewExistsAndHasDataContextThatImplementsIRegionAware_ThenDataContextIsQueriedForNavigationAndNewInstanceIsCreatedIfItRejectsIt()
+        {
+            // Arrange
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var region = new Region();
+
+            var bindingContextMock = new Mock<IRegionAware>();
+            bindingContextMock
+                .Setup(v => v.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(false)
+                .Verifiable();
+            var viewMock = new Mock<View>();
+            viewMock.Object.BindingContext = bindingContextMock.Object;
+
+            region.Add(viewMock.Object);
+
+            var newView = new TestView();
+
+            containerMock.Setup(sl => sl.Resolve(typeof(object), viewMock.Object.GetType().Name)).Returns(newView);
+
+            var navigationContext = new NavigationContext(null, new Uri(viewMock.Object.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+            // Act
+            var returnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+            // Assert
+            Assert.Same(newView, returnedView);
+            Assert.True(region.Views.Contains(newView));
+            bindingContextMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenViewCannotBeCreated_ThenThrowsAnException()
+        {
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(object), typeof(TestView).Name))
+                .Throws(new ContainerResolutionException(typeof(object), typeof(TestView).Name, null));
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var region = new Region();
+
+            var navigationContext = new NavigationContext(null, new Uri(typeof(TestView).Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+            // Act
+            var ex = Record.Exception(() => navigationTargetHandler.LoadContent(region, navigationContext));
+            Assert.IsType<ContainerResolutionException>(ex);
+        }
+
+        [Fact]
+        public void WhenViewAddedByHandlerDoesNotImplementIRegionAware_ThenReturnsView()
+        {
+            // Arrange
+            var containerMock = new Mock<IContainerExtension>();
+
+            var region = new Region();
+
+            var view = new Grid();
+
+            containerMock.Setup(x => x.Resolve(typeof(object), view.GetType().Name)).Returns(view);
+            containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
+                .Returns(new RegionResolverOverrides());
+
+            var navigationContext = new NavigationContext(null, new Uri(view.GetType().Name, UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+            // Act
+            var firstReturnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+            var secondReturnedView = navigationTargetHandler.LoadContent(region, navigationContext);
+
+            // Assert
+            Assert.Same(view, firstReturnedView);
+            Assert.Same(view, secondReturnedView);
+            containerMock.Verify(sl => sl.Resolve(typeof(object), view.GetType().Name), Times.Once());
+        }
+
+        [Fact]
+        public void WhenRequestingContentForNullRegion_ThenThrows()
+        {
+            var containerMock = new Mock<IContainerExtension>();
+
+            var navigationContext = new NavigationContext(null, new Uri("/", UriKind.Relative));
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            ExceptionAssert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    navigationTargetHandler.LoadContent(null, navigationContext);
+
+                });
+        }
+
+        [Fact]
+        public void WhenRequestingContentForNullContext_ThenThrows()
+        {
+            var containerMock = new Mock<IContainerExtension>();
+
+            var region = new Region();
+
+            var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
+
+
+            ExceptionAssert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    navigationTargetHandler.LoadContent(region, null);
+
+                });
+        }
+
+        public class TestRegionNavigationContentLoader : RegionNavigationContentLoader
+        {
+            public TestRegionNavigationContentLoader(IContainerExtension container)
+                : base(container)
+            { }
+        }
+
+        public class TestView : Xamarin.Forms.View { }
+    }
+
+    public class ActivationException : Exception
+    {
+        public ActivationException()
+        {
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/NavigationAsyncExtensionsFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/NavigationAsyncExtensionsFixture.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Prism.Regions.Navigation;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class NavigationAsyncExtensionsFixture
+    {
+        [Fact]
+        public void WhenNavigatingWithANullThis_ThenThrows()
+        {
+            INavigateAsync navigate = null;
+            string target = "";
+
+            ExceptionAssert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    navigate.RequestNavigate(target);
+                });
+        }
+
+        [Fact]
+        public void WhenNavigatingWithANullStringTarget_ThenThrows()
+        {
+            INavigateAsync navigate = new Mock<INavigateAsync>().Object;
+            string target = null;
+
+            ExceptionAssert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    navigate.RequestNavigate(target);
+                });
+        }
+
+        [Fact]
+        public void WhenNavigatingWithARelativeStringTarget_ThenNavigatesToRelativeUri()
+        {
+            var navigateMock = new Mock<INavigateAsync>();
+            navigateMock
+                .Setup(nv =>
+                    nv.RequestNavigate(
+                        It.Is<Uri>(u => !u.IsAbsoluteUri && u.OriginalString == "relative"),
+                        It.Is<Action<IRegionNavigationResult>>(c => c != null)))
+                .Verifiable();
+
+            string target = "relative";
+
+            navigateMock.Object.RequestNavigate(target);
+
+            navigateMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenNavigatingWithAnAbsoluteStringTarget_ThenNavigatesToAbsoluteUri()
+        {
+            var navigateMock = new Mock<INavigateAsync>();
+            navigateMock
+                .Setup(nv =>
+                    nv.RequestNavigate(
+                        It.Is<Uri>(u => u.IsAbsoluteUri && u.Host == "test" && u.AbsolutePath == "/path"),
+                        It.Is<Action<IRegionNavigationResult>>(c => c != null)))
+                .Verifiable();
+
+            string target = "http://test/path";
+
+            navigateMock.Object.RequestNavigate(target);
+
+            navigateMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenNavigatingWithANullThisAndAUri_ThenThrows()
+        {
+            INavigateAsync navigate = null;
+            Uri target = new Uri("test", UriKind.Relative);
+
+            ExceptionAssert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    navigate.RequestNavigate(target);
+                });
+        }
+
+        [Fact]
+        public void WhenNavigatingWithAUri_ThenNavigatesToUriWithCallback()
+        {
+            Uri target = new Uri("relative", UriKind.Relative);
+
+            var navigateMock = new Mock<INavigateAsync>();
+            navigateMock
+                .Setup(nv =>
+                    nv.RequestNavigate(
+                        target,
+                        It.Is<Action<IRegionNavigationResult>>(c => c != null)))
+                .Verifiable();
+
+
+            navigateMock.Object.RequestNavigate(target);
+
+            navigateMock.VerifyAll();
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/NavigationContextFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/NavigationContextFixture.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Prism.Regions;
+using Prism.Regions.Navigation;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class NavigationContextFixture
+    {
+        [Fact]
+        public void WhenCreatingANewContextForAUriWithAQuery_ThenNewContextInitializesPropertiesAndExtractsTheQuery()
+        {
+            var uri = new Uri("test?name=value", UriKind.Relative);
+
+            var navigationJournalMock = new Mock<IRegionNavigationJournal>();
+            var navigationServiceMock = new Mock<IRegionNavigationService>();
+
+            IRegion region = new Region();
+            navigationServiceMock.SetupGet(n => n.Region).Returns(region);
+            navigationServiceMock.SetupGet(x => x.Journal).Returns(navigationJournalMock.Object);
+
+            var context = new NavigationContext(navigationServiceMock.Object, uri);
+
+            Assert.Same(navigationServiceMock.Object, context.NavigationService);
+            Assert.Equal(uri, context.Uri);
+            Assert.Single(context.Parameters);
+            Assert.Equal("value", context.Parameters["name"]);
+        }
+
+        [Fact]
+        public void WhenCreatingANewContextForAUriWithNoQuery_ThenNewContextInitializesPropertiesGetsEmptyQuery()
+        {
+            var uri = new Uri("test", UriKind.Relative);
+
+            var navigationJournalMock = new Mock<IRegionNavigationJournal>();
+
+            var navigationServiceMock = new Mock<IRegionNavigationService>();
+            navigationServiceMock.SetupGet(x => x.Journal).Returns(navigationJournalMock.Object);
+
+            var context = new NavigationContext(navigationServiceMock.Object, uri);
+
+            Assert.Same(navigationServiceMock.Object, context.NavigationService);
+            Assert.Equal(uri, context.Uri);
+            Assert.Empty(context.Parameters);
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionAdapterBaseFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionAdapterBaseFixture.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Forms.Regions.Mocks;
+using Prism.Regions;
+using Prism.Regions.Adapters;
+using Xamarin.Forms;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionAdapterBaseFixture
+    {
+        [Fact]
+        public void IncorrectTypeThrows()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                IRegionAdapter adapter = new TestableRegionAdapterBase();
+                adapter.Initialize(new ContentView(), "Region1");
+            });
+        }
+
+        [Fact]
+        public void InitializeSetsRegionName()
+        {
+            IRegionAdapter adapter = new TestableRegionAdapterBase();
+            var region = adapter.Initialize(new MockRegionTarget(), "Region1");
+            Assert.Equal("Region1", region.Name);
+        }
+
+        [Fact]
+        public void NullRegionNameThrows()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+            {
+                IRegionAdapter adapter = new TestableRegionAdapterBase();
+                var region = adapter.Initialize(new MockRegionTarget(), null);
+            });
+
+        }
+
+        [Fact]
+        public void NullObjectThrows()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+            {
+                IRegionAdapter adapter = new TestableRegionAdapterBase();
+                adapter.Initialize(null, "Region1");
+            });
+
+        }
+
+
+        [Fact]
+        public void CreateRegionReturnValueIsPassedToAdapt()
+        {
+            var regionTarget = new MockRegionTarget();
+            var adapter = new TestableRegionAdapterBase();
+
+            adapter.Initialize(regionTarget, "Region1");
+
+            Assert.Same(adapter.CreateRegionReturnValue, adapter.AdaptArgumentRegion);
+            Assert.Same(regionTarget, adapter.adaptArgumentRegionTarget);
+        }
+
+        [Fact]
+        public void CreateRegionReturnValueIsPassedToAttachBehaviors()
+        {
+            var regionTarget = new MockRegionTarget();
+            var adapter = new TestableRegionAdapterBase();
+
+            var region = adapter.Initialize(regionTarget, "Region1");
+
+            Assert.Same(adapter.CreateRegionReturnValue, adapter.AttachBehaviorsArgumentRegion);
+            Assert.Same(regionTarget, adapter.attachBehaviorsArgumentTargetToAdapt);
+        }
+
+        class TestableRegionAdapterBase : RegionAdapterBase<MockRegionTarget>
+        {
+            public IRegion CreateRegionReturnValue = new MockPresentationRegion();
+            public IRegion AdaptArgumentRegion;
+            public MockRegionTarget adaptArgumentRegionTarget;
+            public IRegion AttachBehaviorsArgumentRegion;
+            public MockRegionTarget attachBehaviorsArgumentTargetToAdapt;
+
+            public TestableRegionAdapterBase() : base(null)
+            {
+
+            }
+
+            protected override void Adapt(IRegion region, MockRegionTarget regionTarget)
+            {
+                AdaptArgumentRegion = region;
+                adaptArgumentRegionTarget = regionTarget;
+            }
+
+            protected override IRegion CreateRegion()
+            {
+                return CreateRegionReturnValue;
+            }
+
+            protected override void AttachBehaviors(IRegion region, MockRegionTarget regionTarget)
+            {
+                AttachBehaviorsArgumentRegion = region;
+                attachBehaviorsArgumentTargetToAdapt = regionTarget;
+                base.AttachBehaviors(region, regionTarget);
+            }
+        }
+
+        class MockRegionTarget : View
+        {
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionAdapterMappingFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionAdapterMappingFixture.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Prism.Forms.Regions.Mocks;
+using Prism.Ioc;
+using Prism.Regions.Adapters;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionAdapterMappingsFixture
+    {
+        //[Fact]
+        //public void ShouldGetRegisteredMapping()
+        //{
+        //    var regionAdapterMappings = new RegionAdapterMappings();
+        //    Type registeredType = typeof(ItemsControl);
+        //    var regionAdapter = new MockRegionAdapter();
+
+        //    regionAdapterMappings.RegisterMapping(registeredType, regionAdapter);
+        //    var returnedAdapter = regionAdapterMappings.GetMapping(registeredType);
+
+        //    Assert.NotNull(returnedAdapter);
+        //    Assert.Same(regionAdapter, returnedAdapter);
+        //}
+
+        //[Fact]
+        //public void ShouldGetRegisteredMapping_UsingGenericControl()
+        //{
+        //    var regionAdapterMappings = new RegionAdapterMappings();
+        //    var regionAdapter = new MockRegionAdapter();
+
+        //    regionAdapterMappings.RegisterMapping<ItemsControl>(regionAdapter);
+
+        //    var returnedAdapter = regionAdapterMappings.GetMapping<ItemsControl>();
+
+        //    Assert.NotNull(returnedAdapter);
+        //    Assert.Same(regionAdapter, returnedAdapter);
+        //}
+
+        //[Fact]
+        //public void ShouldGetRegisteredMapping_UsingGenericControlAndAdapter()
+        //{
+        //    try
+        //    {
+        //        var regionAdapterMappings = new RegionAdapterMappings();
+        //        var regionAdapter = new MockRegionAdapter();
+
+        //        var containerMock = new Mock<IContainerExtension>();
+        //        containerMock.Setup(c => c.Resolve(typeof(MockRegionAdapter)))
+        //                     .Returns(regionAdapter);
+        //        ContainerLocator.ResetContainer();
+        //        ContainerLocator.SetContainerExtension(() => containerMock.Object);
+
+        //        regionAdapterMappings.RegisterMapping<ItemsControl, MockRegionAdapter>();
+
+        //        var returnedAdapter = regionAdapterMappings.GetMapping<ItemsControl>();
+
+        //        Assert.NotNull(returnedAdapter);
+        //        Assert.Same(regionAdapter, returnedAdapter);
+        //    }
+        //    finally
+        //    {
+        //        ContainerLocator.ResetContainer();
+        //    }
+        //}
+
+        //[Fact]
+        //public void ShouldGetMappingForDerivedTypesThanTheRegisteredOnes()
+        //{
+        //    var regionAdapterMappings = new RegionAdapterMappings();
+        //    var regionAdapter = new MockRegionAdapter();
+
+        //    regionAdapterMappings.RegisterMapping(typeof(ItemsControl), regionAdapter);
+        //    var returnedAdapter = regionAdapterMappings.GetMapping(typeof(ItemsControlDescendant));
+
+        //    Assert.NotNull(returnedAdapter);
+        //    Assert.Same(regionAdapter, returnedAdapter);
+        //}
+
+        [Fact]
+        public void GetMappingOfUnregisteredTypeThrows()
+        {
+            var ex = Assert.Throws<KeyNotFoundException>(() =>
+            {
+                var regionAdapterMappings = new RegionAdapterMappings();
+                regionAdapterMappings.GetMapping(typeof(object));
+            });
+
+        }
+
+        //[Fact]
+        //public void ShouldGetTheMostSpecializedMapping()
+        //{
+        //    var regionAdapterMappings = new RegionAdapterMappings();
+        //    var genericAdapter = new MockRegionAdapter();
+        //    var specializedAdapter = new MockRegionAdapter();
+
+        //    regionAdapterMappings.RegisterMapping(typeof(ItemsControl), genericAdapter);
+        //    regionAdapterMappings.RegisterMapping(typeof(ItemsControlDescendant), specializedAdapter);
+        //    var returnedAdapter = regionAdapterMappings.GetMapping(typeof(ItemsControlDescendant));
+
+        //    Assert.NotNull(returnedAdapter);
+        //    Assert.Same(specializedAdapter, returnedAdapter);
+        //}
+
+        //[Fact]
+        //public void RegisterAMappingThatAlreadyExistsThrows()
+        //{
+        //    var ex = Assert.Throws<InvalidOperationException>(() =>
+        //    {
+        //        var regionAdapterMappings = new RegionAdapterMappings();
+        //        var regionAdapter = new MockRegionAdapter();
+
+        //        regionAdapterMappings.RegisterMapping(typeof(ItemsControl), regionAdapter);
+        //        regionAdapterMappings.RegisterMapping(typeof(ItemsControl), regionAdapter);
+        //    });
+        //}
+
+        //[Fact]
+        //public void NullControlThrows()
+        //{
+        //    var ex = Assert.Throws<ArgumentNullException>(() =>
+        //    {
+        //        var regionAdapterMappings = new RegionAdapterMappings();
+        //        var regionAdapter = new MockRegionAdapter();
+
+        //        regionAdapterMappings.RegisterMapping(null, regionAdapter);
+        //    });
+
+        //}
+
+        //[Fact]
+        //public void NullAdapterThrows()
+        //{
+        //    var ex = Assert.Throws<ArgumentNullException>(() =>
+        //    {
+        //        var regionAdapterMappings = new RegionAdapterMappings();
+
+        //        regionAdapterMappings.RegisterMapping(typeof(ItemsControl), null);
+        //    });
+
+        //}
+
+        //class ItemsControlDescendant : ItemsControl { }
+
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionBehaviorCollectionFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionBehaviorCollectionFixture.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Forms.Regions.Mocks;
+using Prism.Regions.Behaviors;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionBehaviorCollectionFixture
+    {
+        [Fact]
+        public void CanAttachRegionBehaviors()
+        {
+            RegionBehaviorCollection behaviorCollection = new RegionBehaviorCollection(new MockPresentationRegion());
+
+            var mock1 = new MockRegionBehavior();
+            var mock1Attached = false;
+            mock1.OnAttach = () => mock1Attached = true;
+            behaviorCollection.Add("Mock1", mock1);
+
+            var mock2 = new MockRegionBehavior();
+            var mock2Attached = false;
+            mock2.OnAttach = () => mock2Attached = true;
+            behaviorCollection.Add("Mock2", mock2);
+
+            Assert.True(mock1Attached);
+            Assert.True(mock2Attached);
+        }
+
+        [Fact]
+        public void ShouldAddRegionWhenAddingBehavior()
+        {
+            var region = new MockPresentationRegion();
+            var behaviorCollection = new RegionBehaviorCollection(region);
+            var behavior = new MockRegionBehavior();
+
+            behaviorCollection.Add("Mock", behavior);
+
+            Assert.NotNull(behavior.Region);
+            Assert.Same(region, behavior.Region);
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionBehaviorFactoryFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionBehaviorFactoryFixture.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using Prism.Forms.Regions.Mocks;
+using Prism.Ioc;
+using Prism.Regions.Behaviors;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionBehaviorFactoryFixture
+    {
+        [Fact]
+        public void CanRegisterType()
+        {
+            var factory = new RegionBehaviorFactory(null);
+
+            factory.AddIfMissing<MockRegionBehavior>("key1");
+            factory.AddIfMissing<MockRegionBehavior>("key2");
+
+            Assert.Equal(2, factory.Count());
+            Assert.True(factory.ContainsKey("key1"));
+        }
+
+        [Fact]
+        public void WillNotAddTypesWithDuplicateKeys()
+        {
+            var factory = new RegionBehaviorFactory(null);
+
+            factory.AddIfMissing<MockRegionBehavior>("key1");
+            factory.AddIfMissing<MockRegionBehavior>("key1");
+
+            Assert.Single(factory);
+        }
+
+        [Fact]
+        public void CanCreateRegisteredType()
+        {
+            var expectedBehavior = new MockRegionBehavior();
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(c => c.Resolve(typeof(MockRegionBehavior))).Returns(expectedBehavior);
+            var factory = new RegionBehaviorFactory(containerMock.Object);
+
+            factory.AddIfMissing<MockRegionBehavior>("key1");
+            var behavior = factory.CreateFromKey("key1");
+
+            Assert.Same(expectedBehavior, behavior);
+        }
+
+        [Fact]
+        public void CreateWithUnknownKeyThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                var factory = new RegionBehaviorFactory(null);
+
+                factory.CreateFromKey("Key1");
+            });
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionBehaviorFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionBehaviorFixture.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Forms.Regions.Mocks;
+using Prism.Regions.Behaviors;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionBehaviorFixture
+    {
+        [Fact]
+        public void CannotChangeRegionAfterAttach()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                TestableRegionBehavior regionBehavior = new TestableRegionBehavior
+                {
+                    Region = new MockPresentationRegion()
+                };
+
+                regionBehavior.Attach();
+                regionBehavior.Region = new MockPresentationRegion();
+            });
+        }
+
+        [Fact]
+        public void ShouldFailWhenAttachedWithoutRegion()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var regionBehavior = new TestableRegionBehavior();
+                regionBehavior.Attach();
+            });
+        }
+
+        [Fact]
+        public void ShouldCallOnAttachWhenAttachMethodIsInvoked()
+        {
+            var regionBehavior = new TestableRegionBehavior
+            {
+                Region = new MockPresentationRegion()
+            };
+
+            regionBehavior.Attach();
+
+            Assert.True(regionBehavior.onAttachCalled);
+        }
+
+        private class TestableRegionBehavior : RegionBehavior
+        {
+            public bool onAttachCalled;
+
+            protected override void OnAttach()
+            {
+                onAttachCalled = true;
+            }
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionFixture.cs
@@ -1,0 +1,563 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using Moq;
+using Prism.Ioc;
+using Prism.Navigation;
+using Prism.Regions;
+using Prism.Regions.Navigation;
+using Xamarin.Forms;
+using Xunit;
+using Region = Prism.Regions.Region;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionFixture
+    {
+        [Fact]
+        public void WhenRegionConstructed_SortComparisonIsDefault()
+        {
+            IRegion region = new Region();
+
+            Assert.NotNull(region.SortComparison);
+            Assert.Equal(region.SortComparison, Region.DefaultSortComparison);
+        }
+
+        [Fact]
+        public void CanAddContentToRegion()
+        {
+            IRegion region = new Region();
+
+            Assert.Empty(region.Views);
+
+            region.Add(new ContentView());
+
+            Assert.Single(region.Views);
+        }
+
+
+        [Fact]
+        public void CanRemoveContentFromRegion()
+        {
+            IRegion region = new Region();
+            var view = new ContentView();
+
+            region.Add(view);
+            region.Remove(view);
+
+            Assert.Empty(region.Views);
+        }
+
+        [Fact]
+        public void RemoveInexistentViewThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                IRegion region = new Region();
+                var view = new ContentView();
+
+                region.Remove(view);
+
+                Assert.Empty(region.Views);
+            });
+
+        }
+
+        [Fact]
+        public void RegionExposesCollectionOfContainedViews()
+        {
+            IRegion region = new Region();
+
+            var view = new ContentView();
+
+            region.Add(view);
+
+            var views = region.Views;
+
+            Assert.NotNull(views);
+            Assert.Single(views);
+            Assert.Same(view, views.ElementAt(0));
+        }
+
+        [Fact]
+        public void CanAddAndRetrieveNamedViewInstance()
+        {
+            IRegion region = new Region();
+            var myView = new ContentView();
+            region.Add(myView, "MyView");
+            object returnedView = region.GetView("MyView");
+
+            Assert.NotNull(returnedView);
+            Assert.Same(returnedView, myView);
+        }
+
+        [Fact]
+        public void AddingDuplicateNamedViewThrows()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                IRegion region = new Region();
+
+                region.Add(new ContentView(), "MyView");
+                region.Add(new ContentView(), "MyView");
+            });
+
+        }
+
+        [Fact]
+        public void AddNamedViewIsAlsoListedInViewsCollection()
+        {
+            IRegion region = new Region();
+            var myView = new ContentView();
+
+            region.Add(myView, "MyView");
+
+            Assert.Single(region.Views);
+            Assert.Same(myView, region.Views.ElementAt(0));
+        }
+
+        [Fact]
+        public void GetViewReturnsNullWhenViewDoesNotExistInRegion()
+        {
+            IRegion region = new Region();
+
+            Assert.Null(region.GetView("InexistentView"));
+        }
+
+
+        [Fact]
+        public void GetViewWithNullOrEmptyStringThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                IRegion region = new Region();
+
+                region.GetView(string.Empty);
+            });
+
+        }
+
+        [Fact]
+        public void AddNamedViewWithNullOrEmptyStringNameThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                IRegion region = new Region();
+
+                region.Add(new ContentView(), string.Empty);
+            });
+
+        }
+
+        [Fact]
+        public void GetViewReturnsNullAfterRemovingViewFromRegion()
+        {
+            IRegion region = new Region();
+            var myView = new ContentView();
+            region.Add(myView, "MyView");
+            region.Remove(myView);
+
+            Assert.Null(region.GetView("MyView"));
+        }
+
+        [Fact]
+        public void AddViewPassesSameScopeByDefaultToView()
+        {
+            var regionManager = Mock.Of<IRegionManager>();
+            IRegion region = new Region
+            {
+                RegionManager = regionManager
+            };
+            var myView = new ContentView();
+
+            region.Add(myView);
+
+            Assert.Same(regionManager, myView.GetValue(Prism.Regions.Xaml.RegionManager.RegionManagerProperty));
+        }
+
+        [Fact]
+        public void AddViewPassesSameScopeByDefaultToNamedView()
+        {
+            var regionManager = Mock.Of<IRegionManager>();
+            IRegion region = new Region
+            {
+                RegionManager = regionManager
+            };
+            var myView = new ContentView();
+
+            region.Add(myView, "MyView");
+
+            Assert.Same(regionManager, myView.GetValue(Prism.Regions.Xaml.RegionManager.RegionManagerProperty));
+        }
+
+        [Fact]
+        public void AddViewPassesDiferentScopeWhenAdding()
+        {
+            var regionManager = Mock.Of<IRegionManager>();
+            IRegion region = new Region
+            {
+                RegionManager = regionManager
+            };
+            var myView = new ContentView();
+
+            region.Add(myView, "MyView", true);
+
+            Assert.NotSame(regionManager, myView.GetValue(Prism.Regions.Xaml.RegionManager.RegionManagerProperty));
+        }
+
+        [Fact]
+        public void CreatingNewScopesAsksTheRegionManagerForNewInstance()
+        {
+            var regionManagerMock = new Mock<IRegionManager>();
+            var createRegionManagerCalled = false;
+            regionManagerMock.Setup(x => x.CreateRegionManager())
+                .Callback(() => createRegionManagerCalled = true)
+                .Returns(Mock.Of<IRegionManager>());
+
+            IRegion region = new Region
+            {
+                RegionManager = regionManagerMock.Object
+            };
+            var myView = new ContentView();
+
+            region.Add(myView, "MyView", true);
+
+            Assert.True(createRegionManagerCalled);
+        }
+
+        [Fact]
+        public void AddViewReturnsExistingRegionManager()
+        {
+            var regionManager = Mock.Of<IRegionManager>();
+            IRegion region = new Region
+            {
+                RegionManager = regionManager
+            };
+            var myView = new ContentView();
+
+            var returnedRegionManager = region.Add(myView, "MyView", false);
+
+            Assert.Same(regionManager, returnedRegionManager);
+        }
+
+        [Fact]
+        public void AddViewReturnsNewRegionManager()
+        {
+            var regionManager = Mock.Of<IRegionManager>();
+            IRegion region = new Region
+            {
+                RegionManager = regionManager
+            };
+            var myView = new ContentView();
+
+            var returnedRegionManager = region.Add(myView, "MyView", true);
+
+            Assert.NotSame(regionManager, returnedRegionManager);
+        }
+
+        [Fact]
+        public void AddingNonDependencyObjectToRegionDoesNotThrow()
+        {
+            IRegion region = new Region();
+            var model = new ContentView();
+
+            region.Add(model);
+
+            Assert.Single(region.Views);
+        }
+
+        [Fact]
+        public void ActivateNonAddedViewThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                IRegion region = new Region();
+
+                var nonAddedView = new ContentView();
+
+                region.Activate(nonAddedView);
+            });
+
+        }
+
+        [Fact]
+        public void DeactivateNonAddedViewThrows()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                IRegion region = new Region();
+
+                var nonAddedView = new ContentView();
+
+                region.Deactivate(nonAddedView);
+            });
+
+        }
+
+        [Fact]
+        public void ActivateNullViewThrows()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+            {
+                IRegion region = new Region();
+
+                region.Activate(null);
+            });
+
+        }
+
+        [Fact]
+        public void AddViewRaisesCollectionViewEvent()
+        {
+            bool viewAddedCalled = false;
+
+            IRegion region = new Region();
+            region.Views.CollectionChanged += (sender, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Add)
+                    viewAddedCalled = true;
+            };
+
+            var model = new ContentView();
+            Assert.False(viewAddedCalled);
+            region.Add(model);
+
+            Assert.True(viewAddedCalled);
+        }
+
+        [Fact]
+        public void ViewAddedEventPassesTheViewAddedInTheEventArgs()
+        {
+            VisualElement viewAdded = null;
+
+            IRegion region = new Region();
+            region.Views.CollectionChanged += (sender, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Add)
+                {
+                    viewAdded = (VisualElement)e.NewItems[0];
+                }
+            };
+            var model = new ContentView();
+            Assert.Null(viewAdded);
+            region.Add(model);
+
+            Assert.NotNull(viewAdded);
+            Assert.Same(model, viewAdded);
+        }
+
+        [Fact]
+        public void RemoveViewFiresViewRemovedEvent()
+        {
+            bool viewRemoved = false;
+
+            IRegion region = new Region();
+            var model = new ContentView();
+            region.Views.CollectionChanged += (sender, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Remove)
+                    viewRemoved = true;
+            };
+
+            region.Add(model);
+            Assert.False(viewRemoved);
+
+            region.Remove(model);
+
+            Assert.True(viewRemoved);
+        }
+
+        [Fact]
+        public void ViewRemovedEventPassesTheViewRemovedInTheEventArgs()
+        {
+            VisualElement removedView = null;
+
+            IRegion region = new Region();
+            region.Views.CollectionChanged += (sender, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Remove)
+                    removedView = (VisualElement)e.OldItems[0];
+            };
+            var model = new ContentView();
+            region.Add(model);
+            Assert.Null(removedView);
+
+            region.Remove(model);
+
+            Assert.Same(model, removedView);
+        }
+
+        [Fact]
+        public void ShowViewFiresViewShowedEvent()
+        {
+            bool viewActivated = false;
+
+            IRegion region = new Region();
+            var model = new ContentView();
+            region.ActiveViews.CollectionChanged += (o, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems.Contains(model))
+                    viewActivated = true;
+            };
+            region.Add(model);
+            Assert.False(viewActivated);
+
+            region.Activate(model);
+
+            Assert.True(viewActivated);
+        }
+
+        [Fact]
+        public void AddingSameViewTwiceThrows()
+        {
+            var view = new ContentView();
+            IRegion region = new Region();
+            region.Add(view);
+
+            try
+            {
+                region.Add(view);
+                //Assert.Fail();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Assert.Equal("View already exists in region.", ex.Message);
+            }
+            catch
+            {
+                //Assert.Fail();
+            }
+        }
+
+        [Fact]
+        public void RemovingViewAlsoRemovesItFromActiveViews()
+        {
+            IRegion region = new Region();
+            var model = new ContentView();
+            region.Add(model);
+            region.Activate(model);
+            Assert.True(region.ActiveViews.Contains(model));
+
+            region.Remove(model);
+
+            Assert.False(region.ActiveViews.Contains(model));
+        }
+
+        [Fact]
+        public void ShouldGetNotificationWhenContextChanges()
+        {
+            IRegion region = new Region();
+            bool contextChanged = false;
+            region.PropertyChanged += (s, args) => { if (args.PropertyName == "Context") contextChanged = true; };
+
+            region.Context = "MyNewContext";
+
+            Assert.True(contextChanged);
+        }
+
+        [Fact]
+        public void ChangingNameOnceItIsSetThrows()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var region = new Region
+                {
+                    Name = "MyRegion"
+                };
+
+                region.Name = "ChangedRegionName";
+            });
+
+        }
+
+        [Fact]
+        public void NavigateDelegatesToIRegionNavigationService()
+        {
+            try
+            {
+                // Prepare
+                IRegion region = new Region();
+
+                var view = new ContentView();
+                region.Add(view);
+
+                var uri = new Uri(view.GetType().Name, UriKind.Relative);
+                Action<IRegionNavigationResult> navigationCallback = nr => { };
+                var navigationParameters = new NavigationParameters();
+
+                var mockRegionNavigationService = new Mock<IRegionNavigationService>();
+                mockRegionNavigationService.Setup(x => x.RequestNavigate(uri, navigationCallback, navigationParameters)).Verifiable();
+
+                var containerMock = new Mock<IContainerExtension>();
+                containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationService))).Returns(mockRegionNavigationService.Object);
+                ContainerLocator.ResetContainer();
+                ContainerLocator.SetContainerExtension(() => containerMock.Object);
+
+                // Act
+                region.NavigationService.RequestNavigate(uri, navigationCallback, navigationParameters);
+
+                // Verify
+                mockRegionNavigationService.VerifyAll();
+            }
+            finally
+            {
+                ContainerLocator.ResetContainer();
+            }
+        }
+
+        [Fact]
+        public void WhenViewsWithSortHintsAdded_RegionSortsViews()
+        {
+            IRegion region = new Region();
+
+            var view1 = new ViewOrder1();
+            var view2 = new ViewOrder2();
+            var view3 = new ViewOrder3();
+
+            region.Add(view1);
+            region.Add(view2);
+            region.Add(view3);
+
+            Assert.Equal(3, region.Views.Count());
+            Assert.Same(view2, region.Views.ElementAt(0));
+            Assert.Same(view3, region.Views.ElementAt(1));
+            Assert.Same(view1, region.Views.ElementAt(2));
+        }
+
+        [Fact]
+        public void WhenViewHasBeenRemovedAndRegionManagerPropertyCleared_ThenItCanBeAddedAgainToARegion()
+        {
+            var regionManagerMock = new Mock<IRegionManager>();
+            regionManagerMock.Setup(x => x.CreateRegionManager())
+                .Returns(Mock.Of<IRegionManager>());
+            IRegion region = new Region { RegionManager = regionManagerMock.Object };
+
+            var view = new ContentView();
+
+            var scopedRegionManager = region.Add(view, null, true);
+
+            Assert.Equal(view, region.Views.First());
+
+            region.Remove(view);
+
+            view.ClearValue(Prism.Regions.Xaml.RegionManager.RegionManagerProperty);
+
+            Assert.Empty(region.Views);
+
+            var newScopedRegion = region.Add(view, null, true);
+
+            Assert.Equal(view, region.Views.First());
+
+            Assert.Same(newScopedRegion, view.GetValue(Prism.Regions.Xaml.RegionManager.RegionManagerProperty));
+        }
+
+        [ViewSortHint("C")]
+        private class ViewOrder1 : View { };
+        [ViewSortHint("A")]
+        private class ViewOrder2 : View { };
+        [ViewSortHint("B")]
+        private class ViewOrder3 : View { };
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionManagerFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionManagerFixture.cs
@@ -1,0 +1,500 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Prism.Forms.Regions.Mocks;
+using Prism.Ioc;
+using Prism.Regions;
+using Xamarin.Forms;
+using Xunit;
+using Region = Prism.Regions.Region;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionManagerFixture
+    {
+        [Fact]
+        public void CanAddRegion()
+        {
+            IRegion region1 = new MockPresentationRegion();
+            region1.Name = "MainRegion";
+
+            var regionManager = new RegionManager();
+            regionManager.Regions.Add(region1);
+
+            IRegion region2 = regionManager.Regions["MainRegion"];
+            Assert.Same(region1, region2);
+        }
+
+        [Fact]
+        public void ShouldFailIfRegionDoesntExists()
+        {
+            var ex = Assert.Throws<KeyNotFoundException>(() =>
+            {
+                var regionManager = new RegionManager();
+                IRegion region = regionManager.Regions["nonExistentRegion"];
+            });
+        }
+
+        [Fact]
+        public void CanCheckTheExistenceOfARegion()
+        {
+            var regionManager = new RegionManager();
+            bool result = regionManager.Regions.ContainsRegionWithName("noRegion");
+
+            Assert.False(result);
+
+            IRegion region = new MockPresentationRegion
+            {
+                Name = "noRegion"
+            };
+            regionManager.Regions.Add(region);
+
+            result = regionManager.Regions.ContainsRegionWithName("noRegion");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AddingMultipleRegionsWithSameNameThrowsArgumentException()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                var regionManager = new RegionManager();
+                regionManager.Regions.Add(new MockPresentationRegion { Name = "region name" });
+                regionManager.Regions.Add(new MockPresentationRegion { Name = "region name" });
+            });
+
+        }
+
+        [Fact]
+        public void AddPassesItselfAsTheRegionManagerOfTheRegion()
+        {
+            var regionManager = new RegionManager();
+            var region = new MockPresentationRegion
+            {
+                Name = "region"
+            };
+            regionManager.Regions.Add(region);
+
+            Assert.Same(regionManager, region.RegionManager);
+        }
+
+        [Fact]
+        public void CreateRegionManagerCreatesANewInstance()
+        {
+            var regionManager = new RegionManager();
+            var createdRegionManager = regionManager.CreateRegionManager();
+            Assert.NotNull(createdRegionManager);
+            Assert.IsType<RegionManager>(createdRegionManager);
+            Assert.NotSame(regionManager, createdRegionManager);
+        }
+
+        [Fact]
+        public void CanRemoveRegion()
+        {
+            var regionManager = new RegionManager();
+            IRegion region = new MockPresentationRegion
+            {
+                Name = "TestRegion"
+            };
+            regionManager.Regions.Add(region);
+
+            regionManager.Regions.Remove("TestRegion");
+
+            Assert.False(regionManager.Regions.ContainsRegionWithName("TestRegion"));
+        }
+
+        [Fact]
+        public void ShouldRemoveRegionManagerWhenRemoving()
+        {
+            var regionManager = new RegionManager();
+            var region = new MockPresentationRegion
+            {
+                Name = "TestRegion"
+            };
+            regionManager.Regions.Add(region);
+
+            regionManager.Regions.Remove("TestRegion");
+
+            Assert.Null(region.RegionManager);
+        }
+
+        [Fact]
+        public void UpdatingRegionsGetsCalledWhenAccessingRegionMembers()
+        {
+            var listener = new MySubscriberClass();
+
+            try
+            {
+                Prism.Regions.Xaml.RegionManager.UpdatingRegions += listener.OnUpdatingRegions;
+                var regionManager = new RegionManager();
+                regionManager.Regions.ContainsRegionWithName("TestRegion");
+                Assert.True(listener.OnUpdatingRegionsCalled);
+
+                listener.OnUpdatingRegionsCalled = false;
+                regionManager.Regions.Add(new MockPresentationRegion() { Name = "TestRegion" });
+                Assert.True(listener.OnUpdatingRegionsCalled);
+
+                listener.OnUpdatingRegionsCalled = false;
+                var region = regionManager.Regions["TestRegion"];
+                Assert.True(listener.OnUpdatingRegionsCalled);
+
+                listener.OnUpdatingRegionsCalled = false;
+                regionManager.Regions.Remove("TestRegion");
+                Assert.True(listener.OnUpdatingRegionsCalled);
+
+                listener.OnUpdatingRegionsCalled = false;
+                regionManager.Regions.GetEnumerator();
+                Assert.True(listener.OnUpdatingRegionsCalled);
+            }
+            finally
+            {
+                Prism.Regions.Xaml.RegionManager.UpdatingRegions -= listener.OnUpdatingRegions;
+            }
+        }
+
+        [Fact]
+        public void ShouldSetObservableRegionContextWhenRegionContextChanges()
+        {
+            var region = new MockPresentationRegion();
+            var view = new ContentView();
+
+            var observableObject = RegionContext.GetObservableContext(view);
+
+            bool propertyChangedCalled = false;
+            observableObject.PropertyChanged += (sender, args) => propertyChangedCalled = true;
+
+            Assert.Null(observableObject.Value);
+            Prism.Regions.Xaml.RegionManager.SetRegionContext(view, "MyContext");
+            Assert.True(propertyChangedCalled);
+            Assert.Equal("MyContext", observableObject.Value);
+        }
+
+        [Fact]
+        public async Task ShouldNotPreventSubscribersToStaticEventFromBeingGarbageCollected()
+        {
+            var subscriber = new MySubscriberClass();
+            Prism.Regions.Xaml.RegionManager.UpdatingRegions += subscriber.OnUpdatingRegions;
+            Prism.Regions.Xaml.RegionManager.UpdateRegions();
+            Assert.True(subscriber.OnUpdatingRegionsCalled);
+            var subscriberWeakReference = new WeakReference(subscriber);
+
+            subscriber = null;
+            await Task.Delay(100);
+            GC.Collect();
+
+            Assert.False(subscriberWeakReference.IsAlive);
+        }
+
+        [Fact]
+        public void ExceptionMessageWhenCallingUpdateRegionsShouldBeClear()
+        {
+            try
+            {
+                ExceptionExtensions.RegisterFrameworkExceptionType(typeof(FrameworkException));
+                Prism.Regions.Xaml.RegionManager.UpdatingRegions += new EventHandler(RegionManager_UpdatingRegions);
+
+                try
+                {
+                    Prism.Regions.Xaml.RegionManager.UpdateRegions();
+                    //Assert.Fail();
+                }
+                catch (Exception ex)
+                {
+                    Assert.Contains("Abcde", ex.Message);
+                }
+            }
+            finally
+            {
+                Prism.Regions.Xaml.RegionManager.UpdatingRegions -= new EventHandler(RegionManager_UpdatingRegions);
+            }
+        }
+
+        private void RegionManager_UpdatingRegions(object sender, EventArgs e)
+        {
+            try
+            {
+                throw new Exception("Abcde");
+            }
+            catch (Exception ex)
+            {
+                throw new FrameworkException(ex);
+            }
+        }
+
+
+        internal class MySubscriberClass
+        {
+            public bool OnUpdatingRegionsCalled;
+
+            public void OnUpdatingRegions(object sender, EventArgs e)
+            {
+                OnUpdatingRegionsCalled = true;
+            }
+        }
+
+        [Fact]
+        public void WhenAddingRegions_ThenRegionsCollectionNotifiesUpdate()
+        {
+            var regionManager = new RegionManager();
+
+            var region1 = new Region { Name = "region1" };
+            var region2 = new Region { Name = "region2" };
+
+            NotifyCollectionChangedEventArgs args = null;
+            regionManager.Regions.CollectionChanged += (s, e) => args = e;
+
+            regionManager.Regions.Add(region1);
+
+            Assert.Equal(NotifyCollectionChangedAction.Add, args.Action);
+            Assert.Equal(new object[] { region1 }, args.NewItems);
+            Assert.Equal(0, args.NewStartingIndex);
+            Assert.Null(args.OldItems);
+            Assert.Equal(-1, args.OldStartingIndex);
+
+            regionManager.Regions.Add(region2);
+
+            Assert.Equal(NotifyCollectionChangedAction.Add, args.Action);
+            Assert.Equal(new object[] { region2 }, args.NewItems);
+            Assert.Equal(0, args.NewStartingIndex);
+            Assert.Null(args.OldItems);
+            Assert.Equal(-1, args.OldStartingIndex);
+        }
+
+        [Fact]
+        public void WhenRemovingRegions_ThenRegionsCollectionNotifiesUpdate()
+        {
+            var regionManager = new RegionManager();
+
+            var region1 = new Region { Name = "region1" };
+            var region2 = new Region { Name = "region2" };
+
+            regionManager.Regions.Add(region1);
+            regionManager.Regions.Add(region2);
+
+            NotifyCollectionChangedEventArgs args = null;
+            regionManager.Regions.CollectionChanged += (s, e) => args = e;
+
+            regionManager.Regions.Remove("region2");
+
+            Assert.Equal(NotifyCollectionChangedAction.Remove, args.Action);
+            Assert.Equal(new object[] { region2 }, args.OldItems);
+            Assert.Equal(0, args.OldStartingIndex);
+            Assert.Null(args.NewItems);
+            Assert.Equal(-1, args.NewStartingIndex);
+
+            regionManager.Regions.Remove("region1");
+
+            Assert.Equal(NotifyCollectionChangedAction.Remove, args.Action);
+            Assert.Equal(new object[] { region1 }, args.OldItems);
+            Assert.Equal(0, args.OldStartingIndex);
+            Assert.Null(args.NewItems);
+            Assert.Equal(-1, args.NewStartingIndex);
+        }
+
+        [Fact]
+        public void WhenRemovingNonExistingRegion_ThenRegionsCollectionDoesNotNotifyUpdate()
+        {
+            var regionManager = new RegionManager();
+
+            var region1 = new Region { Name = "region1" };
+
+            regionManager.Regions.Add(region1);
+
+            NotifyCollectionChangedEventArgs args = null;
+            regionManager.Regions.CollectionChanged += (s, e) => args = e;
+
+            regionManager.Regions.Remove("region2");
+
+            Assert.Null(args);
+        }
+
+        //[Fact]
+        //public void CanAddViewToRegion()
+        //{
+        //    var regionManager = new RegionManager();
+        //    var view1 = new ContentView();
+        //    var view2 = new StackLayout();
+
+
+        //    IRegion region = new MockRegion
+        //    {
+        //        Name = "RegionName"
+        //    };
+        //    regionManager.Regions.Add(region);
+
+        //    regionManager.AddToRegion("RegionName", view1);
+        //    regionManager.AddToRegion("RegionName", view2);
+
+        //    Assert.True(regionManager.Regions["RegionName"].Views.Contains(view1));
+        //    Assert.True(regionManager.Regions["RegionName"].Views.Contains(view2));
+        //}
+
+        [Fact]
+        public void CanRegisterViewType()
+        {
+            try
+            {
+                var mockRegionContentRegistry = new MockRegionContentRegistry();
+
+                string regionName = null;
+                Type viewType = null;
+
+                mockRegionContentRegistry.RegisterContentWithViewType = (name, type) =>
+                {
+                    regionName = name;
+                    viewType = type;
+                    return null;
+                };
+                var containerMock = new Mock<IContainerExtension>();
+                containerMock.Setup(c => c.Resolve(typeof(IRegionViewRegistry))).Returns(mockRegionContentRegistry);
+                ContainerLocator.SetContainerExtension(() => containerMock.Object);
+
+                var regionManager = new RegionManager();
+
+                regionManager.RegisterViewWithRegion("Region1", typeof(object));
+
+                Assert.Equal("Region1", regionName);
+                Assert.Equal(typeof(object), viewType);
+
+
+            }
+            finally
+            {
+                ContainerLocator.ResetContainer();
+            }
+        }
+
+        [Fact]
+        public void CanRegisterViewTypeGeneric()
+        {
+            try
+            {
+                var mockRegionContentRegistry = new MockRegionContentRegistry();
+
+                string regionName = null;
+                Type viewType = null;
+
+                mockRegionContentRegistry.RegisterContentWithViewType = (name, type) =>
+                {
+                    regionName = name;
+                    viewType = type;
+                    return null;
+                };
+                var containerMock = new Mock<IContainerExtension>();
+                containerMock.Setup(c => c.Resolve(typeof(IRegionViewRegistry))).Returns(mockRegionContentRegistry);
+                ContainerLocator.ResetContainer();
+                ContainerLocator.SetContainerExtension(() => containerMock.Object);
+
+                var regionManager = new RegionManager();
+
+                regionManager.RegisterViewWithRegion<object>("Region1");
+
+                Assert.Equal("Region1", regionName);
+                Assert.Equal(typeof(object), viewType);
+
+
+            }
+            finally
+            {
+                ContainerLocator.ResetContainer();
+            }
+        }
+
+        //[Fact]
+        //public void CanRegisterDelegate()
+        //{
+        //    try
+        //    {
+        //        ContainerLocator.ResetContainer();
+        //        var mockRegionContentRegistry = new MockRegionContentRegistry();
+
+        //        string regionName = null;
+        //        Func<object> contentDelegate = null;
+
+        //        Func<object> expectedDelegate = () => true;
+        //        mockRegionContentRegistry.RegisterContentWithDelegate = (name, usedDelegate) =>
+        //        {
+        //            regionName = name;
+        //            contentDelegate = usedDelegate;
+        //            return null;
+        //        };
+        //        var containerMock = new Mock<IContainerExtension>();
+        //        containerMock.Setup(c => c.Resolve(typeof(IRegionViewRegistry))).Returns(mockRegionContentRegistry);
+        //        ContainerLocator.SetContainerExtension(() => containerMock.Object);
+
+        //        var regionManager = new RegionManager();
+
+        //        regionManager.RegisterViewWithRegion("Region1", expectedDelegate);
+
+        //        Assert.Equal("Region1", regionName);
+        //        Assert.Equal(expectedDelegate, contentDelegate);
+        //    }
+        //    finally
+        //    {
+        //        ContainerLocator.ResetContainer();
+        //    }
+        //}
+
+        [Fact]
+        public void CanAddRegionToRegionManager()
+        {
+            var regionManager = new RegionManager();
+            var region = new MockRegion();
+
+            regionManager.Regions.Add("region", region);
+
+            Assert.Single(regionManager.Regions);
+            Assert.Equal("region", region.Name);
+        }
+
+        [Fact]
+        public void ShouldThrowIfRegionNameArgumentIsDifferentToRegionNameProperty()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                var regionManager = new RegionManager();
+                var region = new MockRegion
+                {
+                    Name = "region"
+                };
+
+                regionManager.Regions.Add("another region", region);
+            });
+        }
+    }
+
+    internal class FrameworkException : Exception
+    {
+        public FrameworkException(Exception inner)
+            : base(string.Empty, inner)
+        {
+
+        }
+    }
+
+    internal class MockRegionContentRegistry : IRegionViewRegistry
+    {
+        public Func<string, Type, object> RegisterContentWithViewType;
+        public Func<string, Func<object>, object> RegisterContentWithDelegate;
+        public event EventHandler<ViewRegisteredEventArgs> ContentRegistered;
+        public IEnumerable<object> GetContents(string regionName)
+        {
+            return null;
+        }
+
+        void IRegionViewRegistry.RegisterViewWithRegion(string regionName, Type viewType)
+        {
+            RegisterContentWithViewType?.Invoke(regionName, viewType);
+        }
+
+        void IRegionViewRegistry.RegisterViewWithRegion(string regionName, Func<object> getContentDelegate)
+        {
+            RegisterContentWithDelegate?.Invoke(regionName, getContentDelegate);
+
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionManagerRequestNavigateFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionManagerRequestNavigateFixture.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Prism.Navigation;
+using Prism.Regions;
+using Prism.Regions.Navigation;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionManagerRequestNavigateFixture
+    {
+        const string region = "Region";
+        const string nonExistentRegion = "NonExistentRegion";
+        const string source = "Source";
+
+        private static Uri sourceUri = new Uri(source, UriKind.RelativeOrAbsolute);
+        private static INavigationParameters parameters = new NavigationParameters();
+        private static Action<IRegionNavigationResult> callback = (_) => { };
+
+        private static Mock<IRegion> mockRegion;
+        private static Mock<IRegionNavigationService> mockNavigation;
+        private static RegionManager regionManager;
+
+        public RegionManagerRequestNavigateFixture()
+        {
+            mockNavigation = new Mock<IRegionNavigationService>();
+            mockRegion = new Mock<IRegion>();
+            mockRegion.SetupGet(x => x.NavigationService).Returns(mockNavigation.Object);
+            mockRegion.SetupGet((r) => r.Name).Returns(region);
+
+            regionManager = new RegionManager();
+            regionManager.Regions.Add(mockRegion.Object);
+        }
+
+        [Fact]
+        public void DoesNotThrowWhenNavigationCallbackIsNull()
+        {
+            var ex = Record.Exception(() => regionManager.RequestNavigate(region, source, null, parameters));
+            Assert.Null(ex);
+
+            ex = Record.Exception(() => regionManager.RequestNavigate(region, source, navigationCallback: null));
+            Assert.Null(ex);
+
+            ex = Record.Exception(() => regionManager.RequestNavigate(region, sourceUri, null, parameters));
+            Assert.Null(ex);
+
+            ex = Record.Exception(() => regionManager.RequestNavigate(region, sourceUri, navigationCallback: null));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void WhenNonExistentRegion_ReturnNavigationResultFalse()
+        {
+            IRegionNavigationResult result;
+
+            result = null;
+            regionManager.RequestNavigate(nonExistentRegion, source, (r) => result = r, parameters);
+            Assert.Equal(false, result.Result);
+
+            result = null;
+            regionManager.RequestNavigate(nonExistentRegion, source, (r) => result = r);
+            Assert.Equal(false, result.Result);
+
+            result = null;
+            regionManager.RequestNavigate(nonExistentRegion, sourceUri, (r) => result = r, parameters);
+            Assert.Equal(false, result.Result);
+
+            result = null;
+            regionManager.RequestNavigate(nonExistentRegion, sourceUri, (r) => result = r);
+            Assert.Equal(false, result.Result);
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionSource()
+        {
+            regionManager.RequestNavigate(region, source);
+            mockNavigation.Verify((r) => r.RequestNavigate(sourceUri, It.IsAny<Action<IRegionNavigationResult>>(), null));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionTarget()
+        {
+            regionManager.RequestNavigate(region, sourceUri);
+            mockNavigation.Verify((r) => r.RequestNavigate(sourceUri, It.IsAny<Action<IRegionNavigationResult>>(), null));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionSourceParameters()
+        {
+            regionManager.RequestNavigate(region, source, parameters);
+            mockRegion.Verify((r) => r.NavigationService.RequestNavigate(sourceUri, It.IsAny<Action<IRegionNavigationResult>>(), parameters));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionSourceUriParameters()
+        {
+            regionManager.RequestNavigate(region, sourceUri, parameters);
+            mockRegion.Verify((r) => r.NavigationService.RequestNavigate(sourceUri, It.IsAny<Action<IRegionNavigationResult>>(), parameters));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionSourceCallback()
+        {
+            regionManager.RequestNavigate(region, source, callback);
+            mockNavigation.Verify((r) => r.RequestNavigate(sourceUri, callback, null));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionTargetCallback()
+        {
+            regionManager.RequestNavigate(region, sourceUri, callback);
+            mockNavigation.Verify((r) => r.RequestNavigate(sourceUri, callback, null));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionSourceCallbackParameters()
+        {
+            regionManager.RequestNavigate(region, source, callback, parameters);
+            mockRegion.Verify((r) => r.NavigationService.RequestNavigate(sourceUri, callback, parameters));
+        }
+
+        [Fact]
+        public void DelegatesCallToRegion_RegionSourceUriCallbackParameters()
+        {
+            regionManager.RequestNavigate(region, sourceUri, callback, parameters);
+            mockRegion.Verify((r) => r.NavigationService.RequestNavigate(sourceUri, callback, parameters));
+        }
+    }
+
+    public static class ExceptionAssert
+    {
+        public static void Throws<TException>(Action action)
+            where TException : Exception
+        {
+            Throws(typeof(TException), action);
+        }
+
+        public static void Throws(Type expectedExceptionType, Action action)
+        {
+            var ex = Record.Exception(action);
+            Assert.IsType(expectedExceptionType, ex);
+            //Assert.Fail("No exception thrown.  Expected exception type of {0}.", expectedExceptionType.Name);
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionNavigationJournalFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionNavigationJournalFixture.cs
@@ -1,0 +1,495 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Prism.Navigation;
+using Prism.Regions.Navigation;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionNavigationJournalFixture
+    {
+        [Fact]
+        public void ConstructingJournalInitializesValues()
+        {
+            // Act
+            var target = new RegionNavigationJournal();
+
+            // Verify
+            Assert.False(target.CanGoBack);
+            Assert.False(target.CanGoForward);
+            Assert.Null(target.CurrentEntry);
+            Assert.Null(target.NavigationTarget);
+        }
+
+        [Fact]
+        public void SettingNavigationServiceUpdatesValue()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockINavigate = new Mock<INavigateAsync>();
+
+            // Act
+            target.NavigationTarget = mockINavigate.Object;
+
+            // Verify
+            Assert.Same(mockINavigate.Object, target.NavigationTarget);
+        }
+
+        [Fact]
+        public void RecordingNavigationUpdatesNavigationState()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var uri = new Uri("Uri", UriKind.Relative);
+            var entry = new RegionNavigationJournalEntry() { Uri = uri };
+
+            // Act
+            target.RecordNavigation(entry, true);
+
+            // Verify
+            Assert.False(target.CanGoBack);
+            Assert.False(target.CanGoForward);
+            Assert.Same(entry, target.CurrentEntry);
+        }
+
+        [Fact]
+        public void RecordingNavigationMultipleTimesUpdatesNavigationState()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            // Act
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+            // Verify
+            Assert.True(target.CanGoBack);
+            Assert.False(target.CanGoForward);
+            Assert.Same(entry3, target.CurrentEntry);
+        }
+
+        [Fact]
+        public void ClearUpdatesNavigationState()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+            // Act
+            target.Clear();
+
+            // Verify
+            Assert.False(target.CanGoBack);
+            Assert.False(target.CanGoForward);
+            Assert.Null(target.CurrentEntry);
+        }
+
+        [Fact]
+        public void GoBackNavigatesBack()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            // Act
+            target.GoBack();
+
+            // Verify
+            Assert.True(target.CanGoBack);
+            Assert.True(target.CanGoForward);
+            Assert.Same(entry2, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+        }
+
+        [Fact]
+        public void GoBackDoesNotChangeStateWhenNavigationFails()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, false)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            // Act
+            target.GoBack();
+
+            // Verify
+            Assert.True(target.CanGoBack);
+            Assert.False(target.CanGoForward);
+            Assert.Same(entry3, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+        }
+
+        [Fact]
+        public void GoBackMultipleTimesNavigatesBack()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            // Act
+            target.GoBack();
+            target.GoBack();
+
+            // Verify
+            Assert.False(target.CanGoBack);
+            Assert.True(target.CanGoForward);
+            Assert.Same(entry1, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+        }
+
+        [Fact]
+        public void GoForwardNavigatesForward()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            target.GoBack();
+            target.GoBack();
+
+            // Act
+            target.GoForward();
+
+            // Verify
+            Assert.True(target.CanGoBack);
+            Assert.True(target.CanGoForward);
+            Assert.Same(entry2, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Exactly(2));
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+        }
+
+        [Fact]
+        public void GoForwardDoesNotChangeStateWhenNavigationFails()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, false)));
+
+            target.GoBack();
+
+            // Act
+            target.GoForward();
+
+            // Verify
+            Assert.True(target.CanGoBack);
+            Assert.True(target.CanGoForward);
+            Assert.Same(entry2, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+        }
+
+        [Fact]
+        public void GoForwardMultipleTimesNavigatesForward()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, true);
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            target.GoBack();
+            target.GoBack();
+
+            // Act
+            target.GoForward();
+            target.GoForward();
+
+            // Verify
+            Assert.True(target.CanGoBack);
+            Assert.False(target.CanGoForward);
+            Assert.Same(entry3, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Exactly(2));
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+        }
+
+        [Fact]
+        public void WhenNavigationToNewUri_ThenCanNoLongerNavigateForward()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            var uri4 = new Uri("Uri4", UriKind.Relative);
+            var entry4 = new RegionNavigationJournalEntry() { Uri = uri4 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            target.GoBack();
+
+            Assert.True(target.CanGoForward);
+
+            // Act
+            target.RecordNavigation(entry3, true);
+
+            // Verify
+            Assert.False(target.CanGoForward);
+            Assert.Equal(entry3, target.CurrentEntry);
+        }
+
+        [Fact]
+        public void WhenSavePreviousFalseDoNotRecordEntry()
+        {
+            // Prepare
+            var target = new RegionNavigationJournal();
+
+            var mockNavigationTarget = new Mock<INavigateAsync>();
+            target.NavigationTarget = mockNavigationTarget.Object;
+
+            var uri1 = new Uri("Uri1", UriKind.Relative);
+            var entry1 = new RegionNavigationJournalEntry() { Uri = uri1 };
+
+            var uri2 = new Uri("Uri2", UriKind.Relative);
+            var entry2 = new RegionNavigationJournalEntry() { Uri = uri2 };
+
+            var uri3 = new Uri("Uri3", UriKind.Relative);
+            var entry3 = new RegionNavigationJournalEntry() { Uri = uri3 };
+
+            var uri4 = new Uri("Uri4", UriKind.Relative);
+            var entry4 = new RegionNavigationJournalEntry() { Uri = uri4 };
+
+            target.RecordNavigation(entry1, true);
+            target.RecordNavigation(entry2, true);
+            target.RecordNavigation(entry3, false);
+            target.RecordNavigation(entry4, true);
+
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+            mockNavigationTarget
+                .Setup(x => x.RequestNavigate(uri4, It.IsAny<Action<IRegionNavigationResult>>(), null))
+                .Callback<Uri, Action<IRegionNavigationResult>, INavigationParameters>((u, c, n) => c(new RegionNavigationResult(null, true)));
+
+            Assert.Equal(entry4, target.CurrentEntry);
+
+            target.GoBack();
+
+            Assert.True(target.CanGoBack);
+            Assert.True(target.CanGoForward);
+            Assert.Same(entry2, target.CurrentEntry);
+
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri1, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri2, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Once());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri3, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+            mockNavigationTarget.Verify(x => x.RequestNavigate(uri4, It.IsAny<Action<IRegionNavigationResult>>(), null), Times.Never());
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionNavigationServiceFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionNavigationServiceFixture.cs
@@ -1,0 +1,1223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using Prism.Ioc;
+using Prism.Regions;
+using Prism.Regions.Navigation;
+using Xamarin.Forms;
+using Xunit;
+using Region = Prism.Regions.Region;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionNavigationServiceFixture
+    {
+        [Fact]
+        public void WhenNavigating_ViewIsActivated()
+        {
+            // Prepare
+            var view = new ContentView();
+            var viewUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            IRegion region = new Region();
+            region.Add(view);
+
+            string regionName = "RegionName";
+            var regionManager = new RegionManager();
+            regionManager.Regions.Add(regionName, region);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            bool isNavigationSuccessful = false;
+            target.RequestNavigate(viewUri, nr => isNavigationSuccessful = nr.Result == true);
+
+            // Verify
+            Assert.True(isNavigationSuccessful);
+            bool isViewActive = region.ActiveViews.Contains(view);
+            Assert.True(isViewActive);
+        }
+
+        [Fact]
+        public void WhenNavigatingWithQueryString_ViewIsActivated()
+        {
+            // Prepare
+            var view = new ContentView();
+            var viewUri = new Uri(view.GetType().Name + "?MyQuery=true", UriKind.Relative);
+
+            IRegion region = new Region();
+            region.Add(view);
+
+            string regionName = "RegionName";
+            var regionManager = new RegionManager();
+            regionManager.Regions.Add(regionName, region);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            bool isNavigationSuccessful = false;
+            target.RequestNavigate(viewUri, nr => isNavigationSuccessful = nr.Result == true);
+
+            // Verify
+            Assert.True(isNavigationSuccessful);
+            bool isViewActive = region.ActiveViews.Contains(view);
+            Assert.True(isViewActive);
+        }
+
+        [Fact]
+        public void WhenNavigatingAndViewCannotBeAcquired_ThenNavigationResultHasError()
+        {
+            // Prepare
+            var view = new ContentView();
+            var viewUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            IRegion region = new Region();
+            region.Add(view);
+
+            string otherType = "OtherType";
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+            IContainerExtension container = containerMock.Object;
+
+            var targetHandlerMock = new Mock<IRegionNavigationContentLoader>();
+            targetHandlerMock.Setup(th => th.LoadContent(It.IsAny<IRegion>(), It.IsAny<INavigationContext>())).Throws<ArgumentException>();
+
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, targetHandlerMock.Object, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            Exception error = null;
+            target.RequestNavigate(
+                new Uri(otherType.GetType().Name, UriKind.Relative),
+                nr =>
+                {
+                    error = nr.Error;
+                });
+
+            // Verify
+            bool isViewActive = region.ActiveViews.Contains(view);
+            Assert.False(isViewActive);
+            Assert.IsType<ArgumentException>(error);
+        }
+
+        [Fact]
+        public void WhenNavigatingWithNullUri_Throws()
+        {
+            // Prepare
+            IRegion region = new Region();
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            IRegionNavigationResult navigationResult = null;
+            target.RequestNavigate((Uri)null, nr => navigationResult = nr);
+
+            // Verify
+            Assert.False(navigationResult.Result.Value);
+            Assert.NotNull(navigationResult.Error);
+            Assert.IsType<ArgumentNullException>(navigationResult.Error);
+        }
+
+        [Fact]
+        public void WhenNavigatingAndViewImplementsIRegionAware_ThenNavigatedIsInvokedOnNavigation()
+        {
+            // Prepare
+            var region = new Region();
+
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IRegionAware>()
+                .Setup(ina => ina.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(true);
+            var view = viewMock.Object;
+            region.Add(view);
+
+            var navigationUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            viewMock
+                .As<IRegionAware>()
+                .Verify(v => v.OnNavigatedTo(It.Is<INavigationContext>(nc => nc.Uri == navigationUri && nc.NavigationService == target)));
+        }
+
+        [Fact]
+        public void WhenNavigatingAndBindingContextImplementsIRegionAware_ThenNavigatedIsInvokesOnNavigation()
+        {
+            // Prepare
+            var region = new Region();
+
+            var mockView = new Mock<View>();
+            var mockIRegionAwareBindingContext = new Mock<IRegionAware>();
+            mockIRegionAwareBindingContext
+                .Setup(ina => ina.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(true);
+            mockView.Object.BindingContext = mockIRegionAwareBindingContext.Object;
+
+            var view = mockView.Object;
+            region.Add(view);
+
+            var navigationUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            mockIRegionAwareBindingContext.Verify(v => v.OnNavigatedTo(It.Is<INavigationContext>(nc => nc.Uri == navigationUri)));
+        }
+
+        [Fact]
+        public void WhenNavigatingAndBothViewAndBindingContextImplementIRegionAware_ThenNavigatedIsInvokesOnNavigation()
+        {
+            // Prepare
+            var region = new Region();
+
+            var mockView = new Mock<View>();
+            var mockIRegionAwareView = mockView.As<IRegionAware>();
+            mockIRegionAwareView
+                .Setup(ina => ina.IsNavigationTarget(It.IsAny<INavigationContext>()))
+                .Returns(true);
+
+            var mockIRegionAwareBindingContext = new Mock<IRegionAware>();
+            mockIRegionAwareBindingContext.Setup(ina => ina.IsNavigationTarget(It.IsAny<INavigationContext>())).Returns(true);
+            mockView.Object.BindingContext = mockIRegionAwareBindingContext.Object;
+
+            var view = mockView.Object;
+            region.Add(view);
+
+            var navigationUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            mockIRegionAwareView.Verify(v => v.OnNavigatedTo(It.Is<INavigationContext>(nc => nc.Uri == navigationUri)));
+            mockIRegionAwareBindingContext.Verify(v => v.OnNavigatedTo(It.Is<INavigationContext>(nc => nc.Uri == navigationUri)));
+        }
+
+        [Fact]
+        public void WhenNavigating_NavigationIsRecordedInJournal()
+        {
+            // Prepare
+            var view = new ContentView();
+            var viewUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            IRegion region = new Region();
+            region.Add(view);
+
+            string regionName = "RegionName";
+            var regionManager = new RegionManager();
+            regionManager.Regions.Add(regionName, region);
+
+            IRegionNavigationJournalEntry journalEntry = new RegionNavigationJournalEntry();
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(journalEntry);
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+
+            var journalMock = new Mock<IRegionNavigationJournal>();
+            journalMock.Setup(x => x.RecordNavigation(journalEntry, true)).Verifiable();
+
+            IRegionNavigationJournal journal = journalMock.Object;
+
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(viewUri, nr => { });
+
+            // Verify
+            Assert.NotNull(journalEntry);
+            Assert.Equal(viewUri, journalEntry.Uri);
+            journalMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenNavigatingAndCurrentlyActiveViewImplementsINavigateWithVeto_ThenNavigationRequestQueriesForVeto()
+        {
+            // Prepare
+            var region = new Region();
+
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Verifiable();
+
+            var view = viewMock.Object;
+            region.Add(view);
+            region.Activate(view);
+
+            var navigationUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            viewMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenNavigating_ThenNavigationRequestQueriesForVetoOnAllActiveViewsIfAllSucceed()
+        {
+            // Prepare
+            var region = new Region();
+
+            var view1Mock = new Mock<View>();
+            view1Mock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(true))
+                .Verifiable();
+
+            var view1 = view1Mock.Object;
+            region.Add(view1);
+            region.Activate(view1);
+
+            var view2Mock = new Mock<StackLayout>();
+            view2Mock.As<IConfirmRegionNavigationRequest>();
+
+            var view2 = view2Mock.Object;
+            region.Add(view2);
+
+            var view3Mock = new Mock<Grid>();
+            view3Mock.As<IRegionAware>();
+
+            var view3 = view3Mock.Object;
+            region.Add(view3);
+            region.Activate(view3);
+
+            var view4Mock = new Mock<Frame>();
+            view4Mock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(true))
+                .Verifiable();
+
+            var view4 = view4Mock.Object;
+            region.Add(view4);
+            region.Activate(view4);
+
+            var navigationUri = new Uri(view1.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            view1Mock.VerifyAll();
+            view2Mock
+                .As<IConfirmRegionNavigationRequest>()
+                .Verify(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()), Times.Never());
+            view3Mock.VerifyAll();
+            view4Mock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenRequestNavigateAwayAcceptsThroughCallback_ThenNavigationProceeds()
+        {
+            // Prepare
+            var region = new Region();
+
+            var view1Mock = new Mock<View>();
+            view1Mock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(true))
+                .Verifiable();
+
+            var view1 = view1Mock.Object;
+
+            var view2 = new StackLayout();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            var navigationSucceeded = false;
+            target.RequestNavigate(navigationUri, nr => { navigationSucceeded = nr.Result == true; });
+
+            // Verify
+            view1Mock.VerifyAll();
+            Assert.True(navigationSucceeded);
+            Assert.Equal(new object[] { view1, view2 }, region.ActiveViews.ToArray());
+        }
+
+        [Fact]
+        public void WhenRequestNavigateAwayRejectsThroughCallback_ThenNavigationDoesNotProceed()
+        {
+            // Prepare
+            var region = new Region();
+
+            var view1Mock = new Mock<View>();
+            view1Mock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(false))
+                .Verifiable();
+
+            var view1 = view1Mock.Object;
+
+            var view2 = new StackLayout();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            var navigationFailed = false;
+            target.RequestNavigate(navigationUri, nr => { navigationFailed = nr.Result == false; });
+
+            // Verify
+            view1Mock.VerifyAll();
+            Assert.True(navigationFailed);
+            Assert.Equal(new object[] { view1 }, region.ActiveViews.ToArray());
+        }
+
+        [Fact]
+        public void WhenNavigatingAndBindingContextOnCurrentlyActiveViewImplementsINavigateWithVeto_ThenNavigationRequestQueriesForVeto()
+        {
+            // Prepare
+            var region = new Region();
+
+            var viewModelMock = new Mock<IConfirmRegionNavigationRequest>();
+            viewModelMock
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Verifiable();
+
+            var viewMock = new Mock<View>();
+
+            var view = viewMock.Object;
+            view.BindingContext = viewModelMock.Object;
+
+            region.Add(view);
+            region.Activate(view);
+
+            var navigationUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            viewModelMock.VerifyAll();
+        }
+
+        [Fact]
+        public void WhenRequestNavigateAwayOnBindingContextAcceptsThroughCallback_ThenNavigationProceeds()
+        {
+            // Prepare
+            var region = new Region();
+
+            var view1BindingContextMock = new Mock<IConfirmRegionNavigationRequest>();
+            view1BindingContextMock
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(true))
+                .Verifiable();
+
+            var view1Mock = new Mock<View>();
+            var view1 = view1Mock.Object;
+            view1.BindingContext = view1BindingContextMock.Object;
+
+            var view2 = new StackLayout();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            var navigationSucceeded = false;
+            target.RequestNavigate(navigationUri, nr => { navigationSucceeded = nr.Result == true; });
+
+            // Verify
+            view1BindingContextMock.VerifyAll();
+            Assert.True(navigationSucceeded);
+            Assert.Equal(new object[] { view1, view2 }, region.ActiveViews.ToArray());
+        }
+
+        [Fact]
+        public void WhenRequestNavigateAwayOnBindingContextRejectsThroughCallback_ThenNavigationDoesNotProceed()
+        {
+            // Prepare
+            var region = new Region();
+
+            var view1BindingContextMock = new Mock<IConfirmRegionNavigationRequest>();
+            view1BindingContextMock
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(false))
+                .Verifiable();
+
+            var view1Mock = new Mock<View>();
+            var view1 = view1Mock.Object;
+            view1.BindingContext = view1BindingContextMock.Object;
+
+            var view2 = new StackLayout();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            var navigationFailed = false;
+            target.RequestNavigate(navigationUri, nr => { navigationFailed = nr.Result == false; });
+
+            // Verify
+            view1BindingContextMock.VerifyAll();
+            Assert.True(navigationFailed);
+            Assert.Equal(new object[] { view1 }, region.ActiveViews.ToArray());
+        }
+
+        [Fact]
+        public void WhenViewAcceptsNavigationOutAfterNewIncomingRequestIsReceived_ThenOriginalRequestIsIgnored()
+        {
+            var region = new Region();
+
+            var viewMock = new Mock<View>();
+
+            var confirmationRequests = new List<Action<bool>>();
+
+            viewMock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(icnr => icnr.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => { confirmationRequests.Add(c); });
+
+            var view = viewMock.Object;
+            region.Add(view);
+            region.Activate(view);
+
+            var navigationUri = new Uri("", UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock
+                .Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry)))
+                .Returns(new RegionNavigationJournalEntry());
+
+            var contentLoaderMock = new Mock<IRegionNavigationContentLoader>();
+            contentLoaderMock
+                .Setup(cl => cl.LoadContent(region, It.IsAny<INavigationContext>()))
+                .Returns(view);
+
+            var container = containerMock.Object;
+            var contentLoader = contentLoaderMock.Object;
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            bool firstNavigation = false;
+            bool secondNavigation = false;
+            target.RequestNavigate(navigationUri, nr => firstNavigation = nr.Result.Value);
+            target.RequestNavigate(navigationUri, nr => secondNavigation = nr.Result.Value);
+
+            Assert.Equal(2, confirmationRequests.Count);
+
+            confirmationRequests[0](true);
+            confirmationRequests[1](true);
+
+            Assert.False(firstNavigation);
+            Assert.True(secondNavigation);
+        }
+
+        [Fact]
+        public void WhenViewModelAcceptsNavigationOutAfterNewIncomingRequestIsReceived_ThenOriginalRequestIsIgnored()
+        {
+            var region = new Region();
+
+            var viewModelMock = new Mock<IConfirmRegionNavigationRequest>();
+
+            var viewMock = new Mock<View>();
+            var view = viewMock.Object;
+            view.BindingContext = viewModelMock.Object;
+
+            var confirmationRequests = new List<Action<bool>>();
+
+            viewModelMock
+                .Setup(icnr => icnr.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => { confirmationRequests.Add(c); });
+
+            region.Add(view);
+            region.Activate(view);
+
+            var navigationUri = new Uri("", UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock
+                .Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry)))
+                .Returns(new RegionNavigationJournalEntry());
+
+            var contentLoaderMock = new Mock<IRegionNavigationContentLoader>();
+            contentLoaderMock
+                .Setup(cl => cl.LoadContent(region, It.IsAny<INavigationContext>()))
+                .Returns(view);
+
+            var container = containerMock.Object;
+            var contentLoader = contentLoaderMock.Object;
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            IRegionNavigationResult firstNavigation = null;
+            IRegionNavigationResult secondNavigation = null;
+            target.RequestNavigate(navigationUri, nr => firstNavigation = nr);
+            target.RequestNavigate(navigationUri, nr => secondNavigation = nr);
+
+            Assert.Equal(2, confirmationRequests.Count);
+
+            confirmationRequests[0](true);
+            confirmationRequests[1](true);
+
+            Assert.False(firstNavigation.Result);
+            Assert.True(secondNavigation.Result.Value);
+        }
+
+        [Fact]
+        public void BeforeNavigating_NavigatingEventIsRaised()
+        {
+            // Prepare
+            var view = new ContentView();
+            var viewUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            IRegion region = new Region();
+            region.Add(view);
+
+            string regionName = "RegionName";
+            var regionManager = new RegionManager();
+            regionManager.Regions.Add(regionName, region);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            bool isNavigatingRaised = false;
+            target.Navigating += delegate (object sender, RegionNavigationEventArgs e)
+            {
+                if (sender == target)
+                {
+                    isNavigatingRaised = true;
+                }
+            };
+
+            // Act
+            bool isNavigationSuccessful = false;
+            target.RequestNavigate(viewUri, nr => isNavigationSuccessful = nr.Result == true);
+
+            // Verify
+            Assert.True(isNavigationSuccessful);
+            Assert.True(isNavigatingRaised);
+        }
+
+        [Fact]
+        public void WhenNavigationSucceeds_NavigatedIsRaised()
+        {
+            // Prepare
+            var view = new ContentView();
+            var viewUri = new Uri(view.GetType().Name, UriKind.Relative);
+
+            IRegion region = new Region();
+            region.Add(view);
+
+            string regionName = "RegionName";
+            var regionManager = new RegionManager();
+            regionManager.Regions.Add(regionName, region);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new RegionNavigationContentLoader(container);
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            bool isNavigatedRaised = false;
+            target.Navigated += delegate (object sender, RegionNavigationEventArgs e)
+            {
+                if (sender == target)
+                {
+                    isNavigatedRaised = true;
+                }
+            };
+
+            // Act
+            bool isNavigationSuccessful = false;
+            target.RequestNavigate(viewUri, nr => isNavigationSuccessful = nr.Result == true);
+
+            // Verify
+            Assert.True(isNavigationSuccessful);
+            Assert.True(isNavigatedRaised);
+        }
+
+        [Fact]
+        public void WhenTargetViewCreationThrowsWithAsyncConfirmation_ThenExceptionIsProvidedToNavigationCallback()
+        {
+            var containerMock = new Mock<IContainerExtension>();
+
+            var targetException = new Exception();
+            var targetHandlerMock = new Mock<IRegionNavigationContentLoader>();
+            targetHandlerMock
+                .Setup(th => th.LoadContent(It.IsAny<IRegion>(), It.IsAny<INavigationContext>()))
+                .Throws(targetException);
+
+            var journalMock = new Mock<IRegionNavigationJournal>();
+
+            Action<bool> navigationCallback = null;
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(v => v.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => { navigationCallback = c; });
+
+            var region = new Region();
+            region.Add(viewMock.Object);
+            region.Activate(viewMock.Object);
+
+            var target = new RegionNavigationService(containerMock.Object, targetHandlerMock.Object, journalMock.Object)
+            {
+                Region = region
+            };
+
+            IRegionNavigationResult result = null;
+            target.RequestNavigate(new Uri("", UriKind.Relative), nr => result = nr);
+            navigationCallback(true);
+
+            Assert.NotNull(result);
+            Assert.Same(targetException, result.Error);
+        }
+
+        [Fact]
+        public void WhenNavigatingFromViewThatIsNavigationAware_ThenNotifiesActiveViewNavigatingFrom()
+        {
+            // Arrange
+            var region = new Region();
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IRegionAware>();
+            var view = viewMock.Object;
+            region.Add(view);
+
+            var view2 = new StackLayout();
+            region.Add(view2);
+
+            region.Activate(view);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            viewMock.As<IRegionAware>()
+                .Verify(v => v.OnNavigatedFrom(It.Is<INavigationContext>(ctx => ctx.Uri == navigationUri && ctx.Parameters.Count() == 0)));
+        }
+
+        [Fact]
+        public void WhenNavigationFromViewThatIsNavigationAware_OnlyNotifiesOnNavigateFromForActiveViews()
+        {
+            // Arrange
+
+            bool navigationFromInvoked = false;
+
+            var region = new Region();
+
+            var viewMock = new Mock<View>();
+            viewMock
+                .As<IRegionAware>()
+                .Setup(x => x.OnNavigatedFrom(It.IsAny<INavigationContext>())).Callback(() => navigationFromInvoked = true);
+            var view = viewMock.Object;
+            region.Add(view);
+
+            var targetViewMock = new Mock<StackLayout>();
+            targetViewMock.As<IRegionAware>();
+            region.Add(targetViewMock.Object);
+
+            var activeViewMock = new Mock<Grid>();
+            activeViewMock.As<IRegionAware>();
+            region.Add(activeViewMock.Object);
+
+            region.Activate(activeViewMock.Object);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var navigationUri = new Uri(targetViewMock.Object.GetType().Name, UriKind.Relative);
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            Assert.False(navigationFromInvoked);
+        }
+
+        [Fact]
+        public void WhenNavigatingFromActiveViewWithNavigatinAwareDataConext_NotifiesContextOfNavigatingFrom()
+        {
+            // Arrange
+            var region = new Region();
+
+            var mockBindingContext = new Mock<IRegionAware>();
+
+            var view1Mock = new Mock<View>();
+            var view1 = view1Mock.Object;
+            view1.BindingContext = mockBindingContext.Object;
+
+            region.Add(view1);
+
+            var view2 = new StackLayout();
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+            IContainerExtension container = containerMock.Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            // Act
+            target.RequestNavigate(navigationUri, nr => { });
+
+            // Verify
+            mockBindingContext.Verify(v => v.OnNavigatedFrom(It.Is<INavigationContext>(ctx => ctx.Uri == navigationUri && ctx.Parameters.Count() == 0)));
+        }
+
+        [Fact]
+        public void WhenNavigatingWithNullCallback_ThenThrows()
+        {
+            var region = new Region();
+
+            var navigationUri = new Uri("/", UriKind.Relative);
+            IContainerExtension container = new Mock<IContainerExtension>().Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            ExceptionAssert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    target.RequestNavigate(navigationUri, null);
+                });
+        }
+
+        [Fact]
+        public void WhenNavigatingWithNoRegionSet_ThenMarshallExceptionToCallback()
+        {
+            var navigationUri = new Uri("/", UriKind.Relative);
+            IContainerExtension container = new Mock<IContainerExtension>().Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal);
+
+            Exception error = null;
+            target.RequestNavigate(navigationUri, nr => error = nr.Error);
+
+            Assert.NotNull(error);
+            Assert.IsType<InvalidOperationException>(error);
+        }
+
+        [Fact]
+        public void WhenNavigatingWithNullUri_ThenMarshallExceptionToCallback()
+        {
+            IContainerExtension container = new Mock<IContainerExtension>().Object;
+            var contentLoader = new Mock<RegionNavigationContentLoader>(container).Object;
+            IRegionNavigationJournal journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = new Region()
+            };
+
+            Exception error = null;
+            target.RequestNavigate(null, nr => error = nr.Error);
+
+            Assert.NotNull(error);
+            Assert.IsType<ArgumentNullException>(error);
+        }
+
+
+        [Fact]
+        public void WhenNavigationFailsBecauseTheContentViewCannotBeRetrieved_ThenNavigationFailedIsRaised()
+        {
+            // Prepare
+            var region = new Region { Name = "RegionName" };
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var contentLoaderMock = new Mock<IRegionNavigationContentLoader>();
+            contentLoaderMock
+                .Setup(cl => cl.LoadContent(region, It.IsAny<INavigationContext>()))
+                .Throws<InvalidOperationException>();
+
+            var container = containerMock.Object;
+            var contentLoader = contentLoaderMock.Object;
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            RegionNavigationFailedEventArgs eventArgs = null;
+            target.NavigationFailed += delegate (object sender, RegionNavigationFailedEventArgs e)
+            {
+                if (sender == target)
+                {
+                    eventArgs = e;
+                }
+            };
+
+            // Act
+            bool? isNavigationSuccessful = null;
+            target.RequestNavigate(new Uri("invalid", UriKind.Relative), nr => isNavigationSuccessful = nr.Result);
+
+            // Verify
+            Assert.False(isNavigationSuccessful.Value);
+            Assert.NotNull(eventArgs);
+            Assert.NotNull(eventArgs.Error);
+        }
+
+        [Fact]
+        public void WhenNavigationFailsBecauseActiveViewRejectsIt_ThenNavigationFailedIsRaised()
+        {
+            // Prepare
+            var region = new Region { Name = "RegionName" };
+
+            var view1Mock = new Mock<View>();
+            view1Mock
+                .As<IConfirmRegionNavigationRequest>()
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(false))
+                .Verifiable();
+
+            var view1 = view1Mock.Object;
+
+            var view2 = new StackLayout();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var contentLoaderMock = new Mock<IRegionNavigationContentLoader>();
+            contentLoaderMock
+                .Setup(cl => cl.LoadContent(region, It.IsAny<INavigationContext>()))
+                .Returns(view2);
+
+            var container = containerMock.Object;
+            var contentLoader = contentLoaderMock.Object;
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            RegionNavigationFailedEventArgs eventArgs = null;
+            target.NavigationFailed += delegate (object sender, RegionNavigationFailedEventArgs e)
+            {
+                if (sender == target)
+                {
+                    eventArgs = e;
+                }
+            };
+
+            // Act
+            bool? isNavigationSuccessful = null;
+            target.RequestNavigate(navigationUri, nr => isNavigationSuccessful = nr.Result);
+
+            // Verify
+            view1Mock.VerifyAll();
+            Assert.False(isNavigationSuccessful.Value);
+            Assert.NotNull(eventArgs);
+            Assert.Null(eventArgs.Error);
+        }
+
+        [Fact]
+        public void WhenNavigationFailsBecauseBindingContextForActiveViewRejectsIt_ThenNavigationFailedIsRaised()
+        {
+            // Prepare
+            var region = new Region { Name = "RegionName" };
+
+            var viewModel1Mock = new Mock<IConfirmRegionNavigationRequest>();
+            viewModel1Mock
+                .Setup(ina => ina.ConfirmNavigationRequest(It.IsAny<INavigationContext>(), It.IsAny<Action<bool>>()))
+                .Callback<INavigationContext, Action<bool>>((nc, c) => c(false))
+                .Verifiable();
+
+            var view1Mock = new Mock<View>();
+            var view1 = view1Mock.Object;
+            view1.BindingContext = viewModel1Mock.Object;
+
+            var view2 = new StackLayout();
+
+            region.Add(view1);
+            region.Add(view2);
+
+            region.Activate(view1);
+
+            var navigationUri = new Uri(view2.GetType().Name, UriKind.Relative);
+
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
+
+            var contentLoaderMock = new Mock<IRegionNavigationContentLoader>();
+            contentLoaderMock
+                .Setup(cl => cl.LoadContent(region, It.IsAny<INavigationContext>()))
+                .Returns(view2);
+
+            var container = containerMock.Object;
+            var contentLoader = contentLoaderMock.Object;
+            var journal = Mock.Of<IRegionNavigationJournal>();
+
+            var target = new RegionNavigationService(container, contentLoader, journal)
+            {
+                Region = region
+            };
+
+            RegionNavigationFailedEventArgs eventArgs = null;
+            target.NavigationFailed += delegate (object sender, RegionNavigationFailedEventArgs e)
+            {
+                if (sender == target)
+                {
+                    eventArgs = e;
+                }
+            };
+
+            // Act
+            bool? isNavigationSuccessful = null;
+            target.RequestNavigate(navigationUri, nr => isNavigationSuccessful = nr.Result);
+
+            // Verify
+            viewModel1Mock.VerifyAll();
+            Assert.False(isNavigationSuccessful.Value);
+            Assert.NotNull(eventArgs);
+            Assert.Null(eventArgs.Error);
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionViewRegistryFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionViewRegistryFixture.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Prism.Ioc;
+using Prism.Regions;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class RegionViewRegistryFixture
+    {
+        [Fact]
+        public void CanRegisterContentAndRetrieveIt()
+        {
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(c => c.Resolve(typeof(MockContentObject))).Returns(new MockContentObject());
+            var registry = new RegionViewRegistry(containerMock.Object);
+
+            registry.RegisterViewWithRegion("MyRegion", typeof(MockContentObject));
+            var result = registry.GetContents("MyRegion");
+
+            //Assert.Equal(typeof(MockContentObject), calledType);
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.IsType<MockContentObject>(result.ElementAt(0));
+        }
+
+        [Fact]
+        public void ShouldRaiseEventWhenAddingContent()
+        {
+            var listener = new MySubscriberClass();
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(c => c.Resolve(typeof(MockContentObject))).Returns(new MockContentObject());
+            var registry = new RegionViewRegistry(containerMock.Object);
+
+            registry.ContentRegistered += listener.OnContentRegistered;
+
+            registry.RegisterViewWithRegion("MyRegion", typeof(MockContentObject));
+
+            Assert.NotNull(listener.onViewRegisteredArguments);
+            Assert.NotNull(listener.onViewRegisteredArguments.GetView);
+
+            var result = listener.onViewRegisteredArguments.GetView();
+            Assert.NotNull(result);
+            Assert.IsType<MockContentObject>(result);
+        }
+
+        [Fact]
+        public void CanRegisterContentAsDelegateAndRetrieveIt()
+        {
+            var registry = new RegionViewRegistry(null);
+            var content = new MockContentObject();
+
+            registry.RegisterViewWithRegion("MyRegion", () => content);
+            var result = registry.GetContents("MyRegion");
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Same(content, result.ElementAt(0));
+        }
+
+        [Fact]
+        public async Task ShouldNotPreventSubscribersFromBeingGarbageCollected()
+        {
+            var registry = new RegionViewRegistry(null);
+            var subscriber = new MySubscriberClass();
+            registry.ContentRegistered += subscriber.OnContentRegistered;
+
+            WeakReference subscriberWeakReference = new WeakReference(subscriber);
+
+            subscriber = null;
+
+            await Task.Delay(50);
+            GC.Collect();
+
+            Assert.False(subscriberWeakReference.IsAlive);
+        }
+
+        [Fact]
+        public void OnRegisterErrorShouldGiveClearException()
+        {
+            var registry = new RegionViewRegistry(null);
+            registry.ContentRegistered += new EventHandler<ViewRegisteredEventArgs>(FailWithInvalidOperationException);
+
+            try
+            {
+                registry.RegisterViewWithRegion("R1", typeof(object));
+                //Assert.Fail();
+            }
+            catch (ViewRegistrationException ex)
+            {
+                Assert.Contains("Dont do this", ex.Message);
+                Assert.Contains("R1", ex.Message);
+                Assert.Equal("Dont do this", ex.InnerException.Message);
+            }
+            catch (Exception)
+            {
+                //Assert.Fail("Wrong exception type");
+            }
+        }
+
+        [Fact]
+        public void OnRegisterErrorShouldSkipFrameworkExceptions()
+        {
+            ExceptionExtensions.RegisterFrameworkExceptionType(typeof(FrameworkException));
+            var registry = new RegionViewRegistry(null);
+            registry.ContentRegistered += new EventHandler<ViewRegisteredEventArgs>(FailWithFrameworkException);
+            var ex = Record.Exception(() => registry.RegisterViewWithRegion("R1", typeof(object)));
+            Assert.NotNull(ex);
+            Assert.IsType<ViewRegistrationException>(ex);
+            Assert.Contains("Dont do this", ex.Message);
+            Assert.Contains("R1", ex.Message);
+        }
+
+        private void FailWithFrameworkException(object sender, ViewRegisteredEventArgs e)
+        {
+            try
+            {
+                FailWithInvalidOperationException(sender, e);
+            }
+            catch (Exception ex)
+            {
+                throw new FrameworkException(ex);
+            }
+        }
+
+        private void FailWithInvalidOperationException(object sender, ViewRegisteredEventArgs e)
+        {
+            throw new InvalidOperationException("Dont do this");
+        }
+
+        private class MockContentObject
+        {
+        }
+
+        private class MySubscriberClass
+        {
+            public ViewRegisteredEventArgs onViewRegisteredArguments;
+            public void OnContentRegistered(object sender, ViewRegisteredEventArgs e)
+            {
+                onViewRegisteredArguments = e;
+            }
+        }
+
+        private class FrameworkException : Exception
+        {
+            public FrameworkException(Exception innerException)
+                : base("", innerException)
+            {
+
+            }
+        }
+
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionViewRegistryFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/RegionViewRegistryFixture.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Moq;
 using Prism.Ioc;
 using Prism.Regions;
+using Xamarin.Forms;
 using Xunit;
 
 namespace Prism.Forms.Regions.Tests
@@ -132,7 +133,7 @@ namespace Prism.Forms.Regions.Tests
             throw new InvalidOperationException("Dont do this");
         }
 
-        private class MockContentObject
+        private class MockContentObject : VisualElement
         {
         }
 

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/SingleActiveRegionFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/SingleActiveRegionFixture.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.Regions;
+using Xamarin.Forms;
+using Xunit;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class SingleActiveRegionFixture
+    {
+        [Fact]
+        public void ActivatingNewViewDeactivatesCurrent()
+        {
+            IRegion region = new SingleActiveRegion();
+            var view = new ContentView();
+            region.Add(view);
+            region.Activate(view);
+
+            Assert.True(region.ActiveViews.Contains(view));
+
+            var view2 = new StackLayout();
+            region.Add(view2);
+            region.Activate(view2);
+
+            Assert.False(region.ActiveViews.Contains(view));
+            Assert.True(region.ActiveViews.Contains(view2));
+        }
+    }
+}

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/ViewsCollectionFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/ViewsCollectionFixture.cs
@@ -1,0 +1,344 @@
+﻿using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using Prism.Forms.Regions.Mocks;
+using Prism.Regions;
+using Xamarin.Forms;
+using Xunit;
+using Region = Prism.Regions.Region;
+
+namespace Prism.Forms.Regions.Tests
+{
+    public class ViewsCollectionFixture
+    {
+        [Fact]
+        public void CanWrapCollectionCollection()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => true);
+
+            Assert.Empty(viewsCollection);
+
+            var item = new ContentView();
+            originalCollection.Add(new ItemMetadata(item));
+            Assert.Single(viewsCollection);
+            Assert.Same(item, viewsCollection.First());
+        }
+
+        [Fact]
+        public void CanFilterCollection()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => x.Name == "Possible");
+
+            originalCollection.Add(new ItemMetadata(new ContentView()));
+
+            Assert.Empty(viewsCollection);
+
+            var item = new ContentView();
+            originalCollection.Add(new ItemMetadata(item) { Name = "Possible" });
+            Assert.Single(viewsCollection);
+
+            Assert.Same(item, viewsCollection.First());
+        }
+
+        [Fact]
+        public void RaisesCollectionChangedWhenFilteredCollectionChanges()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => x.IsActive);
+            bool collectionChanged = false;
+            viewsCollection.CollectionChanged += (s, e) => collectionChanged = true;
+
+            originalCollection.Add(new ItemMetadata(new ContentView()) { IsActive = true });
+
+            Assert.True(collectionChanged);
+        }
+
+        [Fact]
+        public void RaisesCollectionChangedWithAddAndRemoveWhenFilteredCollectionChanges()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => x.IsActive);
+            bool addedToCollection = false;
+            bool removedFromCollection = false;
+            viewsCollection.CollectionChanged += (s, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Add)
+                {
+                    addedToCollection = true;
+                }
+                else if (e.Action == NotifyCollectionChangedAction.Remove)
+                {
+                    removedFromCollection = true;
+                }
+            };
+            var filteredInObject = new ItemMetadata(new ContentView()) { IsActive = true };
+
+            originalCollection.Add(filteredInObject);
+
+            Assert.True(addedToCollection);
+            Assert.False(removedFromCollection);
+
+            originalCollection.Remove(filteredInObject);
+
+            Assert.True(removedFromCollection);
+        }
+
+        [Fact]
+        public void DoesNotRaiseCollectionChangedWhenAddingOrRemovingFilteredOutObject()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => x.IsActive);
+            bool collectionChanged = false;
+            viewsCollection.CollectionChanged += (s, e) => collectionChanged = true;
+            var filteredOutObject = new ItemMetadata(new ContentView()) { IsActive = false };
+
+            originalCollection.Add(filteredOutObject);
+            originalCollection.Remove(filteredOutObject);
+
+            Assert.False(collectionChanged);
+        }
+
+        [Fact]
+        public void CollectionChangedPassesWrappedItemInArgumentsWhenAdding()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            var filteredInObject = new ItemMetadata(new ContentView());
+            originalCollection.Add(filteredInObject);
+
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => true);
+            IList oldItemsPassed = null;
+            viewsCollection.CollectionChanged += (s, e) => { oldItemsPassed = e.OldItems; };
+            originalCollection.Remove(filteredInObject);
+
+            Assert.NotNull(oldItemsPassed);
+            Assert.Equal(1, oldItemsPassed.Count);
+            Assert.Same(filteredInObject.Item, oldItemsPassed[0]);
+        }
+
+        [Fact]
+        public void CollectionChangedPassesWrappedItemInArgumentsWhenRemoving()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => true);
+            IList newItemsPassed = null;
+            viewsCollection.CollectionChanged += (s, e) => { newItemsPassed = e.NewItems; };
+            var filteredInObject = new ItemMetadata(new ContentView());
+
+            originalCollection.Add(filteredInObject);
+
+            Assert.NotNull(newItemsPassed);
+            Assert.Equal(1, newItemsPassed.Count);
+            Assert.Same(filteredInObject.Item, newItemsPassed[0]);
+        }
+
+        [Fact]
+        public void EnumeratesWrappedItems()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>()
+                                         {
+                                             new ItemMetadata(new ContentView()),
+                                             new ItemMetadata(new ContentView())
+                                         };
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => true);
+            Assert.Equal(2, viewsCollection.Count());
+
+            Assert.Same(originalCollection[0].Item, viewsCollection.ElementAt(0));
+            Assert.Same(originalCollection[1].Item, viewsCollection.ElementAt(1));
+        }
+
+        [Fact]
+        public void ChangingMetadataOnItemAddsOrRemovesItFromTheFilteredCollection()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, x => x.IsActive);
+            bool addedToCollection = false;
+            bool removedFromCollection = false;
+            viewsCollection.CollectionChanged += (s, e) =>
+            {
+                if (e.Action == NotifyCollectionChangedAction.Add)
+                {
+                    addedToCollection = true;
+                }
+                else if (e.Action == NotifyCollectionChangedAction.Remove)
+                {
+                    removedFromCollection = true;
+                }
+            };
+
+            originalCollection.Add(new ItemMetadata(new ContentView()) { IsActive = true });
+            Assert.True(addedToCollection);
+            Assert.False(removedFromCollection);
+            addedToCollection = false;
+
+            originalCollection[0].IsActive = false;
+
+            Assert.Empty(viewsCollection);
+            Assert.True(removedFromCollection);
+            Assert.False(addedToCollection);
+            Assert.Empty(viewsCollection);
+            addedToCollection = false;
+            removedFromCollection = false;
+
+            originalCollection[0].IsActive = true;
+
+            Assert.Single(viewsCollection);
+            Assert.True(addedToCollection);
+            Assert.False(removedFromCollection);
+        }
+
+        [Fact]
+        public void AddingToOriginalCollectionFiresAddCollectionChangeEvent()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            IViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+
+            var eventTracker = new CollectionChangedTracker(viewsCollection);
+
+            originalCollection.Add(new ItemMetadata(new ContentView()));
+
+            Assert.Contains(NotifyCollectionChangedAction.Add, eventTracker.ActionsFired);
+        }
+
+        [Fact]
+        public void AddingToOriginalCollectionFiresResetNotificationIfSortComparisonSet()
+        {
+            // Reset is fired to support the need to resort after updating the collection
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            var viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+            viewsCollection.SortComparison = (a, b) => { return 0; };
+
+            var eventTracker = new CollectionChangedTracker(viewsCollection);
+
+            originalCollection.Add(new ItemMetadata(new ContentView()));
+
+            Assert.Contains(NotifyCollectionChangedAction.Add, eventTracker.ActionsFired);
+            Assert.Equal(
+                1,
+                eventTracker.ActionsFired.Count(a => a == NotifyCollectionChangedAction.Reset));
+        }
+
+        //[Fact]
+        //public void OnAddNotifyCollectionChangedThenIndexProvided()
+        //{
+        //    var originalCollection = new ObservableCollection<ItemMetadata>();
+        //    IViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+
+        //    var eventTracker = new CollectionChangedTracker(viewsCollection);
+
+        //    originalCollection.Add(new ItemMetadata("a"));
+
+        //    var addEvent = eventTracker.NotifyEvents.Single(e => e.Action == NotifyCollectionChangedAction.Add);
+        //    Assert.Equal(0, addEvent.NewStartingIndex);
+        //}
+
+        //[Fact]
+        //public void OnRemoveNotifyCollectionChangedThenIndexProvided()
+        //{
+        //    var originalCollection = new ObservableCollection<ItemMetadata>();
+        //    originalCollection.Add(new ItemMetadata("a"));
+        //    originalCollection.Add(new ItemMetadata("b"));
+        //    originalCollection.Add(new ItemMetadata("c"));
+        //    IViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+
+        //    var eventTracker = new CollectionChangedTracker(viewsCollection);
+        //    originalCollection.RemoveAt(1);
+
+        //    var removeEvent = eventTracker.NotifyEvents.Single(e => e.Action == NotifyCollectionChangedAction.Remove);
+        //    Assert.NotNull(removeEvent);
+        //    Assert.Equal(1, removeEvent.OldStartingIndex);
+        //}
+
+        //[Fact]
+        //public void OnRemoveOfFilterMatchingItemThenViewCollectionRelativeIndexProvided()
+        //{
+        //    var originalCollection = new ObservableCollection<ItemMetadata>();
+        //    originalCollection.Add(new ItemMetadata("a"));
+        //    originalCollection.Add(new ItemMetadata("b"));
+        //    originalCollection.Add(new ItemMetadata("c"));
+        //    IViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => !"b".Equals(i.Item));
+
+        //    var eventTracker = new CollectionChangedTracker(viewsCollection);
+        //    originalCollection.RemoveAt(2);
+
+        //    var removeEvent = eventTracker.NotifyEvents.Single(e => e.Action == NotifyCollectionChangedAction.Remove);
+        //    Assert.NotNull(removeEvent);
+        //    Assert.Equal(1, removeEvent.OldStartingIndex);
+        //}
+
+
+        //[Fact]
+        //public void RemovingFromFilteredCollectionDoesNotThrow()
+        //{
+        //    var originalCollection = new ObservableCollection<ItemMetadata>();
+        //    originalCollection.Add(new ItemMetadata("a"));
+        //    originalCollection.Add(new ItemMetadata("b"));
+        //    originalCollection.Add(new ItemMetadata("c"));
+        //    IViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+
+        //    CollectionViewSource cvs = new CollectionViewSource { Source = viewsCollection };
+
+        //    var view = cvs.View;
+        //    //try
+        //    //{
+        //    originalCollection.RemoveAt(1);
+        //    //}
+        //    //catch (Exception ex)
+        //    //{
+        //    //Assert.Fail(ex.Message);
+        //    //}
+        //}
+
+        [Fact]
+        public void ViewsCollectionSortedAfterAddingItemToOriginalCollection()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            ViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+            viewsCollection.SortComparison = Region.DefaultSortComparison;
+
+            var view1 = new MockSortableView1();
+            var view2 = new MockSortableView2();
+            var view3 = new MockSortableView3();
+
+            originalCollection.Add(new ItemMetadata(view2));
+            originalCollection.Add(new ItemMetadata(view3));
+            originalCollection.Add(new ItemMetadata(view1));
+
+            Assert.Same(view1, viewsCollection.ElementAt(0));
+            Assert.Same(view2, viewsCollection.ElementAt(1));
+            Assert.Same(view3, viewsCollection.ElementAt(2));
+        }
+
+        [Fact]
+        public void ChangingSortComparisonCausesResortingOfCollection()
+        {
+            var originalCollection = new ObservableCollection<ItemMetadata>();
+            ViewsCollection viewsCollection = new ViewsCollection(originalCollection, (i) => true);
+
+            var view1 = new MockSortableView1();
+            var view2 = new MockSortableView2();
+            var view3 = new MockSortableView3();
+
+            originalCollection.Add(new ItemMetadata(view2));
+            originalCollection.Add(new ItemMetadata(view3));
+            originalCollection.Add(new ItemMetadata(view1));
+
+            // ensure items are in original order
+            Assert.Same(view2, viewsCollection.ElementAt(0));
+            Assert.Same(view3, viewsCollection.ElementAt(1));
+            Assert.Same(view1, viewsCollection.ElementAt(2));
+
+            // change sort comparison
+            viewsCollection.SortComparison = Region.DefaultSortComparison;
+
+            // ensure items are properly sorted
+            Assert.Same(view1, viewsCollection.ElementAt(0));
+            Assert.Same(view2, viewsCollection.ElementAt(1));
+            Assert.Same(view3, viewsCollection.ElementAt(2));
+        }
+    }
+}

--- a/tests/Forms/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
+++ b/tests/Forms/Prism.Unity.Forms.Tests/Prism.Unity.Forms.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Forms\Prism.Forms.Regions\Prism.Forms.Regions.csproj" />
     <ProjectReference Include="..\..\..\src\Forms\Prism.Unity.Forms\Prism.Unity.Forms.csproj" />
   </ItemGroup>
 

--- a/tests/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockRegionManager.cs
+++ b/tests/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/MockRegionManager.cs
@@ -78,5 +78,15 @@ namespace Prism.IocContainer.Wpf.Tests.Support.Mocks
         {
             throw new NotImplementedException();
         }
+
+        public IRegionManager AddToRegion(string regionName, string viewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IRegionManager RegisterViewWithRegion(string regionName, string viewName)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Wpf/Prism.Wpf.Tests/Mocks/MockRegionManager.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Mocks/MockRegionManager.cs
@@ -87,6 +87,16 @@ namespace Prism.Wpf.Tests.Mocks
         {
             throw new System.NotImplementedException();
         }
+
+        public IRegionManager AddToRegion(string regionName, string viewName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IRegionManager RegisterViewWithRegion(string regionName, string viewName)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     internal class MockRegionCollection : List<IRegion>, IRegionCollection

--- a/tests/Wpf/Prism.Wpf.Tests/Mocks/MockViewsCollection.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Mocks/MockViewsCollection.cs
@@ -14,7 +14,7 @@ namespace Prism.Wpf.Tests.Mocks
 
         public void Add(object view)
         {
-            this.Items.Add(view);
+            Items.Add(view);
         }
 
         public bool Contains(object value)

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/RegionManagerRegistrationBehaviorFixture.cs
@@ -292,6 +292,16 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
             {
                 throw new NotImplementedException();
             }
+
+            public IRegionManager AddToRegion(string regionName, string viewName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IRegionManager RegisterViewWithRegion(string regionName, string viewName)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
@@ -529,6 +529,16 @@ namespace Prism.Wpf.Tests.Regions
             {
                 throw new NotImplementedException();
             }
+
+            public IRegionManager AddToRegion(string regionName, string viewName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IRegionManager RegisterViewWithRegion(string regionName, string viewName)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         [Fact]


### PR DESCRIPTION
﻿## Description of Change

Adding some missing APIs to Prism.Forms.Regions as well as making the API more MVVM friendly across all platforms with the ability to Add/Register Views based on the View name and not just type or instance.

Adding Unit Tests for Prism.Forms Regions.

### Bugs Fixed

- #2415 

### API Changes

Added:

IRegion (added to Forms)
- IRegionManager Add(VisualElement view, string viewName);
- IRegionManager Add(VisualElement view, string viewName, bool createRegionManagerScope);

IRegionManager
- IRegionManager AddToRegion(string regionName, string targetName); (added to all Platforms)
- IRegionManager RegisterViewWithRegion(string regionName, string targetName); (added to all Platforms)
- IRegionManager RegisterViewWithRegion(string regionName, Type viewType); (added to Forms)

### Behavioral Changes

Fixed inconsistent behavior in Prism.Forms.Regions with how Regions should work.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard