### PR TITLE
EventAggregator.GetEvent Conditional Lock Acquisition

### DIFF
--- a/src/Prism.Core/Events/EventAggregator.cs
+++ b/src/Prism.Core/Events/EventAggregator.cs
@@ -24,23 +24,22 @@ namespace Prism.Events
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         public TEventType GetEvent<TEventType>() where TEventType : EventBase, new()
         {
-            lock (events)
+            if (!events.TryGetValue(typeof(TEventType), out EventBase eventInstance))
             {
-                EventBase existingEvent = null;
-
-                if (!events.TryGetValue(typeof(TEventType), out existingEvent))
+                lock (events)
                 {
-                    TEventType newEvent = new TEventType();
-                    newEvent.SynchronizationContext = syncContext;
-                    events[typeof(TEventType)] = newEvent;
-
-                    return newEvent;
-                }
-                else
-                {
-                    return (TEventType)existingEvent;
+                    if (!events.TryGetValue(typeof(TEventType), out eventInstance))
+                    {
+                        eventInstance = new TEventType()
+                        {
+                            SynchronizationContext = syncContext
+                        };
+                        events[typeof(TEventType)] = eventInstance;
+                    }
                 }
             }
+
+            return (TEventType)eventInstance;
         }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Because `EventAggregator` is AppendOnly the implementation can be opt…imized so lock acquisition is only done when the collection needs to be updated (known as [Double Check Locking by Jon Skeet](https://jonskeet.uk/csharp/singleton.html)). Benchmarking the two implementations ([Benchmark Repo](https://github.com/justinhachemeister/PrismBenchmarks) for reproducibility) shows this to be almost 40% faster for most runtimes:

### Host Information

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1706 (21H1/May2021Update)
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4510.0), X64 RyuJIT
```

|          Method |              Runtime |     Mean |    Error |   StdDev | Ratio | RatioSD | Rank | Allocated |
|---------------- |--------------------- |---------:|---------:|---------:|------:|--------:|-----:|----------:|
|        Baseline | .NET Framework 4.6.1 | 49.89 ns | 0.984 ns | 0.920 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock | .NET Framework 4.6.1 | 30.40 ns | 0.664 ns | 0.738 ns |  0.61 |    0.02 |    1 |         - |
|                 |                      |          |          |          |       |         |      |           |
|        Baseline | .NET Framework 4.6.2 | 52.96 ns | 1.011 ns | 0.946 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock | .NET Framework 4.6.2 | 30.05 ns | 0.659 ns | 0.677 ns |  0.57 |    0.01 |    1 |         - |
|                 |                      |          |          |          |       |         |      |           |
|        Baseline |   .NET Framework 4.7 | 51.64 ns | 1.103 ns | 1.032 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock |   .NET Framework 4.7 | 30.24 ns | 0.666 ns | 0.889 ns |  0.59 |    0.02 |    1 |         - |
|                 |                      |          |          |          |       |         |      |           |
|        Baseline | .NET Framework 4.7.2 | 48.79 ns | 0.798 ns | 0.746 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock | .NET Framework 4.7.2 | 30.33 ns | 0.586 ns | 0.548 ns |  0.62 |    0.02 |    1 |         - |
|                 |                      |          |          |          |       |         |      |           |
|        Baseline |   .NET Framework 4.8 | 49.15 ns | 0.923 ns | 0.863 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock |   .NET Framework 4.8 | 30.61 ns | 0.662 ns | 0.762 ns |  0.62 |    0.02 |    1 |         - |
|                 |                      |          |          |          |       |         |      |           |
|        Baseline |             .NET 6.0 | 38.03 ns | 0.812 ns | 0.869 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock |             .NET 6.0 | 27.54 ns | 0.574 ns | 0.589 ns |  0.73 |    0.03 |    1 |         - |
|                 |                      |          |          |          |       |         |      |           |
|        Baseline |        .NET Core 3.1 | 40.09 ns | 0.850 ns | 1.420 ns |  1.00 |    0.00 |    2 |         - |
| ConditionalLock |        .NET Core 3.1 | 27.92 ns | 0.595 ns | 0.686 ns |  0.70 |    0.03 |    1 |         - |

### Bugs Fixed

None.

### API Changes

None.

### Behavioral Changes

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

None - change optimizes existing behavior so lock acquisition is only done when the collection is added to.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard