### PR TITLE
Changed the access modifier of the AutowireViewModel method to public

### DIFF
--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Prism.Mvvm;
 #if HAS_UWP
@@ -27,6 +28,7 @@ namespace Prism.Common
         /// the AutoWireViewModel property of the view is null.
         /// </remarks>
         /// <param name="viewOrViewModel">The View or ViewModel.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void AutowireViewModel(object viewOrViewModel)
         {
             if (viewOrViewModel is FrameworkElement view && view.DataContext is null && ViewModelLocator.GetAutowireViewModel(view) is null)
@@ -44,6 +46,7 @@ namespace Prism.Common
         /// the AutoWireViewModel property of the view is null.
         /// </remarks>
         /// <param name="viewOrViewModel">The View or ViewModel.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void AutowireViewModel(object viewOrViewModel)
         {
             if (viewOrViewModel is FrameworkElement view && view.DataContext is null && ViewModelLocator.GetAutoWireViewModel(view) is null)

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -18,7 +18,16 @@ namespace Prism.Common
     public static class MvvmHelpers
     {
 #if HAS_UWP || HAS_WINUI
-        internal static void AutowireViewModel(object viewOrViewModel)
+        /// <summary>
+        /// Sets the AutoWireViewModel property to true for the <paramref name="viewOrViewModel"/>.
+        /// </summary>
+        /// <remarks>
+        /// The AutoWireViewModel property will only be set to true if the view
+        /// is a <see cref="FrameworkElement"/>, the DataContext of the view is null, and
+        /// the AutoWireViewModel property of the view is null.
+        /// </remarks>
+        /// <param name="viewOrViewModel">The View or ViewModel.</param>
+        public static void AutowireViewModel(object viewOrViewModel)
         {
             if (viewOrViewModel is FrameworkElement view && view.DataContext is null && ViewModelLocator.GetAutowireViewModel(view) is null)
             {

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -26,7 +26,16 @@ namespace Prism.Common
             }
         }
 #else
-        internal static void AutowireViewModel(object viewOrViewModel)
+        /// <summary>
+        /// Sets the AutoWireViewModel property to true for the <paramref name="viewOrViewModel"/>.
+        /// </summary>
+        /// <remarks>
+        /// The AutoWireViewModel property will only be set to true if the view
+        /// is a <see cref="FrameworkElement"/>, the DataContext of the view is null, and
+        /// the AutoWireViewModel property of the view is null.
+        /// </remarks>
+        /// <param name="viewOrViewModel">The View or ViewModel.</param>
+        public static void AutowireViewModel(object viewOrViewModel)
         {
             if (viewOrViewModel is FrameworkElement view && view.DataContext is null && ViewModelLocator.GetAutoWireViewModel(view) is null)
             {


### PR DESCRIPTION
﻿## Description of Change

Changed the access modifier of the AutowireViewModel method from internal to public in the MvvmHelpers class and added documentation.

### Bugs Fixed

- #2522 

### API Changes

Changed:

- internal static void  AutowireViewModel => public static void AutowireViewModel

### Behavioral Changes

Developers can now access this method from an external assembly.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard