### PR TITLE
Task: DispatcherQueue property moved across name spaces. WinUI 3 API …

### DIFF
--- a/src/Uno/Prism.Uno/Extensions/DependencyObjectExtensions.Uno.cs
+++ b/src/Uno/Prism.Uno/Extensions/DependencyObjectExtensions.Uno.cs
@@ -32,7 +32,7 @@ namespace Prism
             {
                 // Dispatcher queue HasThreadAccess is not yet implemented in Uno, we can fall back on CoreDispatcher
                 // See https://github.com/unoplatform/uno/issues/5818
-                if(ApiInformation.IsPropertyPresent("Microsoft.System.DispatcherQueue", nameof(Microsoft.System.DispatcherQueue.HasThreadAccess)))
+                if(ApiInformation.IsPropertyPresent("Microsoft.UI.Dispatching.DispatcherQueue", nameof(Microsoft.UI.Dispatching.DispatcherQueue.HasThreadAccess)))
                 {
                     return instance.DispatcherQueue.HasThreadAccess;
                 }


### PR DESCRIPTION
In Reunion 0.8 DispatcherQueue moved from the Microsoft.System to the Microsoft.UI.Dispatching namespace. The error indicates this version of Prism is still using the old namespace and needs to be updated for 0.8.

https://github.com/PrismLibrary/Prism/discussions/2523

﻿## Description of Change

Describe your changes here.

Name space harmonization with WinUI 3 0.8

### Bugs Fixed

https://github.com/microsoft/microsoft-ui-xaml/issues/5601

- Provide links to bugs here

### API Changes

List all API changes here (or just put None), example:

Added:

- void INavigationService.GoBackToRootAsync();

Changed:

- void INavigationService.GoBackAsync => bool INavigationService.GoBackAsync

### Behavioral Changes

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard