### PR TITLE
Fixed dialogservice invoking OnNavigatedTo method

### DIFF
--- a/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationService.cs
@@ -20,7 +20,7 @@ namespace Prism.Navigation
 
         // Brian appears to still be thinking...
         //not sure I like this static property, think about this a little more
-        protected internal static PageNavigationSource NavigationSource { get; protected set; } = PageNavigationSource.Device;
+        protected internal static PageNavigationSource NavigationSource { get; set; } = PageNavigationSource.Device;
 
         private readonly IContainerProvider _container;
         protected readonly IApplicationProvider _applicationProvider;

--- a/src/Forms/Prism.Forms/Navigation/PageNavigationSource.cs
+++ b/src/Forms/Prism.Forms/Navigation/PageNavigationSource.cs
@@ -3,6 +3,7 @@
     public enum PageNavigationSource
     {
         NavigationService,
-        Device
+        Device,
+        DialogService
     }
 }


### PR DESCRIPTION
﻿## Description of Change

When closing a dialog that was opened using the `IDialogService`, the `INavigationAware.OnNavigatedTo` method would be invoked.

This fixed that behavior. No, none of the `InavigatinAware` methods are invoked when closing a dialog.

### Bugs Fixed

- #2588

### API Changes

None

### Behavioral Changes

None

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard