### PR TITLE
Transient factory

### DIFF
--- a/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
+++ b/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
@@ -235,7 +235,7 @@ namespace Prism.DryIoc
         /// <returns>The <see cref="IContainerRegistry" /> instance</returns>
         public IContainerRegistry Register(Type type, Func<object> factoryMethod)
         {
-            Instance.RegisterDelegate(type, r => factoryMethod());
+            Instance.RegisterDelegate(type, r => factoryMethod(), Reuse.Transient);
             return this;
         }
 
@@ -247,7 +247,7 @@ namespace Prism.DryIoc
         /// <returns>The <see cref="IContainerRegistry" /> instance</returns>
         public IContainerRegistry Register(Type type, Func<IContainerProvider, object> factoryMethod)
         {
-            Instance.RegisterDelegate(type, factoryMethod);
+            Instance.RegisterDelegate(type, factoryMethod, Reuse.Transient);
             return this;
         }
 

--- a/tests/Containers/Prism.Container.Shared/Tests/ContainerFixture.cs
+++ b/tests/Containers/Prism.Container.Shared/Tests/ContainerFixture.cs
@@ -438,6 +438,24 @@ namespace Prism.Ioc.Tests
             Assert.Equal(typeof(ServiceA), type);
         }
 
+        [Fact]
+        public void RegisterTransientDelegateReturnsNewInstanceEachTime()
+        {
+            var container = Setup.CreateContainer();
+            Setup.Registry.Register<ServiceA>(() => new ServiceA());
+
+            Assert.NotSame(container.Resolve<ServiceA>(), container.Resolve<ServiceA>());
+        }
+
+        [Fact]
+        public void RegisterTransientDelegateWithContainerReturnsNewInstanceEachTime()
+        {
+            var container = Setup.CreateContainer();
+            Setup.Registry.Register<ServiceA>(x => new ServiceA());
+
+            Assert.NotSame(container.Resolve<ServiceA>(), container.Resolve<ServiceA>());
+        }
+
         private static IServiceA CreateService() =>
             new ServiceA { SomeProperty = "Created through a factory" };
 


### PR DESCRIPTION
﻿## Description of Change

Fixing missing Reuse for transient factory registrations

### Bugs Fixed

- closes #2802

### API Changes

n/a

### Behavioral Changes

adds missing Reuse.Transient for Factory registrations on DryIoc

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard