### PR TITLE
IActiveAware activates inactive views

### DIFF
--- a/e2e/Maui/PrismMauiDemo.sln
+++ b/e2e/Maui/PrismMauiDemo.sln
@@ -21,6 +21,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Maui", "..\..\
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Prism.DryIoc.Shared", "..\..\src\Containers\Prism.DryIoc.Shared\Prism.DryIoc.Shared.shproj", "{6E7EC81D-DA39-4C4F-A898-0148558C34F4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E91F80AA-3D61-4C28-B876-3EDFB5921E7D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Maui.Tests", "..\..\tests\Maui\Prism.DryIoc.Maui.Tests\Prism.DryIoc.Maui.Tests.csproj", "{EE6F0C99-61D1-4E2E-8185-FBA0D246D5C7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Maui.Tests", "..\..\tests\Maui\Prism.Maui.Tests\Prism.Maui.Tests.csproj", "{F3D2DFDB-95FB-4CBB-A624-35EB6550854D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Core.Tests", "..\..\tests\Prism.Core.Tests\Prism.Core.Tests.csproj", "{E0F13AA9-8083-47CA-B10D-93C5285D1505}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +64,18 @@ Global
 		{2CE09D7A-B67C-4586-8432-64EA2D1A3CE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CE09D7A-B67C-4586-8432-64EA2D1A3CE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CE09D7A-B67C-4586-8432-64EA2D1A3CE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE6F0C99-61D1-4E2E-8185-FBA0D246D5C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE6F0C99-61D1-4E2E-8185-FBA0D246D5C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE6F0C99-61D1-4E2E-8185-FBA0D246D5C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE6F0C99-61D1-4E2E-8185-FBA0D246D5C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3D2DFDB-95FB-4CBB-A624-35EB6550854D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3D2DFDB-95FB-4CBB-A624-35EB6550854D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3D2DFDB-95FB-4CBB-A624-35EB6550854D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3D2DFDB-95FB-4CBB-A624-35EB6550854D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0F13AA9-8083-47CA-B10D-93C5285D1505}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0F13AA9-8083-47CA-B10D-93C5285D1505}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0F13AA9-8083-47CA-B10D-93C5285D1505}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0F13AA9-8083-47CA-B10D-93C5285D1505}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,6 +86,9 @@ Global
 		{CC05A6F0-D8FF-498C-80F0-59DC9AAEB08E} = {8202B92A-A573-4365-8A15-E246504A7CBD}
 		{2CE09D7A-B67C-4586-8432-64EA2D1A3CE4} = {8202B92A-A573-4365-8A15-E246504A7CBD}
 		{6E7EC81D-DA39-4C4F-A898-0148558C34F4} = {8202B92A-A573-4365-8A15-E246504A7CBD}
+		{EE6F0C99-61D1-4E2E-8185-FBA0D246D5C7} = {E91F80AA-3D61-4C28-B876-3EDFB5921E7D}
+		{F3D2DFDB-95FB-4CBB-A624-35EB6550854D} = {E91F80AA-3D61-4C28-B876-3EDFB5921E7D}
+		{E0F13AA9-8083-47CA-B10D-93C5285D1505} = {E91F80AA-3D61-4C28-B876-3EDFB5921E7D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {50B0D1F3-D832-4C6C-858E-24F5F3B33632}

--- a/src/Maui/Prism.Maui/Behaviors/MultiPageActiveAwareBehavior.cs
+++ b/src/Maui/Prism.Maui/Behaviors/MultiPageActiveAwareBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using Prism.Common;
+using Prism.Extensions;
 
 namespace Prism.Behaviors;
 
@@ -54,37 +55,22 @@ public class MultiPageActiveAwareBehavior<T> : BehaviorBase<MultiPage<T>> where 
 
     private void SetActiveAware()
     {
-        foreach (var page in AssociatedObject.Children)
+        AssociatedObject.Children.ForEach(page => SetPageIsActive(page, AssociatedObject.CurrentPage == page));
+    }
+
+    private void SetPageIsActive(Page page, bool isActive)
+    {
+        MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, aa => SetIsActive(aa, isActive));
+
+        if (page is NavigationPage navPage)
         {
-            SetPageIsActive(page);
+            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(navPage.CurrentPage, aa => SetIsActive(aa, isActive));
         }
     }
 
-    private void SetPageIsActive(Page page)
+    private static void SetIsActive(IActiveAware activeAware, bool isActive)
     {
-        if(AssociatedObject.CurrentPage == page)
-        {
-            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetIsActive);
-            if (page is NavigationPage navPage)
-                MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(navPage.CurrentPage, SetIsActive);
-        }
-        else
-        {
-            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetNotActive);
-            if (page is NavigationPage navPage)
-                MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(navPage.CurrentPage, SetNotActive);
-        }
-    }
-
-    private void SetNotActive(IActiveAware activeAware)
-    {
-        if (activeAware.IsActive)
-            activeAware.IsActive = false;
-    }
-
-    private void SetIsActive(IActiveAware activeAware)
-    {
-        if (!activeAware.IsActive)
-            activeAware.IsActive = true;
+        if (activeAware?.IsActive != isActive)
+            activeAware.IsActive = isActive;
     }
 }

--- a/src/Maui/Prism.Maui/Behaviors/NavigationPageActiveAwareBehavior.cs
+++ b/src/Maui/Prism.Maui/Behaviors/NavigationPageActiveAwareBehavior.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Prism.Common;
+using Prism.Extensions;
 using PropertyChangingEventArgs = Microsoft.Maui.Controls.PropertyChangingEventArgs;
 
 namespace Prism.Behaviors;
@@ -36,12 +37,20 @@ public class NavigationPageActiveAwareBehavior : BehaviorBase<NavigationPage>
 
     private void SetActiveAware()
     {
-        foreach(var page in AssociatedObject.Navigation.NavigationStack)
+        if(AssociatedObject.Parent is TabbedPage tabbed && tabbed.CurrentPage != AssociatedObject)
         {
-            if (page != AssociatedObject.CurrentPage || AssociatedObject.Parent is TabbedPage tabbed && tabbed.CurrentPage != AssociatedObject)
-                MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetNotActive);
-            else
-                MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetIsActive);
+            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(AssociatedObject, SetNotActive);
+            AssociatedObject.Navigation.NavigationStack.ForEach(page => MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetNotActive));
+        }
+        else
+        {
+            AssociatedObject.Navigation.NavigationStack.ForEach(page =>
+            {
+                if (page != AssociatedObject.CurrentPage)
+                    MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetNotActive);
+                else
+                    MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(page, SetIsActive);
+            });
         }
     }
 

--- a/src/Maui/Prism.Maui/Extensions/CollectionExtensions.cs
+++ b/src/Maui/Prism.Maui/Extensions/CollectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Prism.Extensions;
+
+internal static class CollectionExtensions
+{
+    public static void ForEach<T>(this IReadOnlyList<T> list, Action<T> action)
+    {
+        foreach (var item in list)
+            action(item);
+    }
+
+    public static void ForEach<T>(this IList<T> list, Action<T> action)
+    {
+        foreach (var item in list)
+            action(item);
+    }
+}

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
@@ -75,7 +75,7 @@ public class NavigationBehaviors : TestBase
             b.AddTabbedSegment(t =>
                 t.CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewA"))
                  .CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewB"))
-                 .SelectedTab("MockViewB")));
+                 .SelectedTab("NavigationPage|MockViewB")));
 
         Assert.IsType<TabbedPage>(rootPage);
 

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls;
 using Prism.Controls;
 using Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 using Prism.DryIoc.Maui.Tests.Mocks.Views;
@@ -71,7 +71,11 @@ public class NavigationBehaviors : TestBase
     [Fact]
     public void TabPageSetsSecondTabIsActiveWithNavigationPage()
     {
-        var rootPage = StartAndGetRootPage(b => b.AddTabbedSegment(t => t.CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewA")).CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewB")).SelectedTab("MockViewB")));
+        var rootPage = StartAndGetRootPage(b =>
+            b.AddTabbedSegment(t =>
+                t.CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewA"))
+                 .CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewB"))
+                 .SelectedTab("MockViewB")));
 
         Assert.IsType<TabbedPage>(rootPage);
 

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.Maui.Controls;
+using Prism.Controls;
+using Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
+using Prism.DryIoc.Maui.Tests.Mocks.Views;
+using Prism.Navigation.Builder;
+
+namespace Prism.DryIoc.Maui.Tests.Fixtures.Behaviors;
+
+public class NavigationBehaviors : TestBase
+{
+    public NavigationBehaviors(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [Fact]
+    public void RootPageIsNotActive()
+    {
+        var rootPage = StartAndGetRootPage("NavigationPage/MockViewA/MockViewB");
+
+        Assert.IsType<PrismNavigationPage>(rootPage);
+        var navPage = (NavigationPage)rootPage;
+
+        var viewA = navPage.Navigation.NavigationStack[0];
+        var viewB = navPage.Navigation.NavigationStack[1];
+
+        Assert.IsType<MockViewA>(viewA);
+        Assert.IsType<MockViewB>(viewB);
+
+        AssertIsActive(viewA, false);
+        AssertIsActive(viewB, true);
+    }
+
+    [Fact]
+    public void TabPageSetsFirstTabIsActive()
+    {
+        var rootPage = StartAndGetRootPage(b => b.AddTabbedSegment(t => t.CreateTab("MockViewA").CreateTab("MockViewB")));
+
+        Assert.IsType<TabbedPage>(rootPage);
+
+        var tabbed = (TabbedPage)rootPage;
+        AssertIsActive(tabbed.Children[0], true);
+        AssertIsActive(tabbed.Children[1], false);
+    }
+
+    [Fact]
+    public void TabPageSetsSecondTabIsActive()
+    {
+        var rootPage = StartAndGetRootPage(b => b.AddTabbedSegment(t => t.CreateTab("MockViewA").CreateTab("MockViewB").SelectedTab("MockViewB")));
+
+        Assert.IsType<TabbedPage>(rootPage);
+
+        var tabbed = (TabbedPage)rootPage;
+        AssertIsActive(tabbed.Children[0], false);
+        AssertIsActive(tabbed.Children[1], true);
+    }
+
+    [Fact]
+    public void TabPageSetsFirstTabIsActiveWithNavigationPage()
+    {
+        var rootPage = StartAndGetRootPage(b => b.AddTabbedSegment(t => t.CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewA")).CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewB"))));
+
+        Assert.IsType<TabbedPage>(rootPage);
+
+        var tabbed = (TabbedPage)rootPage;
+
+        AssertIsActive(GetTabChild(tabbed, 0), true);
+        AssertIsActive(GetTabChild(tabbed, 1), false);
+    }
+
+    [Fact]
+    public void TabPageSetsSecondTabIsActiveWithNavigationPage()
+    {
+        var rootPage = StartAndGetRootPage(b => b.AddTabbedSegment(t => t.CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewA")).CreateTab(tb => tb.AddNavigationPage().AddSegment("MockViewB")).SelectedTab("MockViewB")));
+
+        Assert.IsType<TabbedPage>(rootPage);
+
+        var tabbed = (TabbedPage)rootPage;
+        AssertIsActive(GetTabChild(tabbed, 0), false);
+        AssertIsActive(GetTabChild(tabbed, 1), true);
+    }
+
+    private void AssertIsActive(Page page, bool expected)
+    {
+        var viewModel = (MockViewModelBase)page.BindingContext;
+        Assert.Equal(expected, viewModel.IsActive);
+    }
+
+    private Page GetTabChild(TabbedPage tabbed, int index)
+    {
+        var child = tabbed.Children[index];
+        Assert.IsType<PrismNavigationPage>(child);
+        var navPage = (NavigationPage)child;
+        return navPage.CurrentPage;
+    }
+
+    private Page StartAndGetRootPage(Action<INavigationBuilder> initialNav)
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart((_, nav) =>
+        {
+            var navBuilder = nav.CreateBuilder();
+            initialNav(navBuilder);
+            return navBuilder.NavigateAsync();
+        }))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        var rootPage = window.Page;
+
+        Assert.NotNull(rootPage);
+        return rootPage;
+    }
+
+    private Page StartAndGetRootPage(string uri)
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart(uri))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        var rootPage = window.Page;
+
+        Assert.NotNull(rootPage);
+        return rootPage;
+    }
+}

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -3,6 +3,7 @@ using Prism.Controls;
 using Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 using Prism.DryIoc.Maui.Tests.Mocks.Views;
 using Prism.Navigation.Xaml;
+using TabbedPage = Microsoft.Maui.Controls.TabbedPage;
 
 namespace Prism.DryIoc.Maui.Tests.Fixtures.Navigation;
 
@@ -245,6 +246,34 @@ public class NavigationTests : TestBase
         Assert.IsType<MockViewB>(navigationPage.CurrentPage);
         await MvvmHelpers.InvokeViewAndViewModelActionAsync<MockViewModelBase>(navigationPage.CurrentPage, x => x.GoBack());
         Assert.IsType<MockViewA>(navigationPage.CurrentPage);
+    }
+
+    [Fact]
+    public async Task TabbedPageSelectTabSetsCurrentTab()
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart("TabbedPage?createTab=MockViewA&createTab=MockViewB&selectedTab=MockViewB"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        Assert.IsAssignableFrom<TabbedPage>(window.Page);
+        var tabbedPage = (TabbedPage)window.Page;
+        Assert.NotNull(tabbedPage);
+        Assert.IsType<MockViewB>(tabbedPage.CurrentPage);
+    }
+
+    [Fact]
+    public async Task TabbedPageSelectTabSetsCurrentTabWithNavigationPageTab()
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart("TabbedPage?createTab=NavigationPage%2FMockViewA&createTab=NavigationPage%2FMockViewB&selectedTab=NavigationPage|MockViewB"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        Assert.IsAssignableFrom<TabbedPage>(window.Page);
+        var tabbedPage = (TabbedPage)window.Page;
+        Assert.NotNull(tabbedPage);
+        var navPage = tabbedPage.CurrentPage as NavigationPage;
+        Assert.NotNull(navPage);
+        Assert.IsType<MockViewB>(navPage.CurrentPage);
     }
 
     private void TestPage(Page page)

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
@@ -2,9 +2,11 @@
 
 namespace Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 
-public abstract class MockViewModelBase : IConfirmNavigation
+public abstract class MockViewModelBase : IActiveAware, IConfirmNavigation
 {
     private readonly IPageAccessor _pageAccessor;
+
+    public event EventHandler IsActiveChanged;
 
     protected MockViewModelBase(IPageAccessor pageAccessor, INavigationService navigationService)
     {
@@ -21,6 +23,8 @@ public abstract class MockViewModelBase : IConfirmNavigation
     public Page Page => _pageAccessor.Page;
 
     public bool StopNavigation { get; set; }
+
+    public bool IsActive { get; set; }
 
     public bool CanNavigate(INavigationParameters parameters) =>
         !StopNavigation;


### PR DESCRIPTION
﻿## Description of Change

This updates the behaviors to help ensure that we do not accidently mark a View/ViewModel as active when it technically is not. For instance in the case where a NavigationPage is child of a TabbedPage. The NavigationPage may not be the active tab of the TabbedPage while the CurrentPage of the NavigationPage will still be marked as active.

This ensures that all children of the NavigationPage are in fact not active in this scenario.

### Bugs Fixed

- closes #2816 

### API Changes

n/a

### Behavioral Changes

Adds additional checks before setting IActiveAware.IsActive