### PR TITLE
Update to dual license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,48 @@
-The MIT License (MIT)
-
+Prism Library
+Version 1.0, August 2023
 Copyright (c) Prism Library
 
-All rights reserved. Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications, including but not limited to software source
+    code, documentation source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including
+    but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+   "Work" (or "Works") shall mean any Prism Library software made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work.
+
+   "Direct Package Dependency" shall mean any Work in Source or Object form that is installed directly by You.
+
+   "Transitive Package Dependency" shall mean any Work in Object form that is installed indirectly by a third party
+    dependency unrelated to Prism Library.
+
+2. License
+
+   Works in Source or Object form are split licensed and may be licensed under the MIT or a Prism Library Commercial
+   Use License. Works will be subject to the License terms whether using a Direct Package Dependency or a Transitive
+   Package Dependency.
+
+   Licenses are granted based upon You meeting the qualified criteria as stated. Once granted,
+   You must reference the granted license only in all documentation.
+
+   Works in Source or Object form are licensed to You under the MIT if:
+
+   - You are consuming the Work in for use in software licensed under an Open Source or Source Available license.
+   - You are consuming the Work for the purposes of education.
+   - You are consuming the Work in the capacity of a For-profit company/individual with
+     less than 1,000,000.00 USD annual gross revenue.
+   - You are consuming the Work in the capacity of a Non-profit organization
+     or Registered Charity that is actively engaged in disaster response (i.e. The Red Cross).
+
+   For all other scenarios, Works in Source or Object form are licensed to You under the Prism Library Commercial License
+   which may be purchased by visiting https://avantipoint.com/contact/.
+
+3. Restrictions
+
+   The Source may be forked and modified for private use only. It is a violation of the terms of the Prism License to publicly publish a fork of the Prism codebase.


### PR DESCRIPTION
﻿## Description of Change

Updates project license. Prism is now dual licensed. Those organizations earning more than $1,000,000 USD / year should [reach out](https://avantipoint.com/contact) to obtain a license.
