### PR TITLE
Fixing runtime warning

### DIFF
--- a/src/Maui/Prism.Maui/Mvvm/ViewModelLocator.cs
+++ b/src/Maui/Prism.Maui/Mvvm/ViewModelLocator.cs
@@ -52,7 +52,7 @@ public static class ViewModelLocator
         if (newValue == null || bindable.BindingContext != null)
             return;
         else if(newValue is Type)
-            bindable.SetValue(AutowireViewModelProperty, true);
+            bindable.SetValue(AutowireViewModelProperty, ViewModelLocatorBehavior.Automatic);
     }
 
     internal static void Autowire(object view)


### PR DESCRIPTION
Fixed runtime output window warning "Microsoft.Maui.Controls.BindableObject: Warning: Cannot convert True to type 'Prism.Mvvm.ViewModelLocatorBehavior'"

﻿## Description of Change

Replaced old "True" with new "ViewModelLocatorBehavior.Automatic" when setting AutowireViewModel property.

### API Changes

N/A

### Behavioral Changes

No more warning

### PR Checklist

- [X] Tested manually, no warning anymore
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard