### PR TITLE
Adding support for C# Markup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,8 @@
     <PackageVersion Include="Prism.Container.Unity" Version="9.0.61-pre" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
+    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.0.13" />
+    <PackageVersion Include="Uno.WinUI.Markup" Version="5.0.13" />
     <PackageVersion Include="Xamarin.Forms" Version="5.0.0.2401" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
   </ItemGroup>

--- a/PrismLibrary.sln
+++ b/PrismLibrary.sln
@@ -87,6 +87,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Maui.Tests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Events", "src\Prism.Events\Prism.Events.csproj", "{8610485A-BE9F-4938-86D4-E9F1FA1739A0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.Uno.WinUI.Markup", "src\Uno\Prism.Uno.Markup\Prism.Uno.WinUI.Markup.csproj", "{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -397,6 +399,18 @@ Global
 		{8610485A-BE9F-4938-86D4-E9F1FA1739A0}.Release|x64.Build.0 = Release|Any CPU
 		{8610485A-BE9F-4938-86D4-E9F1FA1739A0}.Release|x86.ActiveCfg = Release|Any CPU
 		{8610485A-BE9F-4938-86D4-E9F1FA1739A0}.Release|x86.Build.0 = Release|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Debug|x64.Build.0 = Debug|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Debug|x86.Build.0 = Debug|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x64.ActiveCfg = Release|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x64.Build.0 = Release|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x86.ActiveCfg = Release|Any CPU
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -436,6 +450,7 @@ Global
 		{7A1E157F-D4CD-4E6B-9CE3-1894EB2A15A7} = {540CEEC1-D541-4614-BF0B-18056A83E434}
 		{8711D306-1118-4A11-9399-EF14AA13015E} = {540CEEC1-D541-4614-BF0B-18056A83E434}
 		{8610485A-BE9F-4938-86D4-E9F1FA1739A0} = {F3664D7A-6FF5-4D1F-9F5F-26EE87F032D3}
+		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D} = {8F959801-D494-4CAF-9437-90F30472E169}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7433AE2-B1A0-4C1A-887E-5CAA7AAF67A6}

--- a/PrismLibrary_Uno.slnf
+++ b/PrismLibrary_Uno.slnf
@@ -6,6 +6,7 @@
       "src\\Prism.Events\\Prism.Events.csproj",
       "src\\Uno\\Prism.DryIoc.Uno\\Prism.DryIoc.Uno.WinUI.csproj",
       "src\\Uno\\Prism.Uno\\Prism.Uno.WinUI.csproj",
+      "src\\Uno\\Prism.Uno.Markup\\Prism.Uno.WinUI.Markup.csproj",
       "tests\\Prism.Core.Tests\\Prism.Core.Tests.csproj"
     ]
   }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
         <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
       </PropertyGroup>
       <ItemGroup>
-        <EmbeddedResource Include="LinkerDefinition.mono.xml">
+        <EmbeddedResource Include="LinkerDefinition.mono.xml" Condition="Exists('LinkerDefinition.mono.xml')">
           <LogicalName>$(AssemblyName).xml</LogicalName>
         </EmbeddedResource>
       </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,11 @@
     </When>
   </Choose>
 
+  <PropertyGroup Condition=" $(IsUnoProject) ">
+    <UnoTargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</UnoTargetFrameworks>
+    <UnoTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(UnoTargetFrameworks);net7.0-windows10.0.19041</UnoTargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>$(IsPackable)</GeneratePackageOnBuild>

--- a/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
+++ b/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(UnoTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Prism.DryIoc.Uno</AssemblyName>
     <PackageId>Prism.DryIoc.Uno.WinUI</PackageId>

--- a/src/Uno/Prism.Uno.Markup/AssemblyInfo.cs
+++ b/src/Uno/Prism.Uno.Markup/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using Prism;
+using Uno.Extensions.Markup.Generator;
+
+[assembly: GenerateMarkupForAssembly(typeof(PrismApplicationBase))]

--- a/src/Uno/Prism.Uno.Markup/Prism.Uno.WinUI.Markup.csproj
+++ b/src/Uno/Prism.Uno.Markup/Prism.Uno.WinUI.Markup.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(UnoTargetFrameworks)</TargetFrameworks>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
 

--- a/src/Uno/Prism.Uno.Markup/Prism.Uno.WinUI.Markup.csproj
+++ b/src/Uno/Prism.Uno.Markup/Prism.Uno.WinUI.Markup.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Uno.Extensions.Markup.Generators">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Uno.WinUI.Markup" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Prism.Uno\Prism.Uno.WinUI.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
+++ b/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(UnoTargetFrameworks)</TargetFrameworks>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>Prism.Uno</AssemblyName>
     <RootNamespace>Prism</RootNamespace>


### PR DESCRIPTION
﻿## Description of Change

Adds new package for C# Markup support for Uno Platform

### Bugs Fixed

- n/a

### API Changes

Adds generated C# Markup extensions to make it easier when building Prism applications with Uno Platform and C# Markup. This will allow developers to leverage attached properties within Prism such as the ViewModelLocator to easily set the Autowire property from code.
