### PR TITLE
Update UnityContainerExtension.cs

### DIFF
--- a/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
+++ b/src/Containers/Prism.Unity.Shared/UnityContainerExtension.cs
@@ -291,11 +291,11 @@ namespace Prism.Unity
                 var c = _currentScope?.Container ?? Instance;
                 var overrides = parameters.Select(p => new DependencyOverride(p.Type, p.Instance)).ToArray();
 
-                if (typeof(IEnumerable).IsAssignableFrom(type) && type.GetGenericArguments().Length > 0)
+                /*if (typeof(IEnumerable).IsAssignableFrom(type) && type.GetGenericArguments().Length > 0)
                 {
                     type = type.GetGenericArguments()[0];
                     return c.ResolveAll(type, overrides);
-                }
+                }*/
 
                 return c.Resolve(type, overrides);
             }


### PR DESCRIPTION
﻿## Description of Change

When a generic interface is derived from IEnumerable and regsitered with the container, attempting to resolve an instance through that interface results in an InvalidCastException, and the type is not resolved. Trying to see if it can be resolved from unity without specially handling the INumerable.

### Bugs Fixed #2871

- Provide links to bugs here
[](https://github.com/workingparrot/fictional-octo-doodle)

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard