### PR TITLE
Fix for bump to net6

### DIFF
--- a/src/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/src/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -23,7 +23,7 @@ Prism.Wpf helps you more easily design and build rich, flexible, and easy to mai
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcore')) OR $(TargetFramework.StartsWith('net5'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <Compile Remove="**\*.net45.cs" />
     <None Include="**\*.net45.cs" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change

The Prism.Wpf.csproj file was modified so that .net.cs files are omitted from a .net 6.0 core build.

Currently Prism.Wpf.csproj doesn't build because the .net45.cs files are being included in the .net 6.0 core build. This change ensures the .net45.cs files are only included when building with a version of dotnet that starts with a 4.

The test for this is doing a build. The old version fails, the new version succeeds.

### API Changes

None

### Behavioral Changes

None

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard