### PR TITLE
Add NavigationView RegionAdapter

### DIFF
--- a/e2e/Uno/HelloWorld/Views/Shell.xaml
+++ b/e2e/Uno/HelloWorld/Views/Shell.xaml
@@ -32,7 +32,7 @@
       </DataTemplate>
     </toolkit:ExtendedSplashScreen.LoadingContentTemplate>
     <Grid>
-      <Grid.RowDefinitions>
+      <!--<Grid.RowDefinitions>
         <RowDefinition Height="auto"/>
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
@@ -48,7 +48,15 @@
           <Button Command="{Binding NavigateCommand}" CommandParameter="ViewB">Navigate to View B</Button>
         </StackPanel>
       </StackPanel>
-      <ContentControl Grid.Row="1" pr:RegionManager.RegionName="ContentRegion" />
+      <ContentControl Grid.Row="1" pr:RegionManager.RegionName="ContentRegion" />-->
+      <NavigationView pr:RegionManager.RegionName="ContentRegion"
+                      IsSettingsVisible="false">
+        <NavigationView.MenuItems>
+          <NavigationViewItem Content="View A" Tag="ViewA" />
+          <NavigationViewItem Content="View B" Tag="ViewB" />
+        </NavigationView.MenuItems>
+      </NavigationView>
+
     </Grid>
   </toolkit:ExtendedSplashScreen>
 

--- a/src/Uno/Prism.Uno/Navigation/Regions/NavigationViewRegionAdapter.cs
+++ b/src/Uno/Prism.Uno/Navigation/Regions/NavigationViewRegionAdapter.cs
@@ -1,0 +1,37 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Prism.Navigation.Regions;
+
+public sealed class NavigationViewRegionAdapter : RegionAdapterBase<NavigationView>
+{
+    public NavigationViewRegionAdapter(IRegionBehaviorFactory regionBehaviorFactory)
+        : base(regionBehaviorFactory)
+    {
+    }
+
+    protected override void Adapt(IRegion region, NavigationView regionTarget)
+    {
+        regionTarget.BackRequested += delegate
+        {
+            if (region.NavigationService.Journal.CanGoBack)
+                region.NavigationService.Journal.GoBack();
+        };
+
+        regionTarget.SelectionChanged += delegate
+        {
+            if (regionTarget.SelectedItem is FrameworkElement item && item.Tag is string navigationTarget && !string.IsNullOrEmpty(navigationTarget))
+                region.RequestNavigate(navigationTarget);
+        };
+
+        region.ActiveViews.CollectionChanged += delegate
+        {
+            regionTarget.Content = region.ActiveViews.FirstOrDefault();
+        };
+    }
+
+    protected override IRegion CreateRegion()
+    {
+        return new SingleActiveRegion();
+    }
+}

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -67,6 +67,9 @@ namespace Prism
             regionAdapterMappings.RegisterMapping<Selector, SelectorRegionAdapter>();
             regionAdapterMappings.RegisterMapping<ItemsControl, ItemsControlRegionAdapter>();
             regionAdapterMappings.RegisterMapping<ContentControl, ContentControlRegionAdapter>();
+#if HAS_WINUI
+            regionAdapterMappings.RegisterMapping<NavigationView, NavigationViewRegionAdapter>();
+#endif
         }
 
         internal static void RunModuleManager(IContainerProvider containerProvider)


### PR DESCRIPTION
﻿## Description of Change

Adding Region Adapter for the NavigationView for Uno Platform. This allows you to simply provide a UI like:

```xml
<NavigationView prism:RegionManager.RegionName="ContentRegion"
                IsSettingsVisible="false">
  <NavigationView.MenuItems>
    <NavigationViewItem Content="View A" Tag="ViewA" />
    <NavigationViewItem Content="View B" Tag="ViewB" />
  </NavigationView.MenuItems>
</NavigationView>
```