### PR TITLE
Add null checking for application provider main page

### DIFF
--- a/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
+++ b/src/Forms/Prism.Forms/Services/PageDialogService/PageDialogService.cs
@@ -63,7 +63,8 @@ namespace Prism.Services
         /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
         public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection)
         {
-            return _applicationProvider.MainPage.DisplayAlert(title, message, acceptButton, cancelButton, (XFFlow)flowDirection);
+            return _applicationProvider?.MainPage == null ? Task.FromResult(false) :
+                _applicationProvider.MainPage.DisplayAlert(title, message, acceptButton, cancelButton, (XFFlow)flowDirection);
         }
 
         /// <summary>
@@ -78,7 +79,8 @@ namespace Prism.Services
         /// <returns></returns>
         public virtual Task DisplayAlertAsync(string title, string message, string cancelButton)
         {
-            return _applicationProvider.MainPage.DisplayAlert(title, message, cancelButton);
+            return _applicationProvider?.MainPage == null ? Task.CompletedTask :
+                _applicationProvider.MainPage.DisplayAlert(title, message, cancelButton);
         }
 
         /// <summary>
@@ -94,7 +96,8 @@ namespace Prism.Services
         /// <returns></returns>
         public virtual Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection)
         {
-            return _applicationProvider.MainPage.DisplayAlert(title, message, cancelButton, (XFFlow)flowDirection);
+            return _applicationProvider?.MainPage == null ? Task.CompletedTask :
+                _applicationProvider.MainPage.DisplayAlert(title, message, cancelButton, (XFFlow)flowDirection);
         }
 
         /// <summary>


### PR DESCRIPTION
Add null checking for application provider main page

﻿## Description of Change

The MainPage property could be null and I could see in our production logs that when displaying causes NRE.

### Bugs Fixed

This fixes this https://github.com/PrismLibrary/Prism/issues/2570

### API Changes
Changed:
Implementation changed to add null checking
Task PageDialogService.DisplayAlertAsync
Task<bool> PageDialogService.DisplayAlertAsync

### Behavioral Changes

NA

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard