### PR TITLE
fixing release paths

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: NuGet
-          path: .\artifacts
+          path: .\artifacts\nuget
 
   release:
     uses: avantipoint/workflow-templates/.github/workflows/generate-release.yml@master
@@ -135,4 +135,3 @@ jobs:
       contents: write
     with:
       package-name: Prism.Core
-      artifacts: "Artifacts/NuGet/*.nupkg,Artifacts/NuGet/*.snupkg,Artifacts/*.zip"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,9 +11,7 @@
     <RepositoryUrl>https://github.com/PrismLibrary/Prism</RepositoryUrl>
     <IncludeSymbols>True</IncludeSymbols>
     <IncludeSource>True</IncludeSource>
-    <ArtifactStagingRoot>$(MSBuildThisFileDirectory)Artifacts</ArtifactStagingRoot>
-    <ArtifactStagingRoot Condition=" '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">$(BUILD_ARTIFACTSTAGINGDIRECTORY)</ArtifactStagingRoot>
-    <PackageOutputPath>$([System.IO.Path]::Combine('$(ArtifactStagingRoot)', 'NuGet'))</PackageOutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>
     <EscapedCurrentDirectory>$([System.Text.RegularExpressions.Regex]::Escape('$(MSBuildThisFileDirectory)'))</EscapedCurrentDirectory>
     <RelativeProjectPath>$([System.Text.RegularExpressions.Regex]::Replace('$(MSBuildProjectFullPath)', '$(EscapedCurrentDirectory)', ''))</RelativeProjectPath>
     <PrismPackageIcon>$(MSBuildThisFileDirectory)images/prism-logo.png</PrismPackageIcon>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,35 +11,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
-  <Target Name="_ReleaseBinaryCopy"
-          Condition=" !'$(IsTestProject)' And '$(IsPackable)' "
-          BeforeTargets="AfterBuild;WpfPack">
-
-    <PropertyGroup>
-      <BinariesFolderName Condition=" '$(IsCoreProject)' ">Core</BinariesFolderName>
-      <BinariesFolderName Condition=" '$(IsFormsProject)' ">Forms</BinariesFolderName>
-      <BinariesFolderName Condition=" '$(IsWpfProject)' ">WPF</BinariesFolderName>
-      <BinariesFolderName Condition=" '$(IsUnoProject)' ">Uno</BinariesFolderName>
-      <BinariesFolderName Condition=" '$(IsMauiProject)' ">Maui</BinariesFolderName>
-      <ArtifactStaging>$([System.IO.Path]::Combine('$(ArtifactStagingRoot)', $(Configuration), '$(BinariesFolderName)', '$(TargetFramework)'))</ArtifactStaging>
-    </PropertyGroup>
-
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll"
-          DestinationFolder="$(ArtifactStaging)"
-          Condition=" Exists('$(OutputPath)$(AssemblyName).dll') " />
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).xml"
-          DestinationFolder="$(ArtifactStaging)"
-          Condition=" Exists('$(OutputPath)$(AssemblyName).xml') " />
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).pdb"
-          DestinationFolder="$(ArtifactStaging)"
-          Condition=" Exists('$(OutputPath)$(AssemblyName).pdb') " />
-    <Copy SourceFiles="$(OutputPath)$(AssemblyName).pri"
-          DestinationFolder="$(ArtifactStaging)"
-          Condition=" Exists('$(OutputPath)$(AssemblyName).pri') " />
-
-  </Target>
-
-
   <Choose>
     <When Condition="$(IsUnoProject)">
       <ItemGroup>

--- a/build/consolidate-artifacts.ps1
+++ b/build/consolidate-artifacts.ps1
@@ -2,18 +2,14 @@
 
 $executionRoot = Get-Location
 $artifactsRoot = $executionRoot, 'artifacts' -join '\'
-$binariesRoot = $executionRoot, 'artifacts', 'binaries' -join '\'
-$artifactsZipPath = $executionRoot, 'artifacts', 'Release.zip' -join '\'
 $nugetRoot = $executionRoot, 'artifacts', 'nuget' -join '\'
-Get-ChildItem .\ -Include $binariesRoot -Recurse | ForEach-Object ($_) { Remove-Item $_.Fullname -Force -Recurse }
 Get-ChildItem .\ -Include $nugetRoot -Recurse | ForEach-Object ($_) { Remove-Item $_.Fullname -Force -Recurse }
-New-Item -Path $binariesRoot -ItemType Directory -Force > $null
 New-Item -Path $nugetRoot -ItemType Directory -Force > $null
 $platforms = @('Forms', 'Wpf', 'Uno', 'Maui')
 
 $core = @("Prism.Core", "Prism.Events", "Prism.dll", "Prism.pdb", "Prism.xml")
 $allowedExtensions = @('.dll', '.pdb', '.xml', '.pri', '.nupkg', '.snupkg')
-$files = Get-ChildItem -Path $artifactsRoot -Filter "*" -Recurse | Where-Object { (Test-Path -Path $_.FullName -PathType Leaf) -and $_.FullName.StartsWith($binariesRoot) -eq $false -and $_.FullName.StartsWith($nugetRoot) -eq $false -and ($allowedExtensions -contains [System.IO.Path]::GetExtension($_.FullName)) }
+$files = Get-ChildItem -Path $artifactsRoot -Filter "*" -Recurse | Where-Object { (Test-Path -Path $_.FullName -PathType Leaf) -and $_.FullName.StartsWith($nugetRoot) -eq $false -and ($allowedExtensions -contains [System.IO.Path]::GetExtension($_.FullName)) }
 
 if ($files.Count -eq 0)
 {
@@ -50,8 +46,6 @@ foreach($file in $files)
         $parentDirName = Split-Path -Path (Split-Path -Path $file.FullName -Parent) -Leaf
 
         Write-Output "Determining Copy Path for $parentDirName"
-        $copyPath = Join-Path $binariesRoot -ChildPath $parentDirName
-
         if ((Test-Path -Path $copyPath -PathType Container) -eq $false)
         {
             Write-Output "Creating $copyPath"
@@ -62,7 +56,4 @@ foreach($file in $files)
     }
 }
 
-Get-ChildItem $artifactsRoot | Where-Object { $_.Name -ne 'binaries' -and $_.Name -ne 'nuget' } | ForEach-Object { Remove-Item $_.FullName -Force -Recurse }
-
-Compress-Archive -Path $binariesRoot -DestinationPath $artifactsZipPath -Force
-Remove-Item -Path $binariesRoot -Recurse -Force
+Get-ChildItem $artifactsRoot | Where-Object { $_.Name -ne 'nuget' } | ForEach-Object { Remove-Item $_.FullName -Force -Recurse }


### PR DESCRIPTION
﻿## Description of Change

Deprecates publishing the binaries. This really isn't needed with NuGet packages already being released. This should fix the package signing issue that prevented Prism.Events from getting published.

### Bugs Fixed

- closes #2973