### PR TITLE
Adding Maui packages to the nuget central package version management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,12 @@
     <PackageVersion Include="Xamarin.Forms" Version="5.0.0.2401" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
   </ItemGroup>
+
+  <!-- Maui -->
+  <ItemGroup Condition=" $(UseMaui) == 'true' ">
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-preview.6.8686" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-preview.6.8686" />
+  </ItemGroup>
   <!-- Uno -->
   <ItemGroup Condition=" $(IsUnoProject) == 'true' ">
     <PackageVersion Include="Uno.WinUI" Version="4.9.26" />

--- a/src/Maui/Prism.Maui/Prism.Maui.csproj
+++ b/src/Maui/Prism.Maui/Prism.Maui.csproj
@@ -14,6 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Prism.Maui.Tests" />
     <InternalsVisibleTo Include="Prism.DryIoc.Maui.Tests" />
     <None Include="build\*.targets" Pack="True" PackagePath="buildTransitive" />


### PR DESCRIPTION
- feat: net8 support dropping PrismApplication
- fix: fixed build on net8

﻿## Description of Change

I never imagined this day would come, look at me doing a PR to Prism, lol.

On .net8 Maui packages are shipped as nuget packages and not on workloads, so you need add those explicity on your central package version management.
### Bugs Fixed

Build didn't work, @dansiegel knew it

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard