### PR TITLE
AsyncDelegateCommand enhancements

### DIFF
--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -1,4 +1,4 @@
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -86,17 +86,19 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     ///<summary>
     /// Executes the command.
     ///</summary>
-    public async Task Execute(CancellationToken cancellationToken = default)
+    public async Task Execute(CancellationToken? cancellationToken)
     {
+        var token = cancellationToken ?? _getCancellationToken();
         try
         {
             if (!_enableParallelExecution && IsExecuting)
                 return;
 
             IsExecuting = true;
-            await _executeMethod(cancellationToken);
+            await _executeMethod(token)
+                .ConfigureAwait(false);
         }
-        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (TaskCanceledException) when (token.IsCancellationRequested)
         {
             // Do nothing... the Task was cancelled
         }

--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -90,6 +90,9 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     {
         try
         {
+            if (!_enableParallelExecution && IsExecuting)
+                return;
+
             IsExecuting = true;
             await _executeMethod(cancellationToken);
         }

--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +24,11 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// </summary>
     /// <param name="executeMethod">The <see cref="Func{Task}"/> to invoke when <see cref="ICommand.Execute(object)"/> is called.</param>
     public AsyncDelegateCommand(Func<Task> executeMethod)
+#if NET6_0_OR_GREATER
+        : this (c => executeMethod().WaitAsync(c), () => true)
+#else
         : this(c => executeMethod(), () => true)
+#endif
     {
 
     }
@@ -46,7 +50,11 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// <param name="executeMethod">The <see cref="Func{Task}"/> to invoke when <see cref="ICommand.Execute"/> is called.</param>
     /// <param name="canExecuteMethod">The delegate to invoke when <see cref="ICommand.CanExecute"/> is called</param>
     public AsyncDelegateCommand(Func<Task> executeMethod, Func<bool> canExecuteMethod)
+#if NET6_0_OR_GREATER
+        : this(c => executeMethod().WaitAsync(c), canExecuteMethod)
+#else
         : this(c => executeMethod(), canExecuteMethod)
+#endif
     {
     }
 

--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -164,6 +164,14 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     }
 
     /// <summary>
+    /// Sets the <see cref="CancellationTokenSourceFactory(Func{CancellationToken})"/> based on the specified timeout.
+    /// </summary>
+    /// <param name="timeout">A specified timeout.</param>
+    /// <returns>The current instance of <see cref="AsyncDelegateCommand{T}"/>.</returns>
+    public AsyncDelegateCommand CancelAfter(TimeSpan timeout) =>
+        CancellationTokenSourceFactory(() => new CancellationTokenSource(timeout).Token);
+
+    /// <summary>
     /// Provides a delegate callback to provide a default CancellationToken when the Command is invoked.
     /// </summary>
     /// <param name="factory">The default <see cref="CancellationToken"/> Factory.</param>

--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -98,10 +98,6 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
             await _executeMethod(token)
                 .ConfigureAwait(false);
         }
-        catch (TaskCanceledException) when (token.IsCancellationRequested)
-        {
-            // Do nothing... the Task was cancelled
-        }
         catch (Exception ex)
         {
             if (!ExceptionHandler.CanHandle(ex))
@@ -145,23 +141,11 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// <param name="parameter">Command Parameter</param>
     protected override async void Execute(object? parameter)
     {
+        // We don't want to wrap this in a try/catch because we already handle
+        // or mean to rethrow the exception in the call with the CancellationToken.
         var cancellationToken = _getCancellationToken();
-        try
-        {
-            await Execute(cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // Do nothing... the Task was cancelled
-        }
-        catch (Exception ex)
-        {
-            if (!ExceptionHandler.CanHandle(ex))
-                throw;
-
-            ExceptionHandler.Handle(ex, parameter);
-        }
+        await Execute(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -86,7 +86,7 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     ///<summary>
     /// Executes the command.
     ///</summary>
-    public async Task Execute(CancellationToken? cancellationToken)
+    public async Task Execute(CancellationToken? cancellationToken = null)
     {
         var token = cancellationToken ?? _getCancellationToken();
         try

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +25,11 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// </summary>
     /// <param name="executeMethod">The <see cref="Func{T, Task}"/> to invoke when <see cref="ICommand.Execute(object)"/> is called.</param>
     public AsyncDelegateCommand(Func<T, Task> executeMethod)
+#if NET6_0_OR_GREATER
+        : this((p,t) => executeMethod(p).WaitAsync(t), _ => true)
+#else
         : this((p, t) => executeMethod(p), _ => true)
+#endif
     {
 
     }
@@ -47,7 +51,11 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// <param name="executeMethod">The <see cref="Func{T, Task}"/> to invoke when <see cref="ICommand.Execute"/> is called.</param>
     /// <param name="canExecuteMethod">The delegate to invoke when <see cref="ICommand.CanExecute"/> is called</param>
     public AsyncDelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
+#if NET6_0_OR_GREATER
+        : this((p, c) => executeMethod(p).WaitAsync(c), canExecuteMethod)
+#else
         : this((p, c) => executeMethod(p), canExecuteMethod)
+#endif
     {
 
     }

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -88,7 +88,7 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     ///<summary>
     /// Executes the command.
     ///</summary>
-    public async Task Execute(T parameter, CancellationToken? cancellationToken)
+    public async Task Execute(T parameter, CancellationToken? cancellationToken = null)
     {
         var token = cancellationToken ?? _getCancellationToken();
 

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -188,6 +188,14 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     }
 
     /// <summary>
+    /// Sets the <see cref="CancellationTokenSourceFactory(Func{CancellationToken})"/> based on the specified timeout.
+    /// </summary>
+    /// <param name="timeout">A specified timeout.</param>
+    /// <returns>The current instance of <see cref="AsyncDelegateCommand{T}"/>.</returns>
+    public AsyncDelegateCommand<T> CancelAfter(TimeSpan timeout) =>
+        CancellationTokenSourceFactory(() => new CancellationTokenSource(timeout).Token);
+
+    /// <summary>
     /// Provides a delegate callback to provide a default CancellationToken when the Command is invoked.
     /// </summary>
     /// <param name="factory">The default <see cref="CancellationToken"/> Factory.</param>

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -1,4 +1,4 @@
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,17 +88,20 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     ///<summary>
     /// Executes the command.
     ///</summary>
-    public async Task Execute(T parameter, CancellationToken cancellationToken = default)
+    public async Task Execute(T parameter, CancellationToken? cancellationToken)
     {
+        var token = cancellationToken ?? _getCancellationToken();
+
         try
         {
             if (!_enableParallelExecution && IsExecuting)
                 return;
 
             IsExecuting = true;
-            await _executeMethod(parameter, cancellationToken);
+            await _executeMethod(parameter, token)
+                .ConfigureAwait(false);
         }
-        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (TaskCanceledException) when (token.IsCancellationRequested)
         {
             // Do nothing... the Task was cancelled
         }

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -92,6 +92,9 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     {
         try
         {
+            if (!_enableParallelExecution && IsExecuting)
+                return;
+
             IsExecuting = true;
             await _executeMethod(parameter, cancellationToken);
         }

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -142,9 +142,15 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// <param name="parameter">Command Parameter</param>
     protected override async void Execute(object? parameter)
     {
+        var cancellationToken = _getCancellationToken();
         try
         {
-            await Execute((T)parameter!, _getCancellationToken());
+            await Execute((T)parameter!, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Do nothing... the Task was cancelled
         }
         catch (Exception ex)
         {

--- a/tests/Prism.Core.Tests/Commands/AsyncDelegateCommandFixture.cs
+++ b/tests/Prism.Core.Tests/Commands/AsyncDelegateCommandFixture.cs
@@ -132,4 +132,14 @@ public class AsyncDelegateCommandFixture
 
         Assert.False(command.IsExecuting);
     }
+
+    [Fact]
+    public void ICommandExecute_HandlesErrorOnce()
+    {
+        var handled = 0;
+        ICommand command = new AsyncDelegateCommand<string>(str => throw new System.Exception("Test"))
+            .Catch(ex => handled++);
+        command.Execute(string.Empty);
+        Assert.Equal(1, handled);
+    }
 }

--- a/tests/Prism.Core.Tests/Commands/AsyncDelegateCommandFixture.cs
+++ b/tests/Prism.Core.Tests/Commands/AsyncDelegateCommandFixture.cs
@@ -129,6 +129,7 @@ public class AsyncDelegateCommandFixture
 
         Assert.True(command.IsExecuting);
         cts.Cancel();
+        await Task.Delay(10);
 
         Assert.False(command.IsExecuting);
     }


### PR DESCRIPTION
﻿## Description of Change

Adds various minor fixes for AsyncDelegateCommand

- Adds new CancelAfter(TimeSpan) method to set the CancelationToken Factory to provide a Token that will expire after a specified TimeSpan
- Adds additional check in the Execute to ensure if Parallel Execution is disabled that we do not execute while IsExecuting is true. This will automatically cancel the additional request.
- Sets ConfigureAwait on the Delegate to false as the Command should not need to return to the calling thread.
- Uses WaitAsync(CancelationToken) when running in net6+ for delegates that do not directly provide a CancelationToken