### PR TITLE
XmlDoc for WeakDelegatesManager

### DIFF
--- a/src/Prism.Core/Events/WeakDelegatesManager.cs
+++ b/src/Prism.Core/Events/WeakDelegatesManager.cs
@@ -4,21 +4,36 @@ using System.Linq;
 
 namespace Prism.Events
 {
+    /// <summary>
+    /// Manage delegates using weak references to prevent keeping target instances longer than expected.
+    /// </summary>
     public class WeakDelegatesManager
     {
         private readonly List<DelegateReference> _listeners = new List<DelegateReference>();
 
+        /// <summary>
+        /// Adds a weak reference to the specified <see cref="Delegate"/> listener.
+        /// </summary>
+        /// <param name="listener">The original <see cref="Delegate"/> to add.</param>
         public void AddListener(Delegate listener)
         {
             _listeners.Add(new DelegateReference(listener, false));
         }
 
+        /// <summary>
+        /// Removes the weak reference to the specified <see cref="Delegate"/> listener.
+        /// </summary>
+        /// <param name="listener">The original <see cref="Delegate"/> to remove.</param>
         public void RemoveListener(Delegate listener)
         {
             //Remove the listener, and prune collected listeners
             _listeners.RemoveAll(reference => reference.TargetEquals(null) || reference.TargetEquals(listener));
         }
 
+        /// <summary>
+        /// Invoke the delegates for all targets still being alive.
+        /// </summary>
+        /// <param name="args">An array of objects that are the arguments to pass to the delegates. -or- null, if the method represented by the delegate does not require arguments. </param>
         public void Raise(params object[] args)
         {
             _listeners.RemoveAll(listener => listener.TargetEquals(null));


### PR DESCRIPTION
﻿## Description of Change

Added XmlDoc for WeakDelegatesManager.cs

I opened the PrismLibrary_Wpf.sln solution and this was the only file with XmlDoc warnings.

Should I add an example element?

No code/behavior change.