### PR TITLE
feat: adding Forced option for ViewModelLocationBehavior

### DIFF
--- a/src/Maui/Prism.Maui/Mvvm/ViewModelLocator.cs
+++ b/src/Maui/Prism.Maui/Mvvm/ViewModelLocator.cs
@@ -1,4 +1,4 @@
-﻿namespace Prism.Mvvm;
+namespace Prism.Mvvm;
 
 /// <summary>
 /// This class defines the attached property and related change handler that calls the <see cref="ViewModelLocationProvider"/>.
@@ -9,7 +9,15 @@ public static class ViewModelLocator
     /// Instructs Prism whether or not to automatically create an instance of a ViewModel using a convention, and assign the associated View's <see cref="BindableObject.BindingContext"/> to that instance.
     /// </summary>
     public static readonly BindableProperty AutowireViewModelProperty =
-        BindableProperty.CreateAttached("AutowireViewModel", typeof(ViewModelLocatorBehavior), typeof(ViewModelLocator), ViewModelLocatorBehavior.Automatic);
+        BindableProperty.CreateAttached("AutowireViewModel", typeof(ViewModelLocatorBehavior), typeof(ViewModelLocator), ViewModelLocatorBehavior.Automatic, propertyChanged: OnViewModelLocatorBehaviorChanged);
+
+    private static void OnViewModelLocatorBehaviorChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (newValue is ViewModelLocatorBehavior behavior && behavior == ViewModelLocatorBehavior.Forced)
+        {
+            Autowire(bindable);
+        }
+    }
 
     internal static readonly BindableProperty ViewModelProperty =
         BindableProperty.CreateAttached("ViewModelType",

--- a/src/Maui/Prism.Maui/Mvvm/ViewModelLocatorBehavior.cs
+++ b/src/Maui/Prism.Maui/Mvvm/ViewModelLocatorBehavior.cs
@@ -1,7 +1,33 @@
 ﻿namespace Prism.Mvvm;
 
+/// <summary>
+/// Defines the behavior that the <see cref="ViewModelLocator"/> should use.
+/// </summary>
 public enum ViewModelLocatorBehavior
 {
+    /// <summary>
+    /// The ViewModel will be lazily loaded by the Page/Region Navigation Services
+    /// or the DialogService.
+    /// </summary>
+    /// <remarks>
+    /// This is the default and recommended value for the ViewModelLocator. This will
+    /// allow the View to be fully initialized and ensure that the proper ViewModel is
+    /// resolved based on the route name.
+    /// </remarks>
     Automatic,
-    Disabled
+
+    /// <summary>
+    /// This will disable Prism's automatic ViewModel Location
+    /// </summary>
+    Disabled,
+
+    /// <summary>
+    /// This is not recommended for most situations
+    /// </summary>
+    /// <remarks>
+    /// This is likely to cause breaks in the Container Scoping. It is recommended that
+    /// you allow Prism Page/Region Navigation Services or the Dialog Service properly
+    /// resolve the ViewModel.
+    /// </remarks>
+    Forced
 }

--- a/src/Maui/Prism.Maui/Navigation/Xaml/Navigation.cs
+++ b/src/Maui/Prism.Maui/Navigation/Xaml/Navigation.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Prism.Common;
 using Prism.Navigation.Internals;
 
@@ -154,6 +154,15 @@ public static class Navigation
         {
             if (page.Parent is FlyoutPage flyout && flyout.Flyout == page)
                 return flyout.GetContainerProvider();
+
+            if (Mvvm.ViewModelLocator.GetAutowireViewModel(page) == Mvvm.ViewModelLocatorBehavior.Forced)
+            {
+                container = ContainerLocator.Container.CreateScope();
+                var accessor = container.Resolve<IPageAccessor>();
+                accessor.Page = page;
+                SetContainerProvider(page, container);
+                return container;
+            }
         }
         else if (bindable is Element element && element.Parent is not null)
             return GetContainerProvider(element.Parent);

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -41,6 +41,23 @@ public class NavigationTests : TestBase
     }
 
     [Fact]
+    public async Task ViewModelLocator_Forced_SetsContainer_ResolvedViewModel()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+            .RegisterTypes(c => c.RegisterForNavigation<ForcedView>())
+            .CreateWindow("ForcedView"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        Assert.IsType<ForcedView>(window.Page);
+        Assert.IsType<ForcedViewModel>(window.Page.BindingContext);
+
+        var viewModel = (ForcedViewModel)window.Page.BindingContext;
+        Assert.NotNull(viewModel.Page);
+        Assert.IsType<ForcedView>(viewModel.Page);
+    }
+
+    [Fact]
     public async Task AddsPageFromRelativeURI()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA"))

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/ForcedViewModel.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/ForcedViewModel.cs
@@ -1,0 +1,15 @@
+﻿using Prism.Common;
+
+namespace Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
+
+internal class ForcedViewModel
+{
+    public ForcedViewModel(IPageAccessor accessor)
+    {
+        _accessor = accessor;
+    }
+
+    private readonly IPageAccessor _accessor;
+
+    public Page Page => _accessor.Page;
+}

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/Views/ForcedView.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/Views/ForcedView.cs
@@ -1,0 +1,9 @@
+﻿namespace Prism.DryIoc.Maui.Tests.Mocks.Views;
+
+internal class ForcedView : ContentPage
+{
+    public ForcedView()
+    {
+        ViewModelLocator.SetAutowireViewModel(this, ViewModelLocatorBehavior.Forced);
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

Adds Forced Behavior for ViewModelLocation

### Bugs Fixed

- n/a

### API Changes

Added:

- ViewModelLocationBehavior.Forced

### Behavioral Changes

This restores the expected behavior from Xamarin.Forms where the ViewModel is immediately resolved. This is NOT recommended for most scenarios as you will likely not get the proper Container Scope.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard