### PR TITLE
Adds FileOnQ.Prism.Popups.XCT Community Plugin to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The Prism Template Pack is available on the [Visual Studio Gallery](https://mark
 There are certain things that cannot be added directly into Prism for various reasons. To handle these common tasks such as supporting PopupPage's in Xamarin Forms, there are Prism Plugins. You can find a number of Plugins available on NuGet from our maintainer [@DanJSiegel](https://twitter.com/DanJSiegel).
 
 - [Prism.Plugin.Popups](https://github.com/dansiegel/Prism.Plugin.Popups) (Forms Only)
+- [Prism.Popups.XCT](https://github.com/FileOnQ/Prism.Popups.XCT) (Forms Only)
+  - Adds support for native popups using Xamarin Community Toolkits Popup API
 - [Prism.Plugin.Logging](https://github.com/dansiegel/Prism.Plugin.Logging) (Works on all Platforms)
   - Adds support for Syslog, Loggly, Graylog, Application Insights, &amp; App Center
 - [Prism.Container.Extensions](https://github.com/dansiegel/Prism.Container.Extensions)


### PR DESCRIPTION
﻿## Description of Change

@dansiegel and I were talking about the Popup Plugin that I open sourced and thought it would be a good idea to add our Popup Plugin to the readme so other community members can easily find it. [FileOnQ.Prism.Popups.XCT](https://github.com/FileOnQ/Prism.Popups.XCT) adds support for the Xamarin Community Toolkit native popups.

This PR updates the readme only no code changes to project.

Open to any changes that need to be made to the Readme to ensure the community plugin is communicated correctly.

### Bugs Fixed
N/A

### API Changes
N/A

### Behavioral Changes
N/A

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard