### PR TITLE
Add null check for TabbedPage.Current in OnNavTo/From

### DIFF
--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -804,11 +804,8 @@ namespace Prism.Navigation
         {
             PageUtilities.OnNavigatedTo(toPage, parameters);
 
-            if (toPage is TabbedPage tabbedPage)
+            if (toPage is TabbedPage tabbedPage && tabbedPage.CurrentPage != null)
             {
-                if (tabbedPage.CurrentPage == null)
-                    return;
-
                 if (tabbedPage.CurrentPage is NavigationPage navigationPage)
                 {
                     PageUtilities.OnNavigatedTo(navigationPage.CurrentPage, parameters);
@@ -828,11 +825,8 @@ namespace Prism.Navigation
         {
             PageUtilities.OnNavigatedFrom(fromPage, parameters);
 
-            if (fromPage is TabbedPage tabbedPage)
+            if (fromPage is TabbedPage tabbedPage && tabbedPage.CurrentPage != null)
             {
-                if (tabbedPage.CurrentPage == null)
-                    return;
-
                 if (tabbedPage.CurrentPage is NavigationPage navigationPage)
                 {
                     PageUtilities.OnNavigatedFrom(navigationPage.CurrentPage, parameters);


### PR DESCRIPTION
﻿## Description of Change

Added a null check for the TabbedPage.Current in both the OnNvigatedTo and OnNavigatedFrom methods in the NavigatinService to prevent a null exception when testing with a blank TabbedPage

### Bugs Fixed

- #2576

### API Changes

None

### Behavioral Changes

None

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard