### PR TITLE
Fixes for Android Back

### DIFF
--- a/src/Maui/Prism.Maui/Dialogs/IDialogContainer.cs
+++ b/src/Maui/Prism.Maui/Dialogs/IDialogContainer.cs
@@ -1,11 +1,46 @@
-﻿using System.Windows.Input;
+using System.Windows.Input;
 
+#nullable enable
 namespace Prism.Dialogs;
 
+/// <summary>
+/// Interface representing a container for managing dialogs.
+/// </summary>
 public interface IDialogContainer
 {
+    /// <summary>
+    /// Gets a stack of currently active dialog containers.
+    /// </summary>
+    /// <remarks>
+    /// This property provides access to the list of dialogs currently displayed, typically in the order they were presented.
+    /// </remarks>
+    static IList<IDialogContainer> DialogStack { get; } = [];
+
+    /// <summary>
+    /// Gets the view associated with the currently displayed dialog.
+    /// </summary>
     View DialogView { get; }
+
+    /// <summary>
+    /// Gets a command that can be used to dismiss the currently displayed dialog.
+    /// </summary>
     ICommand Dismiss { get; }
+
+    /// <summary>
+    /// Configures the layout and behavior of the dialog.
+    /// </summary>
+    /// <param name="currentPage">The page on which the dialog is being displayed.</param>
+    /// <param name="dialogView">The view representing the dialog content.</param>
+    /// <param name="hideOnBackgroundTapped">True if the dialog should close when the background is tapped, false otherwise.</param>
+    /// <param name="dismissCommand">The command to execute when the dialog is dismissed.</param>
+    /// <param name="parameters">Optional parameters to pass to the dialog.</param>
+    /// <returns>A task representing the completion of the configuration process.</returns>
     Task ConfigureLayout(Page currentPage, View dialogView, bool hideOnBackgroundTapped, ICommand dismissCommand, IDialogParameters parameters);
+
+    /// <summary>
+    /// Performs the internal logic to display or dismiss the dialog.
+    /// </summary>
+    /// <param name="currentPage">The page on which the dialog is being displayed.</param>
+    /// <returns>A task representing the completion of the pop operation.</returns>
     Task DoPop(Page currentPage);
 }

--- a/src/Maui/Prism.Maui/Dialogs/RelativeContentSizeConverter.cs
+++ b/src/Maui/Prism.Maui/Dialogs/RelativeContentSizeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace Prism.Dialogs;
 
@@ -12,7 +12,7 @@ internal class RelativeContentSizeConverter : IValueConverter
         {
             if (value == 0)
             {
-                relativeSize = 1;
+                relativeSize = -1;
             }
             else if (value > 1)
             {

--- a/src/Maui/Prism.Maui/Navigation/PrismWindow.cs
+++ b/src/Maui/Prism.Maui/Navigation/PrismWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Prism.AppModel;
 using Prism.Common;
 using Prism.Dialogs;
@@ -79,8 +79,17 @@ internal class PrismWindow : Window
         if (PageNavigationService.NavigationSource == PageNavigationSource.Device)
         {
             e.Cancel = true;
-            var navService = Xaml.Navigation.GetNavigationService(e.Modal);
-            await navService.GoBackAsync();
+            var dialogModal = IDialogContainer.DialogStack.LastOrDefault();
+            if (dialogModal is not null)
+            {
+                if (dialogModal.Dismiss.CanExecute(null))
+                    dialogModal.Dismiss.Execute(null);
+            }
+            else
+            {
+                var navService = Xaml.Navigation.GetNavigationService(e.Modal);
+                await navService.GoBackAsync();
+            }
         }
     }
 

--- a/src/Maui/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilder.cs
@@ -46,6 +46,9 @@ public sealed class PrismAppBuilder
             return $"View is not a BindableObject: '{view.GetType().FullName}";
         });
 
+        // Ensure that the DialogStack is cleared when the Application is started.
+        // This is primarily to help with Unit Tests
+        IDialogContainer.DialogStack.Clear();
         MauiBuilder = builder;
         MauiBuilder.ConfigureContainer(new PrismServiceProviderFactory(RegistrationCallback));
         MauiBuilder.ConfigureLifecycleEvents(lifecycle =>
@@ -55,6 +58,15 @@ public sealed class PrismAppBuilder
             {
                 android.OnBackPressed(activity =>
                 {
+                    var dialogModal = IDialogContainer.DialogStack.LastOrDefault();
+                    if (dialogModal is not null)
+                    {
+                        if (dialogModal.Dismiss.CanExecute(null))
+                            dialogModal.Dismiss.Execute(null);
+
+                        return true;
+                    }
+
                     var root = ContainerLocator.Container;
                     if (root is null)
                         return false;

--- a/src/Maui/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilder.cs
@@ -72,14 +72,14 @@ public sealed class PrismAppBuilder
                         return false;
 
                     var app = root.Resolve<IApplication>();
-                    var windows = app.Windows.OfType<PrismWindow>();
-                    if (!windows.Any(x => x.IsActive))
+                    var window = app.Windows.OfType<PrismWindow>()
+                        .FirstOrDefault(x => x.IsActive);
+
+                    if (window is null)
                         return false;
 
-                    var window = windows.First(x => x.IsActive);
-                    if(window.IsRootPage && app is Application application)
+                    if(window.IsRootPage)
                     {
-                        application.Quit();
                         return false;
                     }
 


### PR DESCRIPTION
﻿## Description of Change

Removes Application.Quit() on the Android back from the Root page. Adds logic to handle back request when a Dialog is displayed.

### Bugs Fixed

- fixes #3018
- fixes #2990

### API Changes

Added:

- static IList<IDialogContainer> DialogStack { get; } (IDialogContainer)