### PR TITLE
Use net8 for Uno CI build

### DIFF
--- a/.github/workflows/build_uno.yml
+++ b/.github/workflows/build_uno.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       name: Build Prism.Uno
       solution-path: PrismLibrary_Uno.slnf
-      dotnet-version: 7.0.400
+      dotnet-version: 8.0.x
       windows-sdk-version: 18362
       uno-check: true
       uno-check-parameters: '--skip xcode --skip gtk3 --skip vswin --skip vsmac'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     with:
       name: Build Prism.Uno
       solution-path: PrismLibrary_Uno.slnf
-      dotnet-version: 7.0.400
+      dotnet-version: 8.0.x
       windows-sdk-version: 18362
       uno-check: true
       uno-check-parameters: '--skip xcode --skip gtk3 --skip vswin --skip vsmac'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,9 @@
 {
   "recommendations": [
     "ms-dotnettools.csharp",
-    "ms-azure-devops.azure-pipelines",
     "ms-vscode.powershell",
     "editorconfig.editorconfig",
     "shd101wyy.markdown-preview-enhanced",
-    "streetsidesoftware.code-spell-checker",
-    "clancey.comet-debug",
-    "cschleiden.vscode-github-actions"
+    "streetsidesoftware.code-spell-checker"
   ]
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,6 +87,7 @@
     </When>
     <When Condition="$(TargetFramework.Contains('windows10'))">
       <PropertyGroup>
+        <UseRidGraph Condition=" $(TargetFramework.Contains('net8.0')) ">true</UseRidGraph>
         <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
       </PropertyGroup>

--- a/PrismLibrary.sln
+++ b/PrismLibrary.sln
@@ -1,9 +1,13 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{F3664D7A-6FF5-4D1F-9F5F-26EE87F032D3}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Core", "src\Prism.Core\Prism.Core.csproj", "{F634CA1E-9237-4E69-B23C-91AA6FBCABFF}"
 EndProject
@@ -87,7 +91,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Maui.Tests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Events", "src\Prism.Events\Prism.Events.csproj", "{8610485A-BE9F-4938-86D4-E9F1FA1739A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.Uno.WinUI.Markup", "src\Uno\Prism.Uno.Markup\Prism.Uno.WinUI.Markup.csproj", "{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Uno.WinUI.Markup", "src\Uno\Prism.Uno.Markup\Prism.Uno.WinUI.Markup.csproj", "{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,7 @@
 
   <PropertyGroup Condition=" $(IsUnoProject) ">
     <UnoTargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-macos</UnoTargetFrameworks>
-    <UnoTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(UnoTargetFrameworks);net8.0-windows10.0.19041</UnoTargetFrameworks>
+    <UnoTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(UnoTargetFrameworks);net7.0-windows10.0.19041</UnoTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
﻿## Description of Change

Bumps install version of .NET to net8.0 for Uno builds