### PR TITLE
fix: Navigation inserts page before current page in NavigationPage stack

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -992,8 +992,9 @@ public class PageNavigationService : INavigationService, IRegistryAware
         }
 
         var pageOffset = currentPage.Navigation.NavigationStack.Count;
-        if (currentPage.Navigation.NavigationStack.Count > 2)
-            pageOffset = currentPage.Navigation.NavigationStack.Count - 1;
+        // NOTE: Disabled due to Issue 2232
+        //if (currentPage.Navigation.NavigationStack.Count > 2)
+        //    pageOffset = currentPage.Navigation.NavigationStack.Count - 1;
 
         var onNavigatedFromTarget = currentPage;
         if (currentPage is NavigationPage navPage && navPage.CurrentPage != null)

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -1,3 +1,4 @@
+using Prism.Common;
 using Prism.Controls;
 using Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 using Prism.DryIoc.Maui.Tests.Mocks.Views;
@@ -186,6 +187,33 @@ public class NavigationTests : TestBase
         Assert.True(result.Success);
 
         Assert.IsType<MockViewC>(navigationPage.CurrentPage);
+    }
+
+    [Fact]
+    public async Task GoBack_Issue2232()
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        Assert.IsAssignableFrom<NavigationPage>(window.Page);
+        var navigationPage = (NavigationPage)window.Page;
+
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.NavigateTo("MockViewB"));
+        Assert.IsType<MockViewB>(navigationPage.CurrentPage);
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.NavigateTo("MockViewC"));
+        Assert.IsType<MockViewC>(navigationPage.CurrentPage);
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.NavigateTo("MockViewD/MockViewE"));
+        Assert.IsType<MockViewE>(navigationPage.CurrentPage);
+
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.GoBack());
+        Assert.IsType<MockViewD>(navigationPage.CurrentPage);
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.GoBack());
+        Assert.IsType<MockViewC>(navigationPage.CurrentPage);
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.GoBack());
+        Assert.IsType<MockViewB>(navigationPage.CurrentPage);
+        await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.GoBack());
+        Assert.IsType<MockViewA>(navigationPage.CurrentPage);
     }
 
     private void TestPage(Page page)

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
@@ -14,6 +14,10 @@ public abstract class MockViewModelBase : IConfirmNavigation
 
     public INavigationService NavigationService { get; }
 
+    public Task<INavigationResult> GoBack() => NavigationService.GoBackAsync();
+
+    public Task<INavigationResult> NavigateTo(string uri) => NavigationService.NavigateAsync(uri);
+
     public Page Page => _pageAccessor.Page;
 
     public bool StopNavigation { get; set; }


### PR DESCRIPTION
﻿## Description of Change

Fixes bug where navigation stack starting with `/NavigationPage/ViewA/ViewB` with navigation to `ViewC/ViewD` would end up with `/NavigationPage/ViewA/ViewC/ViewB/ViewD`

### Bugs Fixed

- closes #2832

### API Changes

none

### Behavioral Changes

Fixes bug with insert before logic with Navigation Page

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard