### PR TITLE
Remove legacy xmlns namespaces

### DIFF
--- a/src/Wpf/Prism.Wpf/Properties/AssemblyInfo.cs
+++ b/src/Wpf/Prism.Wpf/Properties/AssemblyInfo.cs
@@ -6,17 +6,9 @@ using System.Windows.Markup;
 
 [assembly: CLSCompliant(true)]
 
-// -----  Legacy -----
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Navigation.Regions")]
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Navigation.Regions.Behaviors")]
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Mvvm")]
-[assembly: XmlnsDefinition("http://www.codeplex.com/prism", "Prism.Interactivity")]
-// -----  Legacy -----
-
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Navigation.Regions")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Navigation.Regions.Behaviors")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Mvvm")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Interactivity")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Dialogs")]
 [assembly: XmlnsDefinition("http://prismlibrary.com/", "Prism.Ioc")]
-


### PR DESCRIPTION
﻿## Description of Change

Removes legacy XmlnsDefinitionAttribute's. `http://www.codeplex.com/prism` namespace will no longer be valid for WPF applications. Namespaces should be updated to use `http://prismlibrary.com/`