### PR TITLE
Update IModuleGroupsCatalog

### DIFF
--- a/src/Wpf/Prism.Wpf/Modularity/IModuleGroupsCatalog.cs
+++ b/src/Wpf/Prism.Wpf/Modularity/IModuleGroupsCatalog.cs
@@ -2,8 +2,16 @@
 
 namespace Prism.Modularity
 {
+    /// <summary>
+    /// Defines a model that can get the collection of <see cref="IModuleCatalogItem"/>.
+    /// </summary>
     public interface IModuleGroupsCatalog
     {
+        /// <summary>
+        /// Gets the items in the <see cref="IModuleCatalog"/>. This property is mainly used to add <see cref="IModuleInfoGroup"/>s or
+        /// <see cref="IModuleInfo"/>s through XAML.
+        /// </summary>
+        /// <value>The items in the catalog.</value>
         Collection<IModuleCatalogItem> Items { get; }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Add Missing XML Docs To IModuleGroupsCatalog.cs.
I refer to [Items Propperty comment](https://github.com/PrismLibrary/Prism/blob/master/src/Prism.Core/Modularity/ModuleCatalogBase.cs#L62).  

I only add missing XML Docs so I omitted tests.

### Bugs Fixed

#1978 

### API Changes

None.

### Behavioral Changes

None.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard