### PR TITLE
EA add static instance

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -12,6 +12,7 @@ on:
       - Directory.Packages.props
       - xunit.runner.json
       - 'src/Prism.Core/**'
+      - 'src/Prism.Events/**'
       - 'tests/Prism.Core.Tests/**'
 
 jobs:

--- a/.github/workflows/build_forms.yml
+++ b/.github/workflows/build_forms.yml
@@ -12,6 +12,7 @@ on:
       - Directory.Packages.props
       - xunit.runner.json
       - 'src/Prism.Core/**'
+      - 'src/Prism.Events/**'
       - 'tests/Prism.Core.Tests/**'
       - 'src/Forms/**'
       - 'tests/Forms/**'

--- a/.github/workflows/build_maui.yml
+++ b/.github/workflows/build_maui.yml
@@ -12,6 +12,7 @@ on:
       - Directory.Packages.props
       - xunit.runner.json
       - 'src/Prism.Core/**'
+      - 'src/Prism.Events/**'
       - 'tests/Prism.Core.Tests/**'
       - 'src/Maui/**'
       - 'tests/Containers/**'

--- a/.github/workflows/build_uno.yml
+++ b/.github/workflows/build_uno.yml
@@ -12,6 +12,7 @@ on:
       - Directory.Packages.props
       - xunit.runner.json
       - 'src/Prism.Core/**'
+      - 'src/Prism.Events/**'
       - 'tests/Prism.Core.Tests/**'
       - 'src/Wpf/**'
       - 'tests/Wpf/**'

--- a/.github/workflows/build_wpf.yml
+++ b/.github/workflows/build_wpf.yml
@@ -12,6 +12,7 @@ on:
       - Directory.Packages.props
       - xunit.runner.json
       - 'src/Prism.Core/**'
+      - 'src/Prism.Events/**'
       - 'tests/Prism.Core.Tests/**'
       - 'src/Wpf/**'
       - 'tests/Wpf/**'

--- a/src/Prism.Events/EventAggregator.cs
+++ b/src/Prism.Events/EventAggregator.cs
@@ -1,7 +1,6 @@
-
-
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 
 namespace Prism.Events
@@ -11,8 +10,31 @@ namespace Prism.Events
     /// </summary>
     public class EventAggregator : IEventAggregator
     {
+        /// <summary>
+        /// Gets the Current Instance of the <see cref="IEventAggregator"/>
+        /// </summary>
+        public static IEventAggregator Current { get; private set; }
+
+        /// <summary>
+        /// Sets the <see cref="Current"/> event aggregator for Testing Purposes.
+        /// This should not be used outside of testing scenarios.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetCurrent(IEventAggregator eventAggregator)
+        {
+            Current = eventAggregator;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="EventAggregator"/>
+        /// </summary>
+        public EventAggregator()
+        {
+            Current = this;
+        }
+
         private readonly Dictionary<Type, EventBase> events = new Dictionary<Type, EventBase>();
-        // Captures the sync context for the UI thread when constructed on the UI thread 
+        // Captures the sync context for the UI thread when constructed on the UI thread
         // in a platform agnostic way so it can be used for UI thread dispatching
         private readonly SynchronizationContext syncContext = SynchronizationContext.Current;
 

--- a/src/Prism.Events/EventAggregator.cs
+++ b/src/Prism.Events/EventAggregator.cs
@@ -10,19 +10,15 @@ namespace Prism.Events
     /// </summary>
     public class EventAggregator : IEventAggregator
     {
-        /// <summary>
-        /// Gets the Current Instance of the <see cref="IEventAggregator"/>
-        /// </summary>
-        public static IEventAggregator Current { get; private set; }
+        private static IEventAggregator _current;
 
         /// <summary>
-        /// Sets the <see cref="Current"/> event aggregator for Testing Purposes.
-        /// This should not be used outside of testing scenarios.
+        /// Gets or Sets the Current Instance of the <see cref="IEventAggregator"/>
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void SetCurrent(IEventAggregator eventAggregator)
+        public static IEventAggregator Current
         {
-            Current = eventAggregator;
+            get => _current ??= new EventAggregator();
+            set => _current = value;
         }
 
         /// <summary>
@@ -30,7 +26,10 @@ namespace Prism.Events
         /// </summary>
         public EventAggregator()
         {
-            Current = this;
+            if(_current is null)
+            {
+                _current = this;
+            }
         }
 
         private readonly Dictionary<Type, EventBase> events = new Dictionary<Type, EventBase>();


### PR DESCRIPTION
﻿## Description of Change

Adds a static Current instance of the EventAggregator. This is useful for scenarios when working in native code where you may not have easy access to CI however you need to publish or subscribe to events.

### Bugs Fixed

- n/a

### API Changes

List all API changes here (or just put None), example:

Added:

- static IEventAggregator Current { get; set; }

### Behavioral Changes

n/a

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard