### PR TITLE
Provide ConfigureWindow for Uno

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,38 +15,38 @@
   </ItemGroup>
   <!-- Uno -->
   <ItemGroup Condition=" $(IsUnoProject) == 'true' ">
-    <PackageVersion Include="Uno.WinUI" Version="5.0.19" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="5.0.19" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="5.0.19" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="5.0.19" />
-    <PackageVersion Include="Uno.Wasm.Bootstrap" Version="8.0.0" />
-    <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.0" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="5.0.19" />
-    <PackageVersion Include="Uno.WinUI.DevServer" Version="5.0.19" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.19" />
+    <PackageVersion Include="Uno.WinUI" Version="5.0.48" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="5.0.48" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="5.0.48" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="5.0.48" />
+    <PackageVersion Include="Uno.Wasm.Bootstrap" Version="8.0.4" />
+    <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.4" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="5.0.48" />
+    <PackageVersion Include="Uno.WinUI.DevServer" Version="5.0.48" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.0.48" />
     <PackageVersion Include="Uno.Core" Version="4.0.1" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.2" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" Condition="$(MSBuildProjectName.Contains('Prism'))" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" Condition="!$(MSBuildProjectName.Contains('Prism'))" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" Condition="!$(MSBuildProjectName.Contains('Prism'))" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.6" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.6" />
-    <PackageVersion Include="Uno.Resizetizer" Version="1.2.0" />
+    <PackageVersion Include="Uno.Resizetizer" Version="1.2.1" />
     <PackageVersion Include="Uno.Extensions.Core" Version="3.0.10" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
-    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="3.0.10" />
-    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="3.0.10" />
+    <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="3.0.11" />
+    <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="3.0.11" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="4.0.4" />
-    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="5.0.15" />
-    <PackageVersion Include="Uno.Toolkit.WinUI" Version="5.0.15" />
-    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="3.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="4.0.6" />
+    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="5.0.17" />
+    <PackageVersion Include="Uno.Toolkit.WinUI" Version="5.0.17" />
+    <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="3.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.10.0.1" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
-    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>
   <!-- Tests -->
   <ItemGroup>
@@ -77,6 +77,6 @@
     <!-- Global Packages -->
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/e2e/Uno/HelloWorld.Mobile/HelloWorld.Mobile.csproj
+++ b/e2e/Uno/HelloWorld.Mobile/HelloWorld.Mobile.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="Uno.Extensions.Logging.OSLog" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
-    <PackageReference Include="Uno.Extensions.Core" />
   </ItemGroup>
   <Choose>
     <When Condition="$(IsAndroid)">

--- a/e2e/Uno/HelloWorld.Skia.Gtk/HelloWorld.Skia.Gtk.csproj
+++ b/e2e/Uno/HelloWorld.Skia.Gtk/HelloWorld.Skia.Gtk.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Uno.Extensions.Hosting.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
-    <PackageReference Include="Uno.Extensions.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HelloWorld\HelloWorld.csproj" />

--- a/e2e/Uno/HelloWorld.Skia.Linux.FrameBuffer/HelloWorld.Skia.Linux.FrameBuffer.csproj
+++ b/e2e/Uno/HelloWorld.Skia.Linux.FrameBuffer/HelloWorld.Skia.Linux.FrameBuffer.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Uno.Extensions.Hosting.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
-    <PackageReference Include="Uno.Extensions.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HelloWorld\HelloWorld.csproj" />

--- a/e2e/Uno/HelloWorld.Skia.WPF/HelloWorld.Skia.WPF.csproj
+++ b/e2e/Uno/HelloWorld.Skia.WPF/HelloWorld.Skia.WPF.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Uno.Extensions.Hosting.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
-    <PackageReference Include="Uno.Extensions.Core" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="Wpf\App.xaml" XamlRuntime="Wpf" />

--- a/e2e/Uno/HelloWorld.Wasm/HelloWorld.Wasm.csproj
+++ b/e2e/Uno/HelloWorld.Wasm/HelloWorld.Wasm.csproj
@@ -56,7 +56,6 @@
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
-    <PackageReference Include="Uno.Extensions.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HelloWorld\HelloWorld.csproj" />

--- a/e2e/Uno/HelloWorld.Windows/HelloWorld.Windows.csproj
+++ b/e2e/Uno/HelloWorld.Windows/HelloWorld.Windows.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Uno.Extensions.Hosting.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
-    <PackageReference Include="Uno.Extensions.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/e2e/Uno/HelloWorld/App.cs
+++ b/e2e/Uno/HelloWorld/App.cs
@@ -1,5 +1,6 @@
 using HelloWorld.Views;
 using ModuleA;
+using Uno.UI;
 
 namespace HelloWorld;
 
@@ -33,6 +34,13 @@ public class App : PrismApplication
                     // TODO: Register your services
                     //services.AddSingleton<IMyService, MyService>();
                 });
+    }
+
+    protected override void ConfigureWindow(Window window)
+    {
+#if DEBUG
+        window.EnableHotReload();
+#endif
     }
 
     protected override void RegisterTypes(IContainerRegistry containerRegistry)

--- a/e2e/Uno/HelloWorld/HelloWorld.csproj
+++ b/e2e/Uno/HelloWorld/HelloWorld.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" />
     <PackageReference Include="Uno.Resizetizer" />
-    <PackageReference Include="Uno.Extensions.Core" />
     <PackageReference Include="Uno.Extensions.Logging.WinUI" />
     <PackageReference Include="Uno.Extensions.Logging.Serilog" />
     <PackageReference Include="Uno.Material.WinUI" />
@@ -19,6 +18,7 @@
     <PackageReference Include="Uno.Toolkit.WinUI" />
     <PackageReference Include="Uno.Extensions.Hosting.WinUI" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Uno.WinUI.DevServer" Condition=" $(Configuration) == 'Debug' " />
   </ItemGroup>
 
   <Choose>

--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -345,7 +345,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
 
         animated = parameters.ContainsKey(KnownNavigationParameters.Animated) ?
             parameters.GetValue<bool>(KnownNavigationParameters.Animated) :
-                pageParameters.ContainsKey(KnownNavigationParameters.Animated) ? pageParameters.GetValue<bool>(KnownNavigationParameters.Animated) : true;        
+                pageParameters.ContainsKey(KnownNavigationParameters.Animated) ? pageParameters.GetValue<bool>(KnownNavigationParameters.Animated) : true;
 
         if (nextSegment == RemovePageSegment)
         {
@@ -837,7 +837,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
             {
                 var tabSegment = tabSegments[i];
                 var child = CreatePageFromSegment(tabSegment);
-                var childParameters = UriParsingHelper.GetSegmentParameters(tabSegment, parameters);                
+                var childParameters = UriParsingHelper.GetSegmentParameters(tabSegment, parameters);
                 if (i == 0 && child is NavigationPage navPage)
                 {
                     navigationPage = navPage;

--- a/src/Uno/Prism.Uno/PrismApplicationBase.cs
+++ b/src/Uno/Prism.Uno/PrismApplicationBase.cs
@@ -89,6 +89,20 @@ namespace Prism
         protected virtual void ConfigureHost(IHostBuilder builder) { }
 
         /// <summary>
+        /// Provides an opportunity to initialize services or otherwise prepare the application Window.
+        /// </summary>
+        /// <param name="window">The primary application <see cref="Window"/></param>
+        /// <example>
+        /// protected override void ConfigureWindow(Window window)
+        /// {
+        ///     #if DEBUG
+        ///     window.EnableHotReload();
+        ///     #endif
+        /// }
+        /// </example>
+        protected virtual void ConfigureWindow(Window window) { }
+
+        /// <summary>
         /// Register Services with the <see cref="IServiceCollection" />.
         /// </summary>
         /// <remarks>
@@ -104,6 +118,7 @@ namespace Prism
         protected virtual void Initialize(IApplicationBuilder builder)
         {
             ConfigureApp(builder);
+            ConfigureWindow(builder.Window);
             builder.Configure(ConfigureHost)
                 .Configure(x => x.ConfigureServices(ConfigureServices)
                     .UseServiceProviderFactory(new PrismServiceProviderFactory(_containerExtension)));


### PR DESCRIPTION
﻿## Description of Change

Provide new Configure Window method in PrismApplicationBase to make an easier to understand API where you might need to configure things with the Window such as enabling HotReload.

- Updates to latest Uno patch releases
- Updates to SourceLink v8.0

### Bugs Fixed

- n/a

### API Changes

Added:

- void PrismApplicationBase.ConfigureWindow(Window);

### Behavioral Changes

n/a