### PR TITLE
BREAKING: Change OnAppStart to CreateWindow

### DIFF
--- a/e2e/Maui/PrismMauiDemo/MauiProgram.cs
+++ b/e2e/Maui/PrismMauiDemo/MauiProgram.cs
@@ -38,7 +38,7 @@ public static class MauiProgram
                     if (status == "Failed" && !string.IsNullOrEmpty(x.Result?.Exception?.Message))
                         Console.Error.WriteLine(x.Result.Exception.Message);
                 }))
-                //.OnAppStart(nav => nav.CreateBuilder()
+                //.CreateWindow(nav => nav.CreateBuilder()
                 //    .AddTabbedSegment(page =>
                 //        page.CreateTab("ViewC")
                 //            .CreateTab(t =>
@@ -49,8 +49,8 @@ public static class MauiProgram
                 //            .SelectedTab("NavigationPage|ViewB"))
                 //    .AddParameter("message_global", "This is a Global Message")
                 //    .Navigate())
-                //.OnAppStart("ViewA/ViewB/ViewC")
-                .OnAppStart(navigationService => navigationService.CreateBuilder()
+                //.CreateWindow("ViewA/ViewB/ViewC")
+                .CreateWindow(navigationService => navigationService.CreateBuilder()
                     .AddSegment<SplashPageViewModel>()
                     .NavigateAsync(HandleNavigationError))
             )

--- a/src/Maui/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilder.cs
@@ -194,7 +194,7 @@ public sealed class PrismAppBuilder
     /// </summary>
     /// <param name="onAppStarted">The Navigation Delegate.</param>
     /// <returns>The <see cref="PrismAppBuilder"/>.</returns>
-    public PrismAppBuilder OnAppStart(Func<IContainerProvider, INavigationService, Task> onAppStarted)
+    public PrismAppBuilder CreateWindow(Func<IContainerProvider, INavigationService, Task> onAppStarted)
     {
         _onAppStarted = onAppStarted;
         return this;

--- a/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using Prism.Modularity;
 using Prism.Mvvm;
 using Prism.Navigation;
+using Prism.Navigation.Builder;
 
 namespace Prism;
 
@@ -60,6 +61,12 @@ public static class PrismAppBuilderExtensions
 
     public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<INavigationService, Task> onAppStarted) =>
         builder.OnAppStart((_, n) => onAppStarted(n));
+
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<INavigationService, INavigationBuilder> onAppStarted) =>
+        builder.OnAppStart(n => onAppStarted(n).NavigateAsync());
+
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, INavigationBuilder> onAppStarted) =>
+        builder.OnAppStart((c, n) => onAppStarted(c, n).NavigateAsync());
 
     public static PrismAppBuilder ConfigureServices(this PrismAppBuilder builder, Action<IServiceCollection> configureServices)
     {

--- a/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -45,28 +45,28 @@ public static class PrismAppBuilderExtensions
         });
     }
 
-    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, string uri) =>
-        builder.OnAppStart(navigation => navigation.NavigateAsync(uri));
+    public static PrismAppBuilder CreateWindow(this PrismAppBuilder builder, string uri) =>
+        builder.CreateWindow(navigation => navigation.NavigateAsync(uri));
 
-    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, string uri, Action<Exception> onError) =>
-        builder.OnAppStart(async navigation =>
+    public static PrismAppBuilder CreateWindow(this PrismAppBuilder builder, string uri, Action<Exception> onError) =>
+        builder.CreateWindow(async navigation =>
         {
             var result = await navigation.NavigateAsync(uri);
             if (result.Exception is not null)
                 onError(result.Exception);
         });
 
-    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, Task> onAppStarted) =>
-        builder.OnAppStart((c, n) => onAppStarted(c, n));
+    public static PrismAppBuilder CreateWindow(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, Task> CreateWindowed) =>
+        builder.CreateWindow((c, n) => CreateWindowed(c, n));
 
-    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<INavigationService, Task> onAppStarted) =>
-        builder.OnAppStart((_, n) => onAppStarted(n));
+    public static PrismAppBuilder CreateWindow(this PrismAppBuilder builder, Func<INavigationService, Task> CreateWindowed) =>
+        builder.CreateWindow((_, n) => CreateWindowed(n));
 
-    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<INavigationService, INavigationBuilder> onAppStarted) =>
-        builder.OnAppStart(n => onAppStarted(n).NavigateAsync());
+    public static PrismAppBuilder CreateWindow(this PrismAppBuilder builder, Func<INavigationService, INavigationBuilder> CreateWindowed) =>
+        builder.CreateWindow(n => CreateWindowed(n).NavigateAsync());
 
-    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, INavigationBuilder> onAppStarted) =>
-        builder.OnAppStart((c, n) => onAppStarted(c, n).NavigateAsync());
+    public static PrismAppBuilder CreateWindow(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, INavigationBuilder> CreateWindowed) =>
+        builder.CreateWindow((c, n) => CreateWindowed(c, n).NavigateAsync());
 
     public static PrismAppBuilder ConfigureServices(this PrismAppBuilder builder, Action<IServiceCollection> configureServices)
     {

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Behaviors/NavigationBehaviors.cs
@@ -100,7 +100,7 @@ public class NavigationBehaviors : TestBase
 
     private Page StartAndGetRootPage(Action<INavigationBuilder> initialNav)
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart((_, nav) =>
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow((_, nav) =>
         {
             var navBuilder = nav.CreateBuilder();
             initialNav(navBuilder);
@@ -117,7 +117,7 @@ public class NavigationBehaviors : TestBase
 
     private Page StartAndGetRootPage(string uri)
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart(uri))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow(uri))
             .Build();
         var window = GetWindow(mauiApp);
 

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/DynamicTabbedPageNavigationFixture.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/DynamicTabbedPageNavigationFixture.cs
@@ -13,7 +13,7 @@ public class DynamicTabbedPageNavigationFixture : TestBase
     [Fact]
     public void CreatesTabs_WithSingleContentPage()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart(navigation =>
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow(navigation =>
         navigation.CreateBuilder()
             .AddTabbedSegment(t =>
                 t.CreateTab("MockViewA")
@@ -33,7 +33,7 @@ public class DynamicTabbedPageNavigationFixture : TestBase
     [Fact]
     public void CreatesTabs_WithNavigationPageAndContentPage()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart(navigation =>
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow(navigation =>
             navigation.CreateBuilder()
                 .AddTabbedSegment(t =>
                     t.CreateTab(ct => ct.AddNavigationPage().AddSegment("MockViewA"))

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -19,7 +19,7 @@ public class NavigationTests : TestBase
     [InlineData("MockHome/NavigationPage/MockViewA")]
     public void PagesInjectScopedInstanceOfIPageAccessor(string uri)
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart(uri))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow(uri))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -42,7 +42,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task AddsPageFromRelativeURI()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -64,7 +64,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task RelativeNavigation_RemovesPage_AndNavigates()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA/MockViewB"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA/MockViewB"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -86,7 +86,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task AbsoluteNavigation_ResetsWindowPage()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("MockViewA"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -102,7 +102,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task AddsModalPageFromRelativeURI()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("MockViewA"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -121,7 +121,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task FlyoutRelativeNavigation_RemovesPage_AndNavigatesNotModally()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("MockHome/NavigationPage/MockViewA"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockHome/NavigationPage/MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -153,7 +153,7 @@ public class NavigationTests : TestBase
     public async Task RelativeNavigation_RemovesPage_AndNavigatesModally()
     {
         Exception startupEx = null;
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("MockViewA/MockViewB", ex =>
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockViewA/MockViewB", ex =>
         {
             startupEx = ex;
         }))
@@ -179,7 +179,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task GoBackTo_Name_PopsToSpecifiedView()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -201,7 +201,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task GoBackTo_ViewModel_PopsToSpecifiedView()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -224,7 +224,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task GoBack_Issue2232()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -251,7 +251,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task TabbedPageSelectTabSetsCurrentTab()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("TabbedPage?createTab=MockViewA&createTab=MockViewB&selectedTab=MockViewB"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("TabbedPage?createTab=MockViewA&createTab=MockViewB&selectedTab=MockViewB"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -264,7 +264,7 @@ public class NavigationTests : TestBase
     [Fact]
     public async Task TabbedPageSelectTabSetsCurrentTabWithNavigationPageTab()
     {
-        var mauiApp = CreateBuilder(prism => prism.OnAppStart("TabbedPage?createTab=NavigationPage%2FMockViewA&createTab=NavigationPage%2FMockViewB&selectedTab=NavigationPage|MockViewB"))
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("TabbedPage?createTab=NavigationPage%2FMockViewA&createTab=NavigationPage%2FMockViewB&selectedTab=NavigationPage|MockViewB"))
             .Build();
         var window = GetWindow(mauiApp);
 

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
@@ -18,7 +18,7 @@ public class RegionFixture : TestBase
         {
             container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
             container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
-        }).OnAppStart(nav => nav.NavigateAsync("MockContentRegionPage"))).Build();
+        }).CreateWindow(nav => nav.NavigateAsync("MockContentRegionPage"))).Build();
         var window = GetWindow(mauiApp);
 
         Assert.IsType<MockContentRegionPage>(window.Page);
@@ -42,7 +42,7 @@ public class RegionFixture : TestBase
                     var regionManager = container.Resolve<IRegionManager>();
                     regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
                 })
-                .OnAppStart("MockContentRegionPage"))
+                .CreateWindow("MockContentRegionPage"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -67,7 +67,7 @@ public class RegionFixture : TestBase
                     var regionManager = container.Resolve<IRegionManager>();
                     regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
                 })
-                .OnAppStart("MockContentRegionPage"))
+                .CreateWindow("MockContentRegionPage"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -93,7 +93,7 @@ public class RegionFixture : TestBase
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
                     container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
                 })
-                .OnAppStart("MockContentRegionPage"))
+                .CreateWindow("MockContentRegionPage"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -117,7 +117,7 @@ public class RegionFixture : TestBase
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
                 })
-                .OnAppStart("MockContentRegionPage"))
+                .CreateWindow("MockContentRegionPage"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -139,7 +139,7 @@ public class RegionFixture : TestBase
                     var regionManager = container.Resolve<IRegionManager>();
                     regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
                 })
-                .OnAppStart("MockContentRegionPage"))
+                .CreateWindow("MockContentRegionPage"))
             .Build();
         var window = GetWindow(mauiApp);
 
@@ -161,7 +161,7 @@ public class RegionFixture : TestBase
                     container.RegisterForNavigation<MockPageWithRegionAndDefaultView>("MainPage");
                     container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
                 })
-                .OnAppStart("MainPage", ex => Assert.Null(ex)))
+                .CreateWindow("MainPage", ex => Assert.Null(ex)))
             .Build();
         var window = GetWindow(mauiApp);
 


### PR DESCRIPTION
﻿## Description of Change

To better align with what Prism/.NET MAUI are doing, the `PrismAppBuilder` method `OnAppStart` is being renamed to `CreateWindow`. This better aligns with where .NET MAUI actually is ultimately invoking the Prism delegate to do the initial navigation and should make the API clearer in aligning with the appropriate method naming used by .NET MAUI

### Bugs Fixed

- n/a

### API Changes

Changed:

- PrismAppBuilder.OnAppStart -> PrismAppBuilder.CreateWindow

### Behavioral Changes

none