### PR TITLE
Remove Window dependency in DialogWindow

### DIFF
--- a/e2e/Uno/HelloWorld/Views/Shell.xaml
+++ b/e2e/Uno/HelloWorld/Views/Shell.xaml
@@ -2,10 +2,8 @@
     x:Class="HelloWorld.Views.Shell"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:pr="using:Prism.Navigation.Regions"
-    xmlns:pvm="using:Prism.Mvvm"
+    xmlns:prism="using:Prism.Navigation.Regions"
     xmlns:toolkit="using:Uno.Toolkit.UI"
-    pvm:ViewModelLocator.AutowireViewModel="true"
     xmlns:local="using:HelloWorld.Views"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" >
 
@@ -48,8 +46,8 @@
           <Button Command="{Binding NavigateCommand}" CommandParameter="ViewB">Navigate to View B</Button>
         </StackPanel>
       </StackPanel>
-      <ContentControl Grid.Row="1" pr:RegionManager.RegionName="ContentRegion" />-->
-      <NavigationView pr:RegionManager.RegionName="ContentRegion"
+      <ContentControl Grid.Row="1" prism:RegionManager.RegionName="ContentRegion" />-->
+      <NavigationView prism:RegionManager.RegionName="ContentRegion"
                       IsSettingsVisible="false">
         <NavigationView.MenuItems>
           <NavigationViewItem Content="View A" Tag="ViewA" />

--- a/src/Uno/Prism.Uno/Dialogs/DialogService.cs
+++ b/src/Uno/Prism.Uno/Dialogs/DialogService.cs
@@ -23,14 +23,18 @@ namespace Prism.Dialogs
                 parameters ??= new DialogParameters();
                 var windowName = parameters.TryGetValue<string>(KnownDialogParameters.WindowName, out var wName) ? wName : null;
 
-                IDialogWindow contentDialog = CreateDialogWindow(windowName);
-                ConfigureDialogWindowEvents(contentDialog, callback);
-                ConfigureDialogWindowContent(name, contentDialog, parameters);
+                var dialogWindow = CreateDialogWindow(windowName);
+                if (dialogWindow is ContentDialog contentDialog)
+                {
+                    contentDialog.XamlRoot = _containerProvider.Resolve<Window>().Content.XamlRoot;
+                }
+                ConfigureDialogWindowEvents(dialogWindow, callback);
+                ConfigureDialogWindowContent(name, dialogWindow, parameters);
 
                 var placement = parameters.ContainsKey(KnownDialogParameters.DialogPlacement) ?
                     (parameters[KnownDialogParameters.DialogPlacement] is ContentDialogPlacement placementValue ? placementValue : Enum.Parse<ContentDialogPlacement>(parameters[KnownDialogParameters.DialogPlacement].ToString() ?? string.Empty)) : ContentDialogPlacement.Popup;
 
-                await contentDialog.ShowAsync(placement);
+                await dialogWindow.ShowAsync(placement);
             }
             catch (Exception ex)
             {

--- a/src/Uno/Prism.Uno/Dialogs/DialogWindow.xaml.cs
+++ b/src/Uno/Prism.Uno/Dialogs/DialogWindow.xaml.cs
@@ -10,10 +10,9 @@ namespace Prism.Dialogs
     /// </summary>
     public partial class DialogWindow : ContentDialog, IDialogWindow
     {
-        public DialogWindow(Window window)
+        public DialogWindow()
         {
             this.InitializeComponent();
-            XamlRoot = window.Content.XamlRoot;
         }
         public IDialogResult? Result { get; set; }
 

--- a/tests/Prism.Core.Tests/Commands/AsyncDelegateCommandFixture.cs
+++ b/tests/Prism.Core.Tests/Commands/AsyncDelegateCommandFixture.cs
@@ -97,7 +97,12 @@ public class AsyncDelegateCommandFixture
         // Arrange
         bool executionStarted = false;
         bool executed = false;
-        var command = new AsyncDelegateCommand(Execute);
+        bool taskCancelled = false;
+        var command = new AsyncDelegateCommand(Execute)
+            .Catch<TaskCanceledException>(ex =>
+            {
+                taskCancelled = true;
+            });
 
         async Task Execute(CancellationToken token)
         {
@@ -116,6 +121,7 @@ public class AsyncDelegateCommandFixture
         // Assert
         Assert.True(executionStarted);
         Assert.False(executed);
+        Assert.True(taskCancelled);
     }
 
     [Fact]


### PR DESCRIPTION
﻿## Description of Change

Removing the strong dependency on the Window in the DialogWindow. This now has shifted to set the XamlRoot from the DialogService if the IDialogWindow is a ContentDialog.