### PR TITLE
add callback in dialogwindow.closing

### DIFF
--- a/src/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
+++ b/src/Wpf/Prism.Wpf/Services/Dialogs/DialogService.cs
@@ -158,7 +158,10 @@ namespace Prism.Services.Dialogs
             closingHandler = (o, e) =>
             {
                 if (!dialogWindow.GetDialogViewModel().CanCloseDialog())
+                {
+                    callback?.Invoke(dialogWindow.Result);
                     e.Cancel = true;
+                }
             };
             dialogWindow.Closing += closingHandler;
 


### PR DESCRIPTION
when the dialogwindow is closed, callback can invoke, but sometimes need callback invoke when the dialogwindow is open