### PR TITLE
Use instance of IContainerProvider to resolve dependencies

### DIFF
--- a/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
+++ b/src/Containers/Prism.DryIoc.Shared/DryIocContainerExtension.cs
@@ -305,7 +305,7 @@ namespace Prism.DryIoc
             }
             catch (Exception ex)
             {
-                throw new ContainerResolutionException(type, ex);
+                throw new ContainerResolutionException(type, ex, this);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Prism.DryIoc
             }
             catch (Exception ex)
             {
-                throw new ContainerResolutionException(type, name, ex);
+                throw new ContainerResolutionException(type, name, ex, this);
             }
         }
 
@@ -427,7 +427,7 @@ namespace Prism.DryIoc
                 }
                 catch (Exception ex)
                 {
-                    throw new ContainerResolutionException(type, ex);
+                    throw new ContainerResolutionException(type, ex, this);
                 }
             }
 
@@ -443,7 +443,7 @@ namespace Prism.DryIoc
                 }
                 catch (Exception ex)
                 {
-                    throw new ContainerResolutionException(type, name, ex);
+                    throw new ContainerResolutionException(type, name, ex, this);
                 }
             }
         }

--- a/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
+++ b/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
@@ -301,7 +301,7 @@ namespace Prism.Unity
             }
             catch (Exception ex)
             {
-                throw new ContainerResolutionException(type, ex);
+                throw new ContainerResolutionException(type, ex, this);
             }
         }
 
@@ -327,7 +327,7 @@ namespace Prism.Unity
             }
             catch (Exception ex)
             {
-                throw new ContainerResolutionException(type, name, ex);
+                throw new ContainerResolutionException(type, name, ex, this);
             }
         }
 
@@ -424,7 +424,7 @@ namespace Prism.Unity
                 }
                 catch (Exception ex)
                 {
-                    throw new ContainerResolutionException(type, ex);
+                    throw new ContainerResolutionException(type, ex, this);
                 }
             }
 
@@ -441,7 +441,7 @@ namespace Prism.Unity
                 }
                 catch (Exception ex)
                 {
-                    throw new ContainerResolutionException(type, name, ex);
+                    throw new ContainerResolutionException(type, name, ex, this);
                 }
             }
         }

--- a/tests/Forms/Prism.Forms.Regions.Tests/Tests/LocatorNavigationTargetHandlerFixture.cs
+++ b/tests/Forms/Prism.Forms.Regions.Tests/Tests/LocatorNavigationTargetHandlerFixture.cs
@@ -295,7 +295,7 @@ namespace Prism.Forms.Regions.Tests
         {
             var containerMock = new Mock<IContainerExtension>();
             containerMock.Setup(x => x.Resolve(typeof(object), typeof(TestView).Name))
-                .Throws(new ContainerResolutionException(typeof(object), typeof(TestView).Name, null));
+                .Throws(new ContainerResolutionException(typeof(object), typeof(TestView).Name, null, containerMock.Object));
             containerMock.Setup(x => x.Resolve(typeof(IActiveRegionHelper)))
                 .Returns(new RegionResolverOverrides());
 


### PR DESCRIPTION
﻿## Description of Change

This updates the ContainerResolutionException to take the IContainerProvider as an argument. This ensures that when GetErrors is called it will make use of the current scope rather than attempting to use the root container.

### Bugs Fixed

- ContainerResolutionException.GetErrors uses root container

### API Changes

- n/a

### Behavioral Changes

ContainerResolutionException will now use the scoped instance of the ContainerProvider that was used when the exception was thrown rather than falling back to the Root.