### PR TITLE
Fix unhandled dismissal of iOS modals

### DIFF
--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -307,6 +307,22 @@ public static class MvvmHelpers
         }
     }
 
+    public static async Task HandleNavigationPageSwipedAway(NavigationPage navigationPage)
+    {
+        var navigationService = Navigation.Xaml.Navigation.GetNavigationService(navigationPage.CurrentPage);
+        var navParams = new NavigationParameters()
+        {
+            {
+                KnownNavigationParameters.UseModalNavigation, true
+            },
+        };
+        var result = await navigationService.GoBackAsync(navParams);
+        if (result.Exception is NavigationException navEx && navEx.Message == NavigationException.CannotPopApplicationMainPage)
+        {
+            Application.Current.Quit();
+        }
+    }
+
     public static void HandleSystemGoBack(IView previousPage, IView currentPage)
     {
         var parameters = new NavigationParameters();

--- a/src/Maui/Prism.Maui/Controls/PrismNavigationPage.cs
+++ b/src/Maui/Prism.Maui/Controls/PrismNavigationPage.cs
@@ -1,4 +1,6 @@
 ﻿using Prism.Common;
+using Prism.Navigation;
+using UIModalPresentationStyle = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle;
 
 namespace Prism.Controls;
 
@@ -39,4 +41,17 @@ public class PrismNavigationPage : NavigationPage
     {
         await MvvmHelpers.HandleNavigationPageGoBack(this);
     }
+
+    protected override async void OnDisappearing()
+    {
+        var presentationStyle = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetModalPresentationStyle(this);
+
+        if (presentationStyle != UIModalPresentationStyle.FullScreen && PageNavigationService.NavigationSource == PageNavigationSource.Device)
+        {
+            await MvvmHelpers.HandleNavigationPageSwipedAway(this);
+        }
+
+        base.OnDisappearing();
+    }
 }
+

--- a/src/Maui/Prism.Maui/Controls/PrismNavigationPage.cs
+++ b/src/Maui/Prism.Maui/Controls/PrismNavigationPage.cs
@@ -42,6 +42,7 @@ public class PrismNavigationPage : NavigationPage
         await MvvmHelpers.HandleNavigationPageGoBack(this);
     }
 
+#if IOS
     protected override async void OnDisappearing()
     {
         var presentationStyle = Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.GetModalPresentationStyle(this);
@@ -53,5 +54,6 @@ public class PrismNavigationPage : NavigationPage
 
         base.OnDisappearing();
     }
+#endif
 }
 

--- a/src/Maui/Prism.Maui/Prism.Maui.csproj
+++ b/src/Maui/Prism.Maui/Prism.Maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
     <Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured, maintainable, and testable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared library targeting the .NET Framework and .NET. Features that need to be platform specific are implemented in the respective libraries for the target platform (WPF, Uno Platform, .NET MAUI and Xamarin Forms).
 


### PR DESCRIPTION
## Description of Change

Added an additional check when `PrismNavigationPage` is dismissed for the following conditions:

- Is the page using a non default value for `ModalPresentationStyle`?
- Is the navigation source `Device`?

If both are true, the navigation service will call go back (modal) once, to ensure that the prism navigation service stack matches the true page stack of the maui app.

### Bugs Fixed

- #3071 

### API Changes

List all API changes here (or just put None), example:

Added:

None

Changed:

None

### Behavioral Changes

There should be no behavioural changes

### PR Checklist

Currently there are no tests for the change in functionality, I can add them if you think they would be useful

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard