### PR TITLE
Prevent NavigationPage & TabbedPage from inheriting parents BindingContext

### DIFF
--- a/src/Forms/Prism.Forms/Common/PageUtilities.cs
+++ b/src/Forms/Prism.Forms/Common/PageUtilities.cs
@@ -305,6 +305,15 @@ namespace Prism.Common
                 //and we don't want that. Set the VML
                 ViewModelLocator.SetAutowireViewModel(element, true);
             }
+
+            //due to the nature of NavigationPage and TabbedPage, it's possibe for them to inherit their parent BindingContext
+            //this causes issues with navigation interfaces being called when they shouldn't be. In this scenario, we want
+            //to set the binding context of these types to prevent them from inheriting their parent's binding context
+            var type = element.GetType();
+            if ((type == typeof(NavigationPage) || type == typeof(TabbedPage)) && element.BindingContext == null)
+            {
+                element.BindingContext = element;
+            }
         }
     }
 }


### PR DESCRIPTION
## Description of Change

By default, elements in a XF app will always inheit their parent's BindingContext. This becomes an issue when using a FlyoutPage and a TabbedPage and then using a NavigationPage as a child. The NavigationPage will inherit the parents BindingContext which would then invoke the Prism navigation interfaces when they shouldn't be invoked.

We fix this by preventing the NavigationPage and TabbedPage from inheriting their parent's BindingContext.

### Bugs Fixed

- #2587

### API Changes

None

### Behavioral Changes
The NavigationPage and TabbedPage types will no longer inherit their Parent's BindingContext. If you would like for these types to have a iffeent BindingContext, you will have to register a ViewModel with the Prism NavigatinService.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard