### PR TITLE
Adding implicit namespaces for DI packages

### DIFF
--- a/e2e/Maui/Directory.Build.targets
+++ b/e2e/Maui/Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project>
   <Import Project="..\..\src\Prism.Core\build\Package.targets" />
+  <Import Project="..\..\src\Prism.Events\build\Package.targets" />
   <Import Project="..\..\src\Maui\Prism.Maui\build\Package.targets" />
 </Project>

--- a/e2e/Uno/Directory.Build.targets
+++ b/e2e/Uno/Directory.Build.targets
@@ -1,3 +1,4 @@
 <Project ToolsVersion="15.0">
   <Import Project="..\..\src\Prism.Core\build\Package.targets" />
+  <Import Project="..\..\src\Prism.Events\build\Package.targets" />
 </Project>

--- a/src/Prism.Core/build/Package.targets
+++ b/src/Prism.Core/build/Package.targets
@@ -4,7 +4,6 @@
     <Using Include="Prism" />
     <Using Include="Prism.Commands" />
     <Using Include="Prism.Dialogs" />
-    <Using Include="Prism.Events" />
     <Using Include="Prism.Ioc" />
     <Using Include="Prism.Modularity" />
     <Using Include="Prism.Mvvm" />

--- a/src/Prism.Events/build/Package.targets
+++ b/src/Prism.Events/build/Package.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  <ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
+    <Using Include="Prism.Events" />
+  </ItemGroup>
+</Project>

--- a/src/Wpf/Prism.DryIoc.Wpf/build/Package.targets
+++ b/src/Wpf/Prism.DryIoc.Wpf/build/Package.targets
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  <ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
+    <Using Include="DryIoc" />
+    <Using Include="Prism.DryIoc" />
+  </ItemGroup>
+</Project>

--- a/src/Wpf/Prism.Unity.Wpf/build/Package.targets
+++ b/src/Wpf/Prism.Unity.Wpf/build/Package.targets
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  <ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
+    <Using Include="Unity" />
+    <Using Include="Prism.Unity" />
+  </ItemGroup>
+</Project>

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/TestBase.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/TestBase.cs
@@ -3,6 +3,7 @@ using Prism.DryIoc.Maui.Tests.Mocks;
 using Prism.DryIoc.Maui.Tests.Mocks.Logging;
 using Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 using Prism.DryIoc.Maui.Tests.Mocks.Views;
+using Prism.Events;
 
 namespace Prism.DryIoc.Maui.Tests.Fixtures;
 


### PR DESCRIPTION
﻿## Description of Change

Adds targets to Prism.DryIoc and Prism.Unity to provide implicit namespace support for their implementation of PrismApplication.
Moves using from Prism.Core to the Prism.Events package for the Prism.Events namespace. This will provide implicit namespace support for Prism.Events even if you don't reference Prism.Core.

### Bugs Fixed

- missing implicit namespaces

### API Changes

none

### Behavioral Changes

implicit namespaces are now supported for Prism.Unity and Prism.DryIoc
