### PR TITLE
Uno 5 update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,20 +15,20 @@
   </ItemGroup>
   <!-- Uno -->
   <ItemGroup Condition=" $(IsUnoProject) == 'true' ">
-    <PackageVersion Include="Uno.WinUI" Version="5.0.0-dev.3265" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="5.0.0-dev.3265" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="5.0.0-dev.3265" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="5.0.0-dev.3265" />
-    <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.29" />
-    <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.29" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="5.0.0-dev.3265" />
-    <PackageVersion Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.WinUI" Version="5.0.0-dev.3400" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="5.0.0-dev.3400" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="5.0.0-dev.3400" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="5.0.0-dev.3400" />
+    <PackageVersion Include="Uno.Wasm.Bootstrap" Version="8.0.0-dev.291" />
+    <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.0-dev.291" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="5.0.0-dev.3400" />
+    <PackageVersion Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3400" />
     <PackageVersion Include="Uno.WinUI.RemoteControl" Version="5.0.0-dev.3265" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3400" />
     <PackageVersion Include="Uno.Core" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.0" />
-    <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.3.0" />
+    <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.0-uno.23" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(MSBuildProjectName.Contains('Prism'))" />
@@ -36,16 +36,16 @@
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.6" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.6" />
-    <PackageVersion Include="Uno.Resizetizer" Version="1.2.0-dev.66" />
-    <PackageVersion Include="Uno.Extensions.Core" Version="3.0.0-dev.2298" />
-    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.6.0" />
-    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="3.0.0-dev.2298" />
-    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="3.0.0-dev.2298" />
-    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.6.0" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="4.0.0-dev.146" />
-    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="5.0.0-dev.110" />
-    <PackageVersion Include="Uno.Toolkit.WinUI" Version="5.0.0-dev.110" />
-    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="3.0.0-dev.2298" />
+    <PackageVersion Include="Uno.Resizetizer" Version="1.2.0-dev.68" />
+    <PackageVersion Include="Uno.Extensions.Core" Version="3.0.0-dev.2301" />
+    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0-dev.1" />
+    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="3.0.0-dev.2301" />
+    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="3.0.0-dev.2301" />
+    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0-dev.1" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="4.0.0-dev.174" />
+    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="5.0.0-dev.117" />
+    <PackageVersion Include="Uno.Toolkit.WinUI" Version="5.0.0-dev.117" />
+    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="3.0.0-dev.2301" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.9.0.3" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,15 +15,16 @@
   </ItemGroup>
   <!-- Uno -->
   <ItemGroup Condition=" $(IsUnoProject) == 'true' ">
-    <PackageVersion Include="Uno.WinUI" Version="4.9.45" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.9.45" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.9.45" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.9.45" />
-    <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.27" />
-    <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.27" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.9.45" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.9.45" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.45" />
+    <PackageVersion Include="Uno.WinUI" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.29" />
+    <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.29" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.WinUI.DevServer" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="5.0.0-dev.3265" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.0-dev.3265" />
     <PackageVersion Include="Uno.Core" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.0" />
@@ -31,24 +32,24 @@
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(MSBuildProjectName.Contains('Prism'))" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230724000" Condition="!$(MSBuildProjectName.Contains('Prism'))" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.5" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.5" />
-    <PackageVersion Include="Uno.Resizetizer" Version="1.1.2" />
-    <PackageVersion Include="Uno.Extensions.Core" Version="2.4.2" />
-    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
-    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="2.4.2" />
-    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="2.4.2" />
-    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="2.6.1" />
-    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="3.0.5" />
-    <PackageVersion Include="Uno.Toolkit.WinUI" Version="3.0.5" />
-    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="2.4.2" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.230913002" Condition="!$(MSBuildProjectName.Contains('Prism'))" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.6" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.6" />
+    <PackageVersion Include="Uno.Resizetizer" Version="1.2.0-dev.66" />
+    <PackageVersion Include="Uno.Extensions.Core" Version="3.0.0-dev.2298" />
+    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.6.0" />
+    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="3.0.0-dev.2298" />
+    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="3.0.0-dev.2298" />
+    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.6.0" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="4.0.0-dev.146" />
+    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="5.0.0-dev.110" />
+    <PackageVersion Include="Uno.Toolkit.WinUI" Version="5.0.0-dev.110" />
+    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="3.0.0-dev.2298" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.7.0.2" />
+    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.9.0.3" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
-    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.5" />
   </ItemGroup>
   <!-- Tests -->
   <ItemGroup>

--- a/e2e/Uno/HelloWorld.Mobile/HelloWorld.Mobile.csproj
+++ b/e2e/Uno/HelloWorld.Mobile/HelloWorld.Mobile.csproj
@@ -21,7 +21,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.WinUI" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />

--- a/e2e/Uno/HelloWorld.Skia.Gtk/HelloWorld.Skia.Gtk.csproj
+++ b/e2e/Uno/HelloWorld.Skia.Gtk/HelloWorld.Skia.Gtk.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
 		<PackageReference Include="SkiaSharp.Skottie" />
 		<PackageReference Include="Uno.WinUI.Skia.Gtk" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />

--- a/e2e/Uno/HelloWorld.Skia.Linux.FrameBuffer/HelloWorld.Skia.Linux.FrameBuffer.csproj
+++ b/e2e/Uno/HelloWorld.Skia.Linux.FrameBuffer/HelloWorld.Skia.Linux.FrameBuffer.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
 		<PackageReference Include="SkiaSharp.Skottie" />
 		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />

--- a/e2e/Uno/HelloWorld.Skia.WPF/HelloWorld.Skia.WPF.csproj
+++ b/e2e/Uno/HelloWorld.Skia.WPF/HelloWorld.Skia.WPF.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" />
 		<PackageReference Include="SkiaSharp.Skottie" />
 		<PackageReference Include="Uno.WinUI.Skia.Wpf" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />

--- a/e2e/Uno/HelloWorld.Wasm/HelloWorld.Wasm.csproj
+++ b/e2e/Uno/HelloWorld.Wasm/HelloWorld.Wasm.csproj
@@ -47,7 +47,7 @@
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" />
+		<PackageReference Include="Uno.WinUI.DevServer" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />

--- a/e2e/Uno/HelloWorld.Windows/HelloWorld.Windows.csproj
+++ b/e2e/Uno/HelloWorld.Windows/HelloWorld.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<RootNamespace>UnoWinUIQuickStart</RootNamespace>
 		<Platforms>x86;x64;arm64</Platforms>
@@ -54,7 +54,7 @@
 		the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
 		must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
 		-->
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.30" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.30" />
 	</ItemGroup>
 </Project>

--- a/e2e/Uno/HelloWorld/HelloWorld.csproj
+++ b/e2e/Uno/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net7.0-ios;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net7.0-windows10.0.22621</TargetFrameworks>
 
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -38,8 +38,8 @@
         the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
         must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
         -->
-        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
+        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.30" />
+        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.30" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/e2e/Uno/ModuleA/Dialogs/AlertDialog.xaml
+++ b/e2e/Uno/ModuleA/Dialogs/AlertDialog.xaml
@@ -10,11 +10,9 @@
     d:DesignWidth="400">
 
   <StackPanel>
-    <TextBlock Text="{Binding Title}"
-               FontSize="20"
-               FontWeight="Bold" />
     <TextBlock Text="{Binding Message}" />
     <Button Content="OK"
-            Command="{Binding CloseCommand}" />
+            Command="{Binding CloseCommand}"
+            Margin="0,15"/>
   </StackPanel>
 </UserControl>

--- a/e2e/Uno/ModuleA/Dialogs/AlertDialog.xaml
+++ b/e2e/Uno/ModuleA/Dialogs/AlertDialog.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+    x:Class="ModuleA.Dialogs.AlertDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:ModuleA"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+  <StackPanel>
+    <TextBlock Text="{Binding Title}"
+               FontSize="20"
+               FontWeight="Bold" />
+    <TextBlock Text="{Binding Message}" />
+    <Button Content="OK"
+            Command="{Binding CloseCommand}" />
+  </StackPanel>
+</UserControl>

--- a/e2e/Uno/ModuleA/Dialogs/AlertDialog.xaml.cs
+++ b/e2e/Uno/ModuleA/Dialogs/AlertDialog.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace ModuleA.Dialogs
+{
+    public sealed partial class AlertDialog : UserControl
+    {
+        public AlertDialog()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/e2e/Uno/ModuleA/Dialogs/AlertDialogViewModel.cs
+++ b/e2e/Uno/ModuleA/Dialogs/AlertDialogViewModel.cs
@@ -1,0 +1,40 @@
+﻿namespace ModuleA.Dialogs;
+
+internal class AlertDialogViewModel : BindableBase, IDialogAware
+{
+    public AlertDialogViewModel()
+    {
+        CloseCommand = new DelegateCommand(() => RequestClose.Invoke(new DialogResult(ButtonResult.OK)));
+    }
+
+    private string _title = string.Empty;
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    private string _message = string.Empty;
+    public string Message
+    {
+        get => _message;
+        set => SetProperty(ref _message, value);
+    }
+
+    public DelegateCommand CloseCommand { get; }
+
+    public DialogCloseListener RequestClose { get; }
+
+    public bool CanCloseDialog() => true;
+
+    public void OnDialogClosed()
+    {
+
+    }
+
+    public void OnDialogOpened(IDialogParameters parameters)
+    {
+        Title = parameters.GetValue<string>("title");
+        Message = parameters.GetValue<string>("message");
+    }
+}

--- a/e2e/Uno/ModuleA/ModuleA.csproj
+++ b/e2e/Uno/ModuleA/ModuleA.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net7.0-ios;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
-     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks> 
+     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net7.0-windows10.0.22621</TargetFrameworks> 
 
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -32,8 +32,8 @@
         the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
         must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
         -->
-        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
-        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" />
+        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.30" />
+        <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.30" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/e2e/Uno/ModuleA/ModuleAModule.cs
+++ b/e2e/Uno/ModuleA/ModuleAModule.cs
@@ -1,4 +1,6 @@
+using ModuleA.Dialogs;
 using ModuleA.Views;
+using AlertDialog = ModuleA.Dialogs.AlertDialog;
 
 namespace ModuleA;
 
@@ -15,6 +17,7 @@ public class ModuleAModule : IModule
     {
         containerRegistry.RegisterForNavigation<ViewA>();
         containerRegistry.RegisterForNavigation<ViewB>();
+        containerRegistry.RegisterDialog<AlertDialog, AlertDialogViewModel>();
     }
 
     public void OnInitialized(IContainerProvider containerProvider)

--- a/e2e/Uno/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/e2e/Uno/ModuleA/ViewModels/ViewAViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ModuleA.ViewModels;
+
+internal class ViewAViewModel : ViewModelBase
+{
+    public ViewAViewModel(IRegionManager regionManager)
+        : base(regionManager)
+    {
+    }
+}

--- a/e2e/Uno/ModuleA/ViewModels/ViewAViewModel.cs
+++ b/e2e/Uno/ModuleA/ViewModels/ViewAViewModel.cs
@@ -1,16 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Windows.Input;
 
 namespace ModuleA.ViewModels;
 
 internal class ViewAViewModel : ViewModelBase
 {
-    public ViewAViewModel(IRegionManager regionManager)
+    private readonly IDialogService _dialogService;
+
+    public ViewAViewModel(IRegionManager regionManager, IDialogService dialogService)
         : base(regionManager)
     {
+        _dialogService = dialogService;
+        ShowAlertCommand = new DelegateCommand(ShowDialog);
+    }
+
+    public ICommand ShowAlertCommand { get; }
+
+    private void ShowDialog()
+    {
+        _dialogService.ShowDialog("AlertDialog", new DialogParameters
+        {
+            { "title", "Oh Snap" },
+            { "message", "You can actually create much more amazing dialogs with Prism. Hello from ViewA!" }
+        });
     }
 }

--- a/e2e/Uno/ModuleA/ViewModels/ViewBViewModel.cs
+++ b/e2e/Uno/ModuleA/ViewModels/ViewBViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace ModuleA.ViewModels;
+
+internal class ViewBViewModel : ViewModelBase
+{
+    public ViewBViewModel(IRegionManager regionManager)
+        : base(regionManager)
+    {
+    }
+}

--- a/e2e/Uno/ModuleA/ViewModels/ViewModelBase.cs
+++ b/e2e/Uno/ModuleA/ViewModels/ViewModelBase.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.ObjectModel;
+
+namespace ModuleA.ViewModels;
+
+internal class ViewModelBase : BindableBase, IRegionAware
+{
+    private readonly string _name;
+    protected IRegionManager RegionManager { get; }
+
+    protected ViewModelBase(IRegionManager regionManager)
+    {
+        RegionManager = regionManager;
+        Title = _name = GetType().Name.Replace("ViewModel", string.Empty);
+    }
+
+    private string _title = string.Empty;
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    private ObservableCollection<string> _messages = new();
+    public IEnumerable<string> Messages => _messages;
+
+
+    public bool IsNavigationTarget(NavigationContext navigationContext) =>
+        navigationContext.NavigatedName() == _name;
+
+    public void OnNavigatedFrom(NavigationContext navigationContext)
+    {
+        _messages.Add("OnNavigatedFrom");
+    }
+
+    public void OnNavigatedTo(NavigationContext navigationContext)
+    {
+        if (navigationContext.Parameters.TryGetValue("title", out string title))
+        {
+            Title = title;
+        }
+
+        _messages.Add("OnNavigatedTo");
+    }
+}

--- a/e2e/Uno/ModuleA/Views/ViewA.xaml
+++ b/e2e/Uno/ModuleA/Views/ViewA.xaml
@@ -9,7 +9,8 @@
     d:DesignHeight="300"
     d:DesignWidth="400">
 
-  <Grid>
+  <StackPanel>
     <TextBlock Text="View A" FontSize="72" />
-  </Grid>
+    <Button Content="Show Dialog" Command="{Binding ShowAlertCommand}" />
+  </StackPanel>
 </UserControl>

--- a/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
+++ b/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net6.0-windows10.0.18362;net7.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Prism.DryIoc.Uno</AssemblyName>
     <PackageId>Prism.DryIoc.Uno.WinUI</PackageId>

--- a/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
+++ b/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net6.0-windows10.0.18362;net7.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>Prism.Uno</AssemblyName>
     <RootNamespace>Prism</RootNamespace>

--- a/src/Wpf/Prism.Wpf/Dialogs/IDialogServiceCompatExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Dialogs/IDialogServiceCompatExtensions.cs
@@ -72,43 +72,5 @@ namespace Prism.Dialogs
             return parameters;
         }
 #endif
-        /// <summary>
-        /// Shows a modal dialog.
-        /// </summary>
-        /// <param name="dialogService">The DialogService</param>
-        /// <param name="name">The name of the dialog to show.</param>
-        public static void ShowDialog(this IDialogService dialogService, string name)
-        {
-            dialogService.ShowDialog(name, new DialogParameters(), DialogCallback.Empty);
-        }
-
-        /// <summary>
-        /// Shows a modal dialog.
-        /// </summary>
-        /// <param name="dialogService">The DialogService</param>
-        /// <param name="name">The name of the dialog to show.</param>
-        /// <param name="callback">The action to perform when the dialog is closed.</param>
-        public static void ShowDialog(this IDialogService dialogService, string name, Action<IDialogResult> callback)
-        {
-            dialogService.ShowDialog(name, new DialogParameters(), new DialogCallback().OnClose(callback));
-        }
-
-        /// <summary>
-        /// Shows a modal dialog.
-        /// </summary>
-        /// <param name="dialogService">The DialogService</param>
-        /// <param name="name">The name of the dialog to show.</param>
-        /// <param name="parameters">The parameters to pass to the dialog.</param>
-        /// <param name="callback">The action to perform when the dialog is closed.</param>
-        /// <param name="windowName">The name of the hosting window registered with the IContainerRegistry.</param>
-        public static void ShowDialog(this IDialogService dialogService, string name, IDialogParameters parameters, Action<IDialogResult> callback, string windowName)
-        {
-            parameters ??= new DialogParameters();
-
-            if (!string.IsNullOrEmpty(windowName))
-                parameters.Add(KnownDialogParameters.WindowName, windowName);
-
-            dialogService.ShowDialog(name, parameters, new DialogCallback().OnClose(callback));
-        }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

This updates Uno to build against Uno 5.0 currently in preview. This adds a Dialog sample to the Uno e2e app, and fixes an ambiguous reference issue with dialog extensions that are now in Core.
