### PR TITLE
bump to 9.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "8.2-pre",
+  "version": "9.0-pre",
+  "buildNumberOffset": 47,
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
﻿## Description of Change

As discussed in issue #2683 the Prism Library has left the .NET Foundation. As a result of this the official License Holder has changed from the .NET Foundation to the Prism Library team. While Prism will continue to ship under the MIT License we are bumping major versions to help better mark that a significant change has occurred.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard