### PR TITLE
Adding Exception Handler

### DIFF
--- a/src/Prism.Core/Commands/DelegateCommand.cs
+++ b/src/Prism.Core/Commands/DelegateCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Prism.Properties;
 
@@ -46,7 +47,17 @@ namespace Prism.Commands
         ///</summary>
         public void Execute()
         {
-            _executeMethod();
+            try
+            {
+                _executeMethod();
+            }
+            catch (Exception ex)
+            {
+                if (!ExceptionHandler.CanHandle(ex))
+                    throw;
+
+                ExceptionHandler.Handle(ex, null);
+            }
         }
 
         /// <summary>
@@ -98,6 +109,102 @@ namespace Prism.Commands
         {
             _canExecuteMethod = canExecuteExpression.Compile();
             ObservesPropertyInternal(canExecuteExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch(Action<Exception> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch(Action<Exception, object> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch<TException>(Action<TException> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch<TException>(Action<TException, object> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch(Func<Exception, Task> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch(Func<Exception, object, Task> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch<TException>(Func<TException, Task> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand Catch<TException>(Func<TException, object, Task> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
             return this;
         }
     }

--- a/src/Prism.Core/Commands/DelegateCommand.cs
+++ b/src/Prism.Core/Commands/DelegateCommand.cs
@@ -66,7 +66,19 @@ namespace Prism.Commands
         /// <returns>Returns <see langword="true"/> if the command can execute,otherwise returns <see langword="false"/>.</returns>
         public bool CanExecute()
         {
-            return _canExecuteMethod();
+            try
+            {
+                return _canExecuteMethod();
+            }
+            catch (Exception ex)
+            {
+                if (!ExceptionHandler.CanHandle(ex))
+                    throw;
+
+                ExceptionHandler.Handle(ex, null);
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Prism.Core/Commands/DelegateCommandBase.cs
+++ b/src/Prism.Core/Commands/DelegateCommandBase.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Windows.Input;
+using Prism.Common;
 
 namespace Prism.Commands
 {
@@ -16,6 +17,11 @@ namespace Prism.Commands
 
         private SynchronizationContext _synchronizationContext;
         private readonly HashSet<string> _observedPropertiesExpressions = new HashSet<string>();
+
+        /// <summary>
+        /// Provides an Exception Handler to register callbacks or handle encountered exceptions within 
+        /// </summary>
+        protected readonly MulticastExceptionHandler ExceptionHandler = new MulticastExceptionHandler();
 
         /// <summary>
         /// Creates a new instance of a <see cref="DelegateCommandBase"/>, specifying both the execute action and the can execute function.
@@ -32,7 +38,7 @@ namespace Prism.Commands
 
         /// <summary>
         /// Raises <see cref="ICommand.CanExecuteChanged"/> so every 
-        /// command invoker can requery <see cref="ICommand.CanExecute"/>.
+        /// command invoker can re-query <see cref="ICommand.CanExecute"/>.
         /// </summary>
         protected virtual void OnCanExecuteChanged()
         {
@@ -48,7 +54,7 @@ namespace Prism.Commands
 
         /// <summary>
         /// Raises <see cref="CanExecuteChanged"/> so every command invoker
-        /// can requery to check if the command can execute.
+        /// can re-query to check if the command can execute.
         /// </summary>
         /// <remarks>Note that this will trigger the execution of <see cref="CanExecuteChanged"/> once for each invoker.</remarks>
         [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]

--- a/src/Prism.Core/Commands/DelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/DelegateCommand{T}.cs
@@ -102,7 +102,19 @@ namespace Prism.Commands
         ///</returns>
         public bool CanExecute(T parameter)
         {
-            return _canExecuteMethod(parameter);
+            try
+            {
+                return _canExecuteMethod(parameter);
+            }
+            catch (Exception ex)
+            {
+                if (!ExceptionHandler.CanHandle(ex))
+                    throw;
+
+                ExceptionHandler.Handle(ex, parameter);
+
+                return false;
+            }
         }
 
         /// <summary>
@@ -133,7 +145,21 @@ namespace Prism.Commands
         /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
         protected override bool CanExecute(object parameter)
         {
-            return CanExecute((T)parameter);
+            try
+            {
+                // Note: We don't call Execute because we would potentially invoke the Try/Catch twice.
+                // It is also needed here incase (T)parameter throws the exception
+                return CanExecute((T)parameter);
+            }
+            catch (Exception ex)
+            {
+                if (!ExceptionHandler.CanHandle(ex))
+                    throw;
+
+                ExceptionHandler.Handle(ex, parameter);
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Prism.Core/Commands/DelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/DelegateCommand{T}.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Prism.Properties;
 
@@ -79,7 +80,17 @@ namespace Prism.Commands
         ///<param name="parameter">Data used by the command.</param>
         public void Execute(T parameter)
         {
-            _executeMethod(parameter);
+            try
+            {
+                _executeMethod(parameter);
+            }
+            catch (Exception ex)
+            {
+                if (!ExceptionHandler.CanHandle(ex))
+                    throw;
+
+                ExceptionHandler.Handle(ex, parameter);
+            }
         }
 
         ///<summary>
@@ -100,7 +111,19 @@ namespace Prism.Commands
         /// <param name="parameter">Command Parameter</param>
         protected override void Execute(object parameter)
         {
-            Execute((T)parameter);
+            try
+            {
+                // Note: We don't call Execute because we would potentially invoke the Try/Catch twice.
+                // It is also needed here incase (T)parameter throws the exception
+                _executeMethod((T)parameter);
+            }
+            catch (Exception ex)
+            {
+                if (!ExceptionHandler.CanHandle(ex))
+                    throw;
+
+                ExceptionHandler.Handle(ex, parameter);
+            }
         }
 
         /// <summary>
@@ -135,6 +158,102 @@ namespace Prism.Commands
             Expression<Func<T, bool>> expression = Expression.Lambda<Func<T, bool>>(canExecuteExpression.Body, Expression.Parameter(typeof(T), "o"));
             _canExecuteMethod = expression.Compile();
             ObservesPropertyInternal(canExecuteExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch(Action<Exception> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch(Action<Exception, object> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch<TException>(Action<TException> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch<TException>(Action<TException, object> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch(Func<Exception, Task> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch(Func<Exception, object, Task> @catch)
+        {
+            ExceptionHandler.Register<Exception>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch<TException>(Func<TException, Task> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an async callback if an exception is encountered while executing the <see cref="DelegateCommand"/>
+        /// </summary>
+        /// <typeparam name="TException">The Exception Type</typeparam>
+        /// <param name="catch">The Callback</param>
+        /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        public DelegateCommand<T> Catch<TException>(Func<TException, object, Task> @catch)
+            where TException : Exception
+        {
+            ExceptionHandler.Register<TException>(@catch);
             return this;
         }
     }

--- a/src/Prism.Core/Common/MulticastExceptionHandler.cs
+++ b/src/Prism.Core/Common/MulticastExceptionHandler.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Prism.Common;
+
+#nullable enable
+/// <summary>
+/// Provides a wrapper for managing multicast delegates for handling specific errors
+/// </summary>
+public struct MulticastExceptionHandler
+{
+    private readonly Dictionary<Type, MulticastDelegate> _handlers;
+
+    /// <summary>
+    /// Initializes a new MulticastExceptionHandler
+    /// </summary>
+    public MulticastExceptionHandler()
+    {
+        _handlers = new Dictionary<Type, MulticastDelegate>();
+    }
+
+    public void Register<TException>(MulticastDelegate callback)
+        where TException : Exception
+    {
+        _handlers.Add(typeof(TException), callback);
+    }
+
+    /// <summary>
+    /// Determines if there is a callback registered to handle the specified exception
+    /// </summary>
+    /// <param name="exception">An <see cref="Exception"/> to handle or rethrow</param>
+    /// <returns><c>True</c> if a Callback has been registered for the given type of <see cref="Exception"/>.</returns>
+    public bool CanHandle(Exception exception) =>
+        GetDelegate(exception.GetType()) is not null;
+
+    /// <summary>
+    /// Handles a specified 
+    /// </summary>
+    /// <param name="exception"></param>
+    /// <param name="parameter"></param>
+    public async void Handle(Exception exception, object? parameter = null) =>
+        await HandleAsync(exception, parameter);
+
+    public async Task HandleAsync(Exception exception, object? parameter = null)
+    {
+        var multicastDelegate = GetDelegate(exception.GetType());
+
+        if (multicastDelegate is null)
+            return;
+
+        // Get Invoke() method of the delegate
+        var invokeMethod = multicastDelegate.GetType().GetMethod("Invoke");
+
+        if (invokeMethod == null)
+            throw new InvalidOperationException($"Could not find Invoke() method for delegate of type {multicastDelegate.GetType().Name}");
+
+        var parameters = invokeMethod.GetParameters();
+        var arguments = parameters.Length switch
+        {
+            0 => Array.Empty<object?>(),
+            1 => typeof(Exception).IsAssignableFrom(parameters[0].ParameterType) ? new object?[] { exception } : new object?[] { parameter },
+            2 => typeof(Exception).IsAssignableFrom(parameters[0].ParameterType) ? new object?[] { exception, parameter } : new object?[] { parameter, exception },
+            _ => throw new InvalidOperationException($"Handler of type {multicastDelegate.GetType().Name} is not supported", exception)
+        };
+
+        // Invoke the delegate
+        var result = invokeMethod.Invoke(multicastDelegate, arguments);
+
+        // If the handler is async (returns a Task), then we await the task
+        if (result is Task task)
+        {
+            await task;
+        }
+#if NET6_0_OR_GREATER
+        else if (result is ValueTask valueTask)
+        {
+            await valueTask;
+        }
+#endif
+    }
+
+    private MulticastDelegate? GetDelegate(Type type)
+    {
+        if (_handlers.ContainsKey(type))
+            return _handlers[type];
+        else if (type.BaseType is not null)
+            return GetDelegate(type.BaseType);
+
+        return null;
+    }
+}

--- a/tests/Prism.Core.Tests/Common/MulticastExceptionHandlerFixture.cs
+++ b/tests/Prism.Core.Tests/Common/MulticastExceptionHandlerFixture.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Prism.Common;
+using Xunit;
+
+namespace Prism.Core.Tests.Common;
+
+#nullable enable
+public class MulticastExceptionHandlerFixture
+{
+    [Fact]
+    public void CanHandleGenericException()
+    {
+        var handler = new MulticastExceptionHandler();
+        void Callback(Exception exception) { }
+        handler.Register<Exception>(Callback);
+        Assert.True(handler.CanHandle(new Exception()));
+    }
+
+    [Fact]
+    public void DidHandleGenericException()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<Exception>(Callback);
+        bool handled = false;
+        void Callback(Exception exception)
+        {
+            handled = true;
+        }
+        handler.Handle(new Exception());
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public void CanHandleGenericExceptionAsync()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<Exception>(Callback);
+        Task Callback(Exception exception)
+        {
+            return Task.CompletedTask;
+        }
+        Assert.True(handler.CanHandle(new Exception()));
+    }
+
+    [Fact]
+    public void CanHandleUsingBaseExceptionType()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<IOException>(Callback);
+        Task Callback(IOException exception)
+        {
+            return Task.CompletedTask;
+        }
+        Assert.True(handler.CanHandle(new FileNotFoundException()));
+    }
+
+    [Fact]
+    public void DidHandleGenericExceptionAsync()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<Exception>(Callback);
+        bool handled = false;
+        Task Callback(Exception exception)
+        {
+            handled = true;
+            return Task.CompletedTask;
+        }
+        handler.Handle(new Exception());
+
+        Assert.True(handled);
+    }
+    [Fact]
+    public void CanHandleSpecificException()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<FileNotFoundException>(Callback);
+        void Callback(FileNotFoundException exception) { }
+        Assert.True(handler.CanHandle(new FileNotFoundException()));
+    }
+
+    [Fact]
+    public async Task DidHandleSpecificException()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<FileNotFoundException>(Callback);
+        bool handled = false;
+        void Callback(FileNotFoundException exception)
+        {
+            handled = true;
+        }
+        await handler.HandleAsync(new FileNotFoundException());
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task DidHandleSpecificExceptionWithParameter()
+    {
+        var handler = new MulticastExceptionHandler();
+        var expected = Guid.NewGuid();
+        bool handled = false;
+        handler.Register<FileNotFoundException>(Callback);
+
+        void Callback(FileNotFoundException fnfe, object? parameter)
+        {
+            Assert.Equal(expected, parameter);
+            handled = true;
+        }
+        await handler.HandleAsync(new FileNotFoundException(), expected);
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public void CanHandleSpecificExceptionAsync()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<FileNotFoundException>(Callback);
+        Task Callback(FileNotFoundException exception)
+        {
+            return Task.CompletedTask;
+        }
+        Assert.True(handler.CanHandle(new FileNotFoundException()));
+    }
+
+    [Fact]
+    public async Task DidHandleSpecificExceptionAsync()
+    {
+        var handler = new MulticastExceptionHandler();
+        handler.Register<FileNotFoundException>(Callback);
+        bool handled = false;
+        Task Callback(FileNotFoundException exception)
+        {
+            handled = true;
+            return Task.CompletedTask;
+        }
+        await handler.HandleAsync(new FileNotFoundException());
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task DidHandleSpecificExceptionAsyncWithParameter()
+    {
+        var handler = new MulticastExceptionHandler();
+        bool handled = false;
+        var expected = Guid.NewGuid();
+        handler.Register<FileNotFoundException>(Callback);
+
+        Task Callback(FileNotFoundException fnfe, object?  parameter)
+        {
+            Assert.Equal(expected, parameter);
+            handled = true;
+            return Task.CompletedTask;
+        }
+        await handler.HandleAsync(new FileNotFoundException(), expected);
+
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task DidHandleSpecificExceptionAsyncWithParameterFirst()
+    {
+        var handler = new MulticastExceptionHandler();
+        bool handled = false;
+        var expected = Guid.NewGuid();
+        handler.Register<FileNotFoundException>(Callback);
+
+        Task Callback(object? parameter, FileNotFoundException fnfe)
+        {
+            Assert.Equal(expected, parameter);
+            handled = true;
+            return Task.CompletedTask;
+        }
+        await handler.HandleAsync(new FileNotFoundException(), expected);
+
+        Assert.True(handled);
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

This adds a MulticastExceptionHandler. This allows some flexibility in being able to provide more dynamic types which includes the ability to specify strongly typed Exception handlers for specific Exception types.

### Bugs Fixed

- closes #2873

### API Changes

Adds public API's to the DelegateCommand for `Catch<TException>`

### Behavioral Changes

When a Catch is specified this will attempt to catch any exception thrown during the execution of the command. If no delegate is registered for it, it will rethrow the exception.

**NOTE** for `DelegateCommand<T>` the protected implementation has been updated to no longer call the `Execute(T parameter)` and instead now will simply call the delegate directly. This is because we need to also allow developers to catch an InvalidCastException in the event that the UI Framework causes this error.