### PR TITLE
Add nullable annotations to commands

### DIFF
--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -130,7 +130,7 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
     /// </summary>
     /// <param name="parameter">Command Parameter</param>
-    protected override async void Execute(object parameter)
+    protected override async void Execute(object? parameter)
     {
         await Execute(_getCancellationToken());
     }
@@ -140,7 +140,7 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// </summary>
     /// <param name="parameter"></param>
     /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
-    protected override bool CanExecute(object parameter)
+    protected override bool CanExecute(object? parameter)
     {
         return CanExecute();
     }

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -132,11 +132,11 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
     /// </summary>
     /// <param name="parameter">Command Parameter</param>
-    protected override async void Execute(object parameter)
+    protected override async void Execute(object? parameter)
     {
         try
         {
-            await Execute((T)parameter, _getCancellationToken());
+            await Execute((T)parameter!, _getCancellationToken());
         }
         catch (Exception ex)
         {
@@ -152,11 +152,11 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// </summary>
     /// <param name="parameter"></param>
     /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
-    protected override bool CanExecute(object parameter)
+    protected override bool CanExecute(object? parameter)
     {
         try
         {
-            return CanExecute((T)parameter);
+            return CanExecute((T)parameter!);
         }
         catch (Exception ex)
         {
@@ -243,7 +243,7 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
         try
         {
             // If T is not nullable this may throw an exception
-            await Execute((T)parameter, _getCancellationToken());
+            await Execute((T)parameter!, _getCancellationToken());
         }
         catch (Exception ex)
         {
@@ -259,7 +259,7 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
         try
         {
             // If T is not nullable this may throw an exception
-            await Execute((T)parameter, cancellationToken);
+            await Execute((T)parameter!, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Prism.Core/Commands/DelegateCommand.cs
+++ b/src/Prism.Core/Commands/DelegateCommand.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Prism.Properties;
 
+#nullable enable
 namespace Prism.Commands
 {
     /// <summary>
@@ -85,7 +86,7 @@ namespace Prism.Commands
         /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
         /// </summary>
         /// <param name="parameter">Command Parameter</param>
-        protected override void Execute(object parameter)
+        protected override void Execute(object? parameter)
         {
             Execute();
         }
@@ -95,7 +96,7 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="parameter"></param>
         /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
-        protected override bool CanExecute(object parameter)
+        protected override bool CanExecute(object? parameter)
         {
             return CanExecute();
         }

--- a/src/Prism.Core/Commands/DelegateCommandBase.cs
+++ b/src/Prism.Core/Commands/DelegateCommandBase.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using Prism.Common;
 using Prism.Mvvm;
 
+#nullable enable
 namespace Prism.Commands
 {
     /// <summary>
@@ -16,13 +17,13 @@ namespace Prism.Commands
     {
         private bool _isActive;
 
-        private SynchronizationContext _synchronizationContext;
-        private readonly HashSet<string> _observedPropertiesExpressions = new HashSet<string>();
+        private SynchronizationContext? _synchronizationContext;
+        private readonly HashSet<string> _observedPropertiesExpressions = new();
 
         /// <summary>
         /// Provides an Exception Handler to register callbacks or handle encountered exceptions within 
         /// </summary>
-        protected readonly MulticastExceptionHandler ExceptionHandler = new MulticastExceptionHandler();
+        protected readonly MulticastExceptionHandler ExceptionHandler = new();
 
         /// <summary>
         /// Creates a new instance of a <see cref="DelegateCommandBase"/>, specifying both the execute action and the can execute function.
@@ -35,7 +36,7 @@ namespace Prism.Commands
         /// <summary>
         /// Occurs when changes occur that affect whether or not the command should execute.
         /// </summary>
-        public virtual event EventHandler CanExecuteChanged;
+        public virtual event EventHandler? CanExecuteChanged;
 
         /// <summary>
         /// Raises <see cref="ICommand.CanExecuteChanged"/> so every 
@@ -64,12 +65,12 @@ namespace Prism.Commands
             OnCanExecuteChanged();
         }
 
-        void ICommand.Execute(object parameter)
+        void ICommand.Execute(object? parameter)
         {
             Execute(parameter);
         }
 
-        bool ICommand.CanExecute(object parameter)
+        bool ICommand.CanExecute(object? parameter)
         {
             return CanExecute(parameter);
         }
@@ -78,14 +79,14 @@ namespace Prism.Commands
         /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
         /// </summary>
         /// <param name="parameter">Command Parameter</param>
-        protected abstract void Execute(object parameter);
+        protected abstract void Execute(object? parameter);
 
         /// <summary>
         /// Handle the internal invocation of <see cref="ICommand.CanExecute(object)"/>
         /// </summary>
         /// <param name="parameter"></param>
         /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
-        protected abstract bool CanExecute(object parameter);
+        protected abstract bool CanExecute(object? parameter);
 
         /// <summary>
         /// Observes a property that implements INotifyPropertyChanged, and automatically calls DelegateCommandBase.RaiseCanExecuteChanged on property changed notifications.
@@ -96,7 +97,7 @@ namespace Prism.Commands
         {
             if (_observedPropertiesExpressions.Contains(propertyExpression.ToString()))
             {
-                throw new ArgumentException($"{propertyExpression.ToString()} is already being observed.",
+                throw new ArgumentException($"{propertyExpression} is already being observed.",
                     nameof(propertyExpression));
             }
             else
@@ -121,10 +122,10 @@ namespace Prism.Commands
         /// <summary>
         /// Fired if the <see cref="IsActive"/> property changes.
         /// </summary>
-        public virtual event EventHandler IsActiveChanged;
+        public virtual event EventHandler? IsActiveChanged;
 
         /// <summary>
-        /// This raises the <see cref="DelegateCommandBase.IsActiveChanged"/> event.
+        /// This raises the <see cref="IsActiveChanged"/> event.
         /// </summary>
         protected virtual void OnIsActiveChanged()
         {

--- a/src/Prism.Core/Commands/DelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/DelegateCommand{T}.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Prism.Properties;
 
+#nullable enable
 namespace Prism.Commands
 {
     /// <summary>
@@ -121,13 +122,13 @@ namespace Prism.Commands
         /// Handle the internal invocation of <see cref="ICommand.Execute(object)"/>
         /// </summary>
         /// <param name="parameter">Command Parameter</param>
-        protected override void Execute(object parameter)
+        protected override void Execute(object? parameter)
         {
             try
             {
                 // Note: We don't call Execute because we would potentially invoke the Try/Catch twice.
                 // It is also needed here incase (T)parameter throws the exception
-                _executeMethod((T)parameter);
+                _executeMethod((T)parameter!);
             }
             catch (Exception ex)
             {
@@ -143,13 +144,13 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="parameter"></param>
         /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
-        protected override bool CanExecute(object parameter)
+        protected override bool CanExecute(object? parameter)
         {
             try
             {
                 // Note: We don't call Execute because we would potentially invoke the Try/Catch twice.
                 // It is also needed here incase (T)parameter throws the exception
-                return CanExecute((T)parameter);
+                return CanExecute((T)parameter!);
             }
             catch (Exception ex)
             {

--- a/src/Prism.Core/Commands/PropertyObserver.cs
+++ b/src/Prism.Core/Commands/PropertyObserver.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reflection;
 
+#nullable enable
 namespace Prism.Commands
 {
     /// <summary>
@@ -20,16 +21,20 @@ namespace Prism.Commands
             SubscribeListeners(propertyExpression);
         }
 
-        private void SubscribeListeners(Expression propertyExpression)
+        private void SubscribeListeners(Expression? propertyExpression)
         {
             var propNameStack = new Stack<PropertyInfo>();
             while (propertyExpression is MemberExpression temp) // Gets the root of the property chain.
             {
                 propertyExpression = temp.Expression;
-                propNameStack.Push(temp.Member as PropertyInfo); // Records the member info as property info
+
+                if (temp.Member is PropertyInfo propertyInfo)
+                {
+                    propNameStack.Push(propertyInfo); // Records the member info as property info
+                }
             }
 
-            if (!(propertyExpression is ConstantExpression constantExpression))
+            if (propertyExpression is not ConstantExpression constantExpression)
                 throw new NotSupportedException("Operation not supported for the given expression type. " +
                                                 "Only MemberExpression and ConstantExpression are currently supported.");
 
@@ -42,9 +47,9 @@ namespace Prism.Commands
                 previousNode = currentNode;
             }
 
-            object propOwnerObject = constantExpression.Value;
+            object? propOwnerObject = constantExpression.Value;
 
-            if (!(propOwnerObject is INotifyPropertyChanged inpcObject))
+            if (propOwnerObject is not INotifyPropertyChanged inpcObject)
                 throw new InvalidOperationException("Trying to subscribe PropertyChanged listener in object that " +
                                                     $"owns '{propObserverNodeRoot.PropertyInfo.Name}' property, but the object does not implements INotifyPropertyChanged.");
 

--- a/src/Prism.Core/Commands/PropertyObserverNode.cs
+++ b/src/Prism.Core/Commands/PropertyObserverNode.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Reflection;
 
+#nullable enable
 namespace Prism.Commands
 {
     /// <summary>
@@ -11,10 +12,10 @@ namespace Prism.Commands
     internal class PropertyObserverNode
     {
         private readonly Action _action;
-        private INotifyPropertyChanged _inpcObject;
+        private INotifyPropertyChanged? _inpcObject;
 
         public PropertyInfo PropertyInfo { get; }
-        public PropertyObserverNode Next { get; set; }
+        public PropertyObserverNode? Next { get; set; }
 
         public PropertyObserverNode(PropertyInfo propertyInfo, Action action)
         {
@@ -40,11 +41,11 @@ namespace Prism.Commands
         {
             var nextProperty = PropertyInfo.GetValue(_inpcObject);
             if (nextProperty == null) return;
-            if (!(nextProperty is INotifyPropertyChanged nextInpcObject))
+            if (nextProperty is not INotifyPropertyChanged nextInpcObject)
                 throw new InvalidOperationException("Trying to subscribe PropertyChanged listener in object that " +
-                                                    $"owns '{Next.PropertyInfo.Name}' property, but the object does not implements INotifyPropertyChanged.");
+                                                    $"owns '{Next?.PropertyInfo.Name}' property, but the object does not implements INotifyPropertyChanged.");
 
-            Next.SubscribeListenerFor(nextInpcObject);
+            Next?.SubscribeListenerFor(nextInpcObject);
         }
 
         private void UnsubscribeListener()
@@ -55,7 +56,7 @@ namespace Prism.Commands
             Next?.UnsubscribeListener();
         }
 
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e?.PropertyName == PropertyInfo.Name || string.IsNullOrEmpty(e?.PropertyName))
             {


### PR DESCRIPTION
I have also taken the opportunity to apply the features of new versions of C#.

I have concerns on how to act on the AsyncDelegateCommand when casting. I have chosen to use ! (null-forgiving) but I want your opinion.