### PR TITLE
Adding select tab API to INavigationService

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/INavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationService.cs
@@ -33,9 +33,18 @@ public interface INavigationService
     /// </summary>
     /// <param name="uri">The Uri to navigate to</param>
     /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
     /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
     /// <example>
-    /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
+    /// NavigateAsync(new Uri("MainPage?id=3&amp;name=Brian", UriKind.RelativeSource), parameters);
     /// </example>
     Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters);
+
+    /// <summary>
+    /// Selects a Tab of the TabbedPage parent.
+    /// </summary>
+    /// <param name="name">The name of the tab to select</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    Task<INavigationResult> SelectTabAsync(string name, INavigationParameters parameters);
 }

--- a/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -117,6 +117,15 @@ public static class INavigationServiceExtensions
         });
     }
 
+    /// <summary>
+    /// Selects a tab programatically
+    /// </summary>
+    /// <param name="navigationService"></param>
+    /// <param name="tabName">The name of the tab to select</param>
+    /// <returns>The <see cref="INavigationResult"/>.</returns>
+    public static Task<INavigationResult> SelectTabAsync(this INavigationService navigationService, string tabName) =>
+        navigationService.SelectTabAsync(tabName, new NavigationParameters());
+
     private static INavigationParameters GetNavigationParameters((string Key, object Value)[] parameters)
     {
         var navParams = new NavigationParameters();

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -280,7 +280,7 @@ public class NavigationTests : TestBase
     public async Task TabbedPage_SelectsNewTab()
     {
         var mauiApp = CreateBuilder(prism => prism
-            .OnAppStart(nav => nav.CreateBuilder()
+            .CreateWindow(nav => nav.CreateBuilder()
                 .AddTabbedSegment(s => s.CreateTab("MockViewA")
                                                        .CreateTab("MockViewB")
                                                        .CreateTab("MockViewC"))
@@ -306,7 +306,7 @@ public class NavigationTests : TestBase
     public async Task TabbedPage_SelectsNewTab_WithNavigationParameters()
     {
         var mauiApp = CreateBuilder(prism => prism
-            .OnAppStart(nav => nav.CreateBuilder()
+            .CreateWindow(nav => nav.CreateBuilder()
                 .AddTabbedSegment(s => s.CreateTab("MockViewA")
                                                        .CreateTab("MockViewB")
                                                        .CreateTab("MockViewC"))
@@ -336,7 +336,7 @@ public class NavigationTests : TestBase
     public async Task NavigationPage_DoesNotHave_MauiPage_AsRootPage()
     {
         var mauiApp = CreateBuilder(prism => prism
-            .OnAppStart("NavigationPage/MockViewA"))
+            .CreateWindow("NavigationPage/MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -354,7 +354,7 @@ public class NavigationTests : TestBase
     public async Task NavigationPage_UsesRootPageTitle_WithTabbedParent()
     {
         var mauiApp = CreateBuilder(prism => prism
-            .OnAppStart(n => n.CreateBuilder()
+            .CreateWindow(n => n.CreateBuilder()
                 .AddTabbedSegment(s => s
                     .CreateTab(t => t.AddNavigationPage()
                                                 .AddSegment("MockViewA")))

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -249,7 +249,7 @@ public class NavigationTests : TestBase
     }
 
     [Fact]
-    public async Task TabbedPageSelectTabSetsCurrentTab()
+    public async Task TabbedPage_SelectTabSets_CurrentTab()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("TabbedPage?createTab=MockViewA&createTab=MockViewB&selectedTab=MockViewB"))
             .Build();
@@ -262,7 +262,7 @@ public class NavigationTests : TestBase
     }
 
     [Fact]
-    public async Task TabbedPageSelectTabSetsCurrentTabWithNavigationPageTab()
+    public async Task TabbedPage_SelectTab_SetsCurrentTab_WithNavigationPageTab()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("TabbedPage?createTab=NavigationPage%2FMockViewA&createTab=NavigationPage%2FMockViewB&selectedTab=NavigationPage|MockViewB"))
             .Build();
@@ -274,6 +274,62 @@ public class NavigationTests : TestBase
         var navPage = tabbedPage.CurrentPage as NavigationPage;
         Assert.NotNull(navPage);
         Assert.IsType<MockViewB>(navPage.CurrentPage);
+    }
+
+    [Fact]
+    public async Task TabbedPage_SelectsNewTab()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+            .OnAppStart(nav => nav.CreateBuilder()
+                .AddTabbedSegment(s => s.CreateTab("MockViewA")
+                                                       .CreateTab("MockViewB")
+                                                       .CreateTab("MockViewC"))
+                .NavigateAsync()))
+            .Build();
+        var window = GetWindow(mauiApp);
+        Assert.IsAssignableFrom<TabbedPage>(window.Page);
+        var tabbed = window.Page as TabbedPage;
+
+        Assert.NotNull(tabbed);
+
+        Assert.IsType<MockViewA>(tabbed.CurrentPage);
+        var mockViewA = tabbed.CurrentPage;
+        var mockViewANav = Prism.Navigation.Xaml.Navigation.GetNavigationService(mockViewA);
+
+        await mockViewANav.SelectTabAsync("MockViewB");
+
+        Assert.IsNotType<MockViewA>(tabbed.CurrentPage);
+        Assert.IsType<MockViewB>(tabbed.CurrentPage);
+    }
+
+    [Fact]
+    public async Task TabbedPage_SelectsNewTab_WithNavigationParameters()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+            .OnAppStart(nav => nav.CreateBuilder()
+                .AddTabbedSegment(s => s.CreateTab("MockViewA")
+                                                       .CreateTab("MockViewB")
+                                                       .CreateTab("MockViewC"))
+                .NavigateAsync()))
+            .Build();
+        var window = GetWindow(mauiApp);
+        Assert.IsAssignableFrom<TabbedPage>(window.Page);
+        var tabbed = window.Page as TabbedPage;
+
+        Assert.NotNull(tabbed);
+
+        Assert.IsType<MockViewA>(tabbed.CurrentPage);
+        var mockViewA = tabbed.CurrentPage;
+        var mockViewANav = Prism.Navigation.Xaml.Navigation.GetNavigationService(mockViewA);
+
+        var expectedMessage = nameof(TabbedPage_SelectsNewTab_WithNavigationParameters);
+        await mockViewANav.SelectTabAsync("MockViewB", new NavigationParameters { { "Message", expectedMessage } });
+
+        Assert.IsNotType<MockViewA>(tabbed.CurrentPage);
+        Assert.IsType<MockViewB>(tabbed.CurrentPage);
+
+        var viewModel = tabbed.CurrentPage.BindingContext as MockViewBViewModel;
+        Assert.Equal(expectedMessage, viewModel?.Message);
     }
 
     [Fact]

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
@@ -2,7 +2,7 @@
 
 namespace Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 
-public abstract class MockViewModelBase : IActiveAware, IConfirmNavigation
+public abstract class MockViewModelBase : IActiveAware, INavigationAware, IConfirmNavigation
 {
     private readonly IPageAccessor _pageAccessor;
 
@@ -13,6 +13,11 @@ public abstract class MockViewModelBase : IActiveAware, IConfirmNavigation
         _pageAccessor = pageAccessor;
         NavigationService = navigationService;
     }
+
+    public string Message { get; private set; }
+
+    private List<string> _actions = [];
+    public IEnumerable<string> Actions => _actions;
 
     public INavigationService NavigationService { get; }
 
@@ -26,6 +31,21 @@ public abstract class MockViewModelBase : IActiveAware, IConfirmNavigation
 
     public bool IsActive { get; set; }
 
-    public bool CanNavigate(INavigationParameters parameters) =>
-        !StopNavigation;
+    public bool CanNavigate(INavigationParameters parameters)
+    {
+        _actions.Add(nameof(CanNavigate));
+        return !StopNavigation;
+    }
+
+    public void OnNavigatedFrom(INavigationParameters parameters)
+    {
+        _actions.Add(nameof(OnNavigatedFrom));
+    }
+
+    public void OnNavigatedTo(INavigationParameters parameters)
+    {
+        _actions.Add(nameof(OnNavigatedTo));
+        if (parameters.TryGetValue<string>("Message", out var message))
+            Message = message;
+    }
 }


### PR DESCRIPTION
﻿## Description of Change

In Prism.Forms you had the ability to select the tab from another tab. This isn't quite possible to do from an Extension method now that we've removed IPageAware. This has now been added as an API on INavigationService itself.

### Bugs Fixed

- n/a

### API Changes

Added:

- Task<INavigationResult> INavigationService.SelectTabAsync(INavigationParameters);