### PR TITLE
Update IDialogResult and DialogResult

### DIFF
--- a/src/Forms/Prism.Forms/Services/Dialogs/DialogResult.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/DialogResult.cs
@@ -5,9 +5,20 @@ using Prism.Navigation;
 
 namespace Prism.Services.Dialogs
 {
+    /// <summary>
+    /// An <see cref="IDialogResult"/> that contains <see cref="IDialogParameters"/> from the dialog
+    /// and the <see cref="System.Exception"/> of the dialog.
+    /// </summary>
     internal class DialogResult : IDialogResult
     {
+        /// <summary>
+        /// The exception of the dialog.
+        /// </summary>
         public Exception Exception { get; set; }
+
+        /// <summary>
+        /// The parameters from the dialog.
+        /// </summary>
         public IDialogParameters Parameters { get; set; }
     }
 }

--- a/src/Forms/Prism.Forms/Services/Dialogs/DialogResult.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/DialogResult.cs
@@ -6,7 +6,7 @@ using Prism.Navigation;
 namespace Prism.Services.Dialogs
 {
     /// <summary>
-    /// Provides returns information about a dialog that has been closed.
+    /// Provides information about a dialog that has been closed.
     /// </summary>
     internal class DialogResult : IDialogResult
     {

--- a/src/Forms/Prism.Forms/Services/Dialogs/DialogResult.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/DialogResult.cs
@@ -6,19 +6,14 @@ using Prism.Navigation;
 namespace Prism.Services.Dialogs
 {
     /// <summary>
-    /// An <see cref="IDialogResult"/> that contains <see cref="IDialogParameters"/> from the dialog
-    /// and the <see cref="System.Exception"/> of the dialog.
+    /// Provides returns information about a dialog that has been closed.
     /// </summary>
     internal class DialogResult : IDialogResult
     {
-        /// <summary>
-        /// The exception of the dialog.
-        /// </summary>
+        /// <inheritdoc />
         public Exception Exception { get; set; }
 
-        /// <summary>
-        /// The parameters from the dialog.
-        /// </summary>
+        /// <inheritdoc />
         public IDialogParameters Parameters { get; set; }
     }
 }

--- a/src/Forms/Prism.Forms/Services/Dialogs/IDialogResult.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/IDialogResult.cs
@@ -2,9 +2,20 @@
 
 namespace Prism.Services.Dialogs
 {
+    /// <summary>
+    /// Contains <see cref="IDialogParameters"/> from the dialog
+    /// and the <see cref="System.Exception"/> of the dialog.
+    /// </summary>
     public interface IDialogResult
     {
+        /// <summary>
+        /// The exception of the dialog.
+        /// </summary>
         Exception Exception { get; }
+
+        /// <summary>
+        /// The parameters from the dialog.
+        /// </summary>
         IDialogParameters Parameters { get; }
     }
 }

--- a/src/Forms/Prism.Forms/Services/Dialogs/IDialogResult.cs
+++ b/src/Forms/Prism.Forms/Services/Dialogs/IDialogResult.cs
@@ -3,18 +3,17 @@
 namespace Prism.Services.Dialogs
 {
     /// <summary>
-    /// Contains <see cref="IDialogParameters"/> from the dialog
-    /// and the <see cref="System.Exception"/> of the dialog.
+    /// Represents a class that returns information about a dialog that has been closed.
     /// </summary>
     public interface IDialogResult
     {
         /// <summary>
-        /// The exception of the dialog.
+        /// Gets the exception of the dialog.
         /// </summary>
         Exception Exception { get; }
 
         /// <summary>
-        /// The parameters from the dialog.
+        /// Gets the parameters from the dialog.
         /// </summary>
         IDialogParameters Parameters { get; }
     }


### PR DESCRIPTION
﻿## Description of Change

Add Missing XML Docs To IDialogResult and DialogResult.
I refer to [PrismLibrary_Wpf  comment](https://github.com/PrismLibrary/Prism/blob/master/src/Wpf/Prism.Wpf/Services/Dialogs/IDialogResult.cs).

I only add missing XML Docs so I omitted tests.

### Bugs Fixed

- #1978 

### API Changes

None.

### Behavioral Changes

None.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard