### PR TITLE
Fix MAUI flyout navigation

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -340,7 +340,9 @@ public class PageNavigationService : INavigationService, IRegistryAware
 
         var pageParameters = UriParsingHelper.GetSegmentParameters(nextSegment);
 
-        useModalNavigation = pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation) ? pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation) : useModalNavigation;
+        useModalNavigation = pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation) ? pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation) : false;
+        if (!useModalNavigation.Value && !MvvmHelpers.HasNavigationPageParent(currentPage) && (currentPage is not FlyoutPage || (currentPage.Parent is FlyoutPage parentFlyout && parentFlyout.Flyout == currentPage)))
+            useModalNavigation = true;
 
         animated = parameters.ContainsKey(KnownNavigationParameters.Animated) ?
             parameters.GetValue<bool>(KnownNavigationParameters.Animated) :

--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -340,9 +340,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
 
         var pageParameters = UriParsingHelper.GetSegmentParameters(nextSegment);
 
-        useModalNavigation =  pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation) ? pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation) : false;        
-        if (!useModalNavigation.Value && !MvvmHelpers.HasNavigationPageParent(currentPage))
-            useModalNavigation = true;
+        useModalNavigation = pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation) ? pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation) : useModalNavigation;
 
         animated = parameters.ContainsKey(KnownNavigationParameters.Animated) ?
             parameters.GetValue<bool>(KnownNavigationParameters.Animated) :

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -117,6 +117,38 @@ public class NavigationTests : TestBase
         Assert.IsType<MockViewB>(rootPage.Navigation.ModalStack.Last());
     }
 
+    [Fact]
+    public async Task FlyoutRelativeNavigation_RemovesPage_AndNavigatesNotModally()
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart("MockHome/NavigationPage/MockViewA"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        var rootPage = window.Page as MockHome;
+        Assert.NotNull(rootPage);
+        TestPage(rootPage);
+        Assert.NotNull(rootPage.Detail);
+        var detailPage = rootPage.Detail as NavigationPage;
+        Assert.NotNull(detailPage);
+        TestPage(detailPage);
+        var currentPage = detailPage.CurrentPage;
+        Assert.IsType<MockViewA>(currentPage);
+        TestPage(currentPage);
+        var container = rootPage.GetContainerProvider();
+        var navService = container.Resolve<INavigationService>();
+        Assert.Empty(rootPage.Navigation.ModalStack);
+        var result = await navService.NavigateAsync("./NavigationPage/MockViewB");
+        Assert.True(result.Success);
+        Assert.Empty(rootPage.Navigation.ModalStack);
+        Assert.NotNull(rootPage.Detail);
+        detailPage = rootPage.Detail as NavigationPage;
+        Assert.NotNull(detailPage);
+        TestPage(detailPage);
+        currentPage = detailPage.CurrentPage;
+        Assert.IsType<MockViewB>(currentPage);
+        TestPage(currentPage);
+    }
+
     [Fact(Skip = "Blocked by dotnet/maui/issues/8157")]
     public async Task RelativeNavigation_RemovesPage_AndNavigatesModally()
     {

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -134,8 +134,7 @@ public class NavigationTests : TestBase
         var currentPage = detailPage.CurrentPage;
         Assert.IsType<MockViewA>(currentPage);
         TestPage(currentPage);
-        var container = rootPage.GetContainerProvider();
-        var navService = container.Resolve<INavigationService>();
+        var navService = Prism.Navigation.Xaml.Navigation.GetNavigationService(rootPage);
         Assert.Empty(rootPage.Navigation.ModalStack);
         var result = await navService.NavigateAsync("./NavigationPage/MockViewB");
         Assert.True(result.Success);


### PR DESCRIPTION
﻿## Description of Change

There was a fallback to `true` for `useModalNavigation` if no other value was specified. This broke the FlyoutPage navigation (and maybe other things as well).
I added a new test that fails without my changes and succeeds with my changes.

### Bugs Fixed

- fixes #2820 

### API Changes

n/a

### Behavioral Changes

`useModalNavigation` is now correctly calculated
