### PR TITLE
Delete unused `args` argument

### DIFF
--- a/e2e/Uno/src/HelloWorld.Skia.Gtk/Program.cs
+++ b/e2e/Uno/src/HelloWorld.Skia.Gtk/Program.cs
@@ -14,7 +14,7 @@ namespace HelloWorld.Skia.Gtk
                 expArgs.ExitApplication = true;
             };
 
-            var host = new GtkHost(() => new App(), args);
+            var host = new GtkHost(() => new App());
 
             host.Run();
         }


### PR DESCRIPTION
https://github.com/unoplatform/uno/blob/45c85c08ca4e52dbc62fb11feb19b26996e15bbb/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs#L67-L79

The constructor that takes `args` will be removed in Uno 5 and `args` is already unused.