### PR TITLE
Fix DialogService - Setting XamlRoot

### DIFF
--- a/src/Uno/Prism.Uno/Dialogs/DialogService.cs
+++ b/src/Uno/Prism.Uno/Dialogs/DialogService.cs
@@ -16,16 +16,27 @@ namespace Prism.Dialogs
             _containerProvider = containerProvider;
         }
 
-        public void ShowDialog(string name, IDialogParameters parameters, DialogCallback callback)
+        public async void ShowDialog(string name, IDialogParameters parameters, DialogCallback callback)
         {
-            parameters ??= new DialogParameters();
-            var windowName = parameters.TryGetValue<string>(KnownDialogParameters.WindowName, out var wName) ? wName : null;
+            try
+            {
+                parameters ??= new DialogParameters();
+                var windowName = parameters.TryGetValue<string>(KnownDialogParameters.WindowName, out var wName) ? wName : null;
 
-            IDialogWindow contentDialog = CreateDialogWindow(windowName);
-            ConfigureDialogWindowEvents(contentDialog, callback);
-            ConfigureDialogWindowContent(name, contentDialog, parameters);
+                IDialogWindow contentDialog = CreateDialogWindow(windowName);
+                ConfigureDialogWindowEvents(contentDialog, callback);
+                ConfigureDialogWindowContent(name, contentDialog, parameters);
 
-            _ = contentDialog.ShowAsync();
+                var placement = parameters.ContainsKey(KnownDialogParameters.DialogPlacement) ?
+                    (parameters[KnownDialogParameters.DialogPlacement] is ContentDialogPlacement placementValue ? placementValue : Enum.Parse<ContentDialogPlacement>(parameters[KnownDialogParameters.DialogPlacement].ToString() ?? string.Empty)) : ContentDialogPlacement.Popup;
+
+                await contentDialog.ShowAsync(placement);
+            }
+            catch (Exception ex)
+            {
+                var str = ex.ToString();
+                await callback.Invoke(ex);
+            }
         }
 
         IDialogWindow CreateDialogWindow(string? name)

--- a/src/Uno/Prism.Uno/Dialogs/DialogWindow.xaml.cs
+++ b/src/Uno/Prism.Uno/Dialogs/DialogWindow.xaml.cs
@@ -10,9 +10,10 @@ namespace Prism.Dialogs
     /// </summary>
     public partial class DialogWindow : ContentDialog, IDialogWindow
     {
-        public DialogWindow()
+        public DialogWindow(Window window)
         {
             this.InitializeComponent();
+            XamlRoot = window.Content.XamlRoot;
         }
         public IDialogResult? Result { get; set; }
 

--- a/src/Uno/Prism.Uno/Dialogs/IDialogWindow.cs
+++ b/src/Uno/Prism.Uno/Dialogs/IDialogWindow.cs
@@ -20,7 +20,7 @@ namespace Prism.Dialogs
 
         object? Content { get; set; }
 
-        IAsyncOperation<ContentDialogResult> ShowAsync();
+        IAsyncOperation<ContentDialogResult> ShowAsync(ContentDialogPlacement placement);
 
         void Hide();
     }

--- a/src/Uno/Prism.Uno/PrismApplicationBase.cs
+++ b/src/Uno/Prism.Uno/PrismApplicationBase.cs
@@ -109,6 +109,7 @@ namespace Prism
                 .Configure(x => x.ConfigureServices(ConfigureServices)
                     .UseServiceProviderFactory(new PrismServiceProviderFactory(_containerExtension)));
 
+            _containerExtension.RegisterInstance(builder.Window);
             RegisterRequiredTypes(_containerExtension);
             RegisterTypes(_containerExtension);
             _containerExtension.FinalizeExtension();

--- a/src/Wpf/Prism.Wpf/Dialogs/KnownDialogParameters.cs
+++ b/src/Wpf/Prism.Wpf/Dialogs/KnownDialogParameters.cs
@@ -10,7 +10,12 @@ public static class KnownDialogParameters
     /// </summary>
     public const string WindowName = "windowName";
 
-#if !HAS_WINUI
+#if HAS_WINUI
+    /// <summary>
+    /// The <see cref="Microsoft.UI.Xaml.Controls.ContentDialogPlacement"/> to use when showing the dialog
+    /// </summary>
+    public const string DialogPlacement = "dialogPlacement";
+#else
     /// <summary>
     /// Flag to show the Dialog Modally or Non-Modally
     /// </summary>


### PR DESCRIPTION
﻿## Description of Change

This fixes an exception encountered in the DialogService on WinUI by setting the XamlRoot. 

- Caused by https://github.com/microsoft/microsoft-ui-xaml/issues/3678