### PR TITLE
fix: Adjust net5.0 targetframework to fix assets packaging

### DIFF
--- a/e2e/Uno/ModuleA/ModuleA.WinUI.csproj
+++ b/e2e/Uno/ModuleA/ModuleA.WinUI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;MonoAndroid10.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
@@ -14,7 +14,7 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('xamarinios')) or $(TargetFramework.StartsWith('xamarinmac')) or $(TargetFramework.StartsWith('MonoAndroid')) or $(TargetFramework.StartsWith('netstandard'))">
     <PackageReference Include="Uno.WinUI" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362.0'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'">
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
     <Compile Update="**\*.xaml.cs">
       <DependentUpon>%(Filename)</DependentUpon>

--- a/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
+++ b/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;MonoAndroid10.0;xamarinmac20</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Prism.DryIoc.Uno</AssemblyName>
     <PackageId>Prism.DryIoc.Uno.WinUI</PackageId>

--- a/src/Uno/Prism.Unity.Uno/Prism.Unity.Uno.WinUI.csproj
+++ b/src/Uno/Prism.Unity.Uno/Prism.Unity.Uno.WinUI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;MonoAndroid10.0;xamarinmac20</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
     <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
     <AssemblyName>Prism.Unity.Uno</AssemblyName>
     <RootNamespace>Prism.Unity</RootNamespace>

--- a/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
+++ b/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;xamarinios10;MonoAndroid10.0;xamarinmac20</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net5.0-windows10.0.18362</TargetFrameworks>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>Prism.Uno</AssemblyName>
     <RootNamespace>Prism</RootNamespace>
@@ -26,10 +26,10 @@
     <PackageReference Include="Uno.Core" />
     <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362.0'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows10.0.18362'">
     <Page Include="**\*.xaml"
           Exclude="bin\**\*.xaml;obj\**\*.xaml" />
     <Compile Update="**\*.xaml.cs">


### PR DESCRIPTION
﻿## Description of Change

Reunion 0.8 uses the TargetFramework verbatim to package additional content, which is different from what nuget infers.

Using `net5.0-windows10.0.18362.0` is transformed to `net5.0-windows10.0.18362` by nuget, but the mrt packaging still uses `net5.0-windows10.0.18362.0` causing a build failure where some resource files cannot be found.

### API Changes

List all API changes here (or just put None), example:

Added: None 
Changed: None

### Behavioral Changes

None

### PR Checklist

- [ ] ~~Has tests (if omitted, state reason in description)~~
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard