### PR TITLE
Navigation RemovePageInstruction not working correctly

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -134,6 +134,16 @@ public class PageNavigationService : INavigationService, IRegistryAware
     public virtual async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
     {
         await _semaphore.WaitAsync();
+
+        INavigationResult result = await GoBackInternalAsync(parameters);
+
+        _semaphore.Release();
+
+        return result;
+    }
+
+    private async Task<INavigationResult> GoBackInternalAsync(INavigationParameters parameters)
+    {
         Page page = null;
         try
         {
@@ -174,7 +184,6 @@ public class PageNavigationService : INavigationService, IRegistryAware
         finally
         {
             NavigationSource = PageNavigationSource.Device;
-            _semaphore.Release();
         }
 
         return Notify(NavigationRequestType.GoBack, parameters, GetGoBackException(page, GetPageFromWindow()));
@@ -468,7 +477,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
 
         RemovePagesFromNavigationPage(currentPage, pagesToRemove);
 
-        return GoBackAsync(parameters);
+        return GoBackInternalAsync(parameters);
     }
 
     private async Task RemoveAndPush(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -83,6 +83,28 @@ public class NavigationTests : TestBase
         Assert.Equal(2, rootPage.Navigation.NavigationStack.Count);
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task Issue3047_RelativeNavigation_RemovesPage_AndGoBack()
+    {
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA/MockViewB"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        var rootPage = window.Page as NavigationPage;
+        Assert.NotNull(rootPage);
+        TestPage(rootPage);
+        var currentPage = rootPage.CurrentPage;
+        Assert.IsType<MockViewB>(currentPage);
+        TestPage(currentPage);
+        var container = currentPage.GetContainerProvider();
+        var navService = container.Resolve<INavigationService>();
+        Assert.Equal(2, rootPage.Navigation.NavigationStack.Count);
+        await navService.NavigateAsync("../");
+        Assert.IsType<MockViewA>(rootPage.CurrentPage);
+        TestPage(rootPage.CurrentPage);
+        Assert.Single(rootPage.Navigation.NavigationStack);
+    }
+
     [Fact]
     public async Task AbsoluteNavigation_ResetsWindowPage()
     {


### PR DESCRIPTION
﻿## Description of Change

Extracted the navigation of `GoBackAsync `into a new method `GoBackInternalAsync`.
`GoBackAsync` will wait for the semaphore and call `GoBackInternalAsync`.
`RemoveAndGoBack` calls `GoBackInternalAsync` to prevent a deadlock during navigation.

### Bugs Fixed

#3047 

### API Changes

None

### Behavioral Changes

N/a

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard