### PR TITLE
Add Support for NavigateTo within EventToCommandBehavior

### DIFF
--- a/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
+++ b/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Prism.Behaviors;
 using Prism.Properties;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -84,6 +85,10 @@ namespace Prism.Xaml
                 throw new ArgumentException(Resources.ServiceProviderDidNotHaveIProvideValueTarget);
 
             _targetElement = valueTargetProvider.TargetObject as Element;
+
+            //this is handling the scenario of the extension being used within the EventToCommandBehavior
+            if (_targetElement is null && valueTargetProvider.TargetObject is BehaviorBase<BindableObject> behavior)
+                _targetElement = behavior.AssociatedObject as Element;
 
             if (_targetElement is null)
                 throw new ArgumentNullException(nameof(TargetElement));

--- a/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
+++ b/src/Forms/Prism.Forms/Xaml/ParentPageAwareExtension.cs
@@ -91,7 +91,7 @@ namespace Prism.Xaml
                 _targetElement = behavior.AssociatedObject as Element;
 
             if (_targetElement is null)
-                throw new ArgumentNullException(nameof(TargetElement));
+                throw new Exception($"{valueTargetProvider.TargetObject} is not supported");
 
             var parentPage = (Page)GetBindableStack().FirstOrDefault(p => p.GetType()
                                                                            .IsSubclassOf(typeof(Page)));


### PR DESCRIPTION
﻿## Description of Change

Added support for the NavigateTo markup extension to work within the Prism EventToCommandBehavior. You can now do something like this:

```
        <ListView ItemsSource="{Binding Authors}">
            <ListView.Behaviors>
                <prism:EventToCommandBehavior EventName="ItemTapped"
                                              Command="{prism:NavigateTo 'AuthorDetailPage'}"
                                              EventArgsParameterPath="Item" />
            </ListView.Behaviors>
        </ListView>
```

### Bugs Fixed

- #2484

### API Changes

NONE

### Behavioral Changes

NavigateTo now works with the EventToCommandBehavior

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard