### PR TITLE
Code Refactorings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,13 +10,21 @@ root = true
 
 [*]
 indent_style = space
-end_of_line = CRLF
+end_of_line = crlf
 trim_trailing_whitespace = true
 insert_final_newline = true
+charset = utf-8
 
 ##########################################
 # File Extension Settings
 ##########################################
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[.vsconfig]
+indent_size = 2
+end_of_line = lf
 
 [*.sln]
 indent_style = tab
@@ -25,40 +33,135 @@ indent_size = 2
 [*.{csproj,proj,projitems,shproj}]
 indent_size = 2
 
-[*.json]
+[*.{json,slnf}]
 indent_size = 2
+end_of_line = lf
 
 [*.{props,targets}]
 indent_size = 2
 
-[*.targets]
-indent_size = 2
-
 [*.xaml]
 indent_size = 2
+charset = utf-8-bom
+
+[*.xml]
+indent_size = 2
+end_of_line = lf
 
 [*.plist]
 indent_size = 2
 indent_style = tab
+end_of_line = lf
+
+[*.manifest]
+indent_size = 2
+
+[*.appxmanifest]
+indent_size = 2
+
+[*.{json,css,webmanifest}]
+indent_size = 2
+end_of_line = lf
+
+[web.config]
+indent_size = 2
+end_of_line = lf
 
 [*.sh]
 indent_size = 2
 end_of_line = lf
 
 [*.cs]
+# EOL should be normalized by Git. See https://github.com/dotnet/format/issues/1099
+end_of_line = unset
+
+# See https://github.com/dotnet/roslyn/issues/20356#issuecomment-310143926
+trim_trailing_whitespace = false
+
+tab_width = 4
 indent_size = 4
 
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+
 # Avoid "this." and "Me." if not necessary
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
-# Suggest more modern language features when available
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,9 +54,30 @@
     <MSBuildSdkExtrasVersion>3.0.44</MSBuildSdkExtrasVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(IsUnoProject)">
-    <DefineConstants>$(DefineConstants);UNO_WINUI_PROJECT</DefineConstants>
-  </PropertyGroup>
+  <!--
+    -->
+  <Choose>
+    <When Condition="$(IsWpfProject)">
+      <ItemGroup>
+        <Using Include="System.Windows" />
+        <Using Include="System.Windows.Controls" />
+        <Using Include="System.Windows.Controls.Primitives" />
+        <Using Include="System.Windows.Data" />
+      </ItemGroup>
+    </When>
+    <When Condition="$(IsUnoProject)">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);UNO_WINUI_PROJECT</DefineConstants>
+      </PropertyGroup>
+      <ItemGroup>
+        <Using Include="Microsoft.UI.Xaml" />
+        <Using Include="Microsoft.UI.Xaml.Controls" />
+        <Using Include="Microsoft.UI.Xaml.Controls.Primitives" />
+        <Using Include="Microsoft.UI.Xaml.Data" />
+        <Using Include="Microsoft.UI.Xaml.Media" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <!-- Versioning -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,6 +58,9 @@
     -->
   <Choose>
     <When Condition="$(IsWpfProject)">
+      <PropertyGroup>
+        <DefineConstants>$(DefineConstants);WPF</DefineConstants>
+      </PropertyGroup>
       <ItemGroup>
         <Using Include="System.Windows" />
         <Using Include="System.Windows.Controls" />
@@ -67,7 +70,8 @@
     </When>
     <When Condition="$(IsUnoProject)">
       <PropertyGroup>
-        <DefineConstants>$(DefineConstants);UNO_WINUI_PROJECT</DefineConstants>
+        <DefineConstants>$(DefineConstants);UNO_WINUI</DefineConstants>
+        <DefineConstants Condition="!$(TargetFramework.Contains('-')) OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">$(DefineConstants);UNO_WASM</DefineConstants>
       </PropertyGroup>
       <ItemGroup>
         <Using Include="Microsoft.UI.Xaml" />

--- a/src/Forms/Prism.Forms/Modularity/ModuleCatalog.cs
+++ b/src/Forms/Prism.Forms/Modularity/ModuleCatalog.cs
@@ -7,7 +7,7 @@ namespace Prism.Modularity
     /// application. Each module is described in a <see cref="ModuleInfo"/> class, that records the
     /// name and type of the module.
     /// </summary>
-#if HAS_WINUI
+#if UNO_WINUI
     [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Items))]
 #else
     [Xamarin.Forms.ContentProperty(nameof(Items))]

--- a/src/Forms/Prism.Forms/Modularity/ModuleInfo.cs
+++ b/src/Forms/Prism.Forms/Modularity/ModuleInfo.cs
@@ -9,7 +9,7 @@ namespace Prism.Modularity
     /// <summary>
     /// Defines the metadata that describes a module.
     /// </summary>
-#if HAS_WINUI
+#if UNO_WINUI
     [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(DependsOn))]
 #else
     [Xamarin.Forms.ContentProperty(nameof(DependsOn))]

--- a/src/Maui/Prism.Maui/Ioc/MicrosoftDependencyInjectionExtensions.cs
+++ b/src/Maui/Prism.Maui/Ioc/MicrosoftDependencyInjectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Prism.Ioc;
 /// </summary>
 public static class MicrosoftDependencyInjectionExtensions
 {
-#if !UNO_WINUI_PROJECT
+#if !UNO_WINUI
     private static readonly Type PageType = typeof(Page);
 
     public static IServiceCollection RegisterForNavigation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView>(this IServiceCollection services, string name = null)

--- a/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Prism.Common;
+using Prism.Common;
 
 namespace Prism.Navigation;
 
@@ -10,6 +10,7 @@ public static class INavigationServiceExtensions
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
     /// <param name="name">The name of the View to navigate back to</param>
     /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
     public static Task<INavigationResult> GoBackToAsync(this INavigationService navigationService, string name) =>
@@ -52,6 +53,7 @@ public static class INavigationServiceExtensions
     /// <summary>
     /// Initiates navigation to the target specified by the <paramref name="uri"/>.
     /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
     /// <param name="uri">The Uri to navigate to</param>
     /// <example>
     /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource));
@@ -78,6 +80,7 @@ public static class INavigationServiceExtensions
     /// <summary>
     /// Initiates navigation to the target specified by the <paramref name="name"/>.
     /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
     /// <param name="name">The name of the target to navigate to.</param>
     public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name) =>
         navigationService.NavigateAsync(name, default(INavigationParameters));
@@ -85,6 +88,7 @@ public static class INavigationServiceExtensions
     /// <summary>
     /// Initiates navigation to the target specified by the <paramref name="name"/>.
     /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
     /// <param name="name">The name of the target to navigate to.</param>
     /// <param name="parameters">The navigation parameters</param>
     public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, INavigationParameters parameters)

--- a/src/Maui/Prism.Maui/Navigation/Regions/Behaviors/RegionActiveAwareBehavior.cs
+++ b/src/Maui/Prism.Maui/Navigation/Regions/Behaviors/RegionActiveAwareBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Specialized;
+using System.Collections.Specialized;
 using Prism.Common;
 
 namespace Prism.Navigation.Regions.Behaviors;
@@ -11,7 +11,7 @@ namespace Prism.Navigation.Regions.Behaviors;
 /// </summary>
 /// <remarks>
 /// This class can also sync the active state for any scoped regions directly on the view based on the <see cref="SyncActiveStateAttribute"/>.
-/// If you use the <see cref="Regions.Region.Add(VisualElement,string,bool)" /> method with the createRegionManagerScope option, the scoped manager will be attached to the view.
+/// If you use the <see cref="Regions.Region.Add(object,string,bool)" /> method with the createRegionManagerScope option, the scoped manager will be attached to the view.
 /// </remarks>
 public class RegionActiveAwareBehavior : IRegionBehavior
 {

--- a/src/Maui/Prism.Maui/Navigation/Regions/Behaviors/RegionCreationException.cs
+++ b/src/Maui/Prism.Maui/Navigation/Regions/Behaviors/RegionCreationException.cs
@@ -1,11 +1,10 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace Prism.Navigation.Regions.Behaviors;
 
 /// <summary>
 /// Represents errors that occurred during region creation.
 /// </summary>
-[Serializable]
 public partial class RegionCreationException : Exception
 {
     /// <summary>
@@ -33,16 +32,6 @@ public partial class RegionCreationException : Exception
     /// (Nothing in Visual Basic) if no inner exception is specified.</param>
     public RegionCreationException(string message, Exception inner)
         : base(message, inner)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RegionCreationException"/> class with serialized data.
-    /// </summary>
-    /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-    protected RegionCreationException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 }

--- a/src/Maui/Prism.Maui/Navigation/Regions/Navigation/RegionNavigationContentLoader.cs
+++ b/src/Maui/Prism.Maui/Navigation/Regions/Navigation/RegionNavigationContentLoader.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
@@ -27,11 +27,8 @@ public class RegionNavigationContentLoader : IRegionNavigationContentLoader
     /// <exception cref="ArgumentException">when a new view cannot be created for the navigation request.</exception>
     public object LoadContent(IRegion region, NavigationContext navigationContext)
     {
-        if (region == null)
-            throw new ArgumentNullException(nameof(region));
-
-        if (navigationContext == null)
-            throw new ArgumentNullException(nameof(navigationContext));
+        ArgumentNullException.ThrowIfNull(region);
+        ArgumentNullException.ThrowIfNull(navigationContext);
 
         string candidateTargetContract = GetContractFromNavigationContext(navigationContext);
 
@@ -58,6 +55,7 @@ public class RegionNavigationContentLoader : IRegionNavigationContentLoader
     /// Provides a new item for the region based on the supplied candidate target contract name.
     /// </summary>
     /// <param name="candidateTargetContract">The target contract to build.</param>
+    /// <param name="region">The <see cref="IRegion"/> to create the new Region Item in.</param>
     /// <returns>An instance of an item to put into the <see cref="IRegion"/>.</returns>
     protected virtual object CreateNewRegionItem(string candidateTargetContract, IRegion region)
     {
@@ -89,7 +87,7 @@ public class RegionNavigationContentLoader : IRegionNavigationContentLoader
     /// <returns>The candidate contract to seek within the <see cref="IRegion"/> and to use, if not found, when resolving from the container.</returns>
     protected virtual string GetContractFromNavigationContext(NavigationContext navigationContext)
     {
-        if (navigationContext == null) throw new ArgumentNullException(nameof(navigationContext));
+        ArgumentNullException.ThrowIfNull(navigationContext);
 
         var candidateTargetContract = UriParsingHelper.EnsureAbsolute(navigationContext.Uri).AbsolutePath;
         candidateTargetContract = candidateTargetContract.TrimStart('/');
@@ -104,17 +102,14 @@ public class RegionNavigationContentLoader : IRegionNavigationContentLoader
     /// <returns>An enumerable of candidate objects from the <see cref="IRegion"/></returns>
     protected virtual IEnumerable<VisualElement> GetCandidatesFromRegion(IRegion region, string candidateNavigationContract)
     {
-        if (region is null)
-        {
-            throw new ArgumentNullException(nameof(region));
-        }
+        ArgumentNullException.ThrowIfNull(region);
 
         if (string.IsNullOrEmpty(candidateNavigationContract))
         {
             throw new ArgumentNullException(nameof(candidateNavigationContract));
         }
 
-        var contractCandidates = GetCandidatesFromRegionViews(region, candidateNavigationContract);
+        var contractCandidates = RegionNavigationContentLoader.GetCandidatesFromRegionViews(region, candidateNavigationContract);
 
         if (!contractCandidates.Any())
         {
@@ -122,16 +117,16 @@ public class RegionNavigationContentLoader : IRegionNavigationContentLoader
             var registration = registry.Registrations.FirstOrDefault(x => x.Type == ViewType.Region && (x.Name == candidateNavigationContract || x.View.Name == candidateNavigationContract || x.View.FullName == candidateNavigationContract));
             if (registration is null)
             {
-                GetCandidatesFromRegionViews(region, registration.View.FullName);
+                RegionNavigationContentLoader.GetCandidatesFromRegionViews(region, registration.View.FullName);
             }
 
-            return Array.Empty<VisualElement>();
+            return [];
         }
 
         return contractCandidates;
     }
 
-    private IEnumerable<VisualElement> GetCandidatesFromRegionViews(IRegion region, string candidateNavigationContract)
+    private static IEnumerable<VisualElement> GetCandidatesFromRegionViews(IRegion region, string candidateNavigationContract)
     {
         return region.Views.OfType<VisualElement>().Where(v => ViewIsMatch(v.GetType(), candidateNavigationContract));
     }

--- a/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
+++ b/src/Uno/Prism.DryIoc.Uno/Prism.DryIoc.Uno.WinUI.csproj
@@ -5,7 +5,6 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Prism.DryIoc.Uno</AssemblyName>
     <PackageId>Prism.DryIoc.Uno.WinUI</PackageId>
-    <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <!--

--- a/src/Uno/Prism.Uno/Common/BindingOperations.cs
+++ b/src/Uno/Prism.Uno/Common/BindingOperations.cs
@@ -1,0 +1,7 @@
+﻿namespace Prism;
+
+internal static class BindingOperations
+{
+    public static BindingExpression GetBinding(FrameworkElement instance, DependencyProperty property) =>
+        instance.GetBindingExpression(property);
+}

--- a/src/Uno/Prism.Uno/Common/DesignerProperties.cs
+++ b/src/Uno/Prism.Uno/Common/DesignerProperties.cs
@@ -1,0 +1,7 @@
+namespace Prism;
+
+internal static class DesignerProperties
+{
+    public static bool GetIsInDesignMode(DependencyObject _) =>
+        Windows.ApplicationModel.DesignMode.DesignModeEnabled;
+}

--- a/src/Uno/Prism.Uno/Extensions/DependencyObjectExtensions.Uno.cs
+++ b/src/Uno/Prism.Uno/Extensions/DependencyObjectExtensions.Uno.cs
@@ -1,44 +1,35 @@
-﻿using System.Runtime.InteropServices;
-using Microsoft.UI.Xaml;
+using System.Runtime.InteropServices;
 
-namespace Prism
+namespace Prism;
+
+internal static partial class DependencyObjectExtensions
 {
-    internal static partial class DependencyObjectExtensions
+#if UNO_WASM
+    // Related to :
+    // https://github.com/dotnet/runtime/issues/76959
+    // https://github.com/unoplatform/uno/blob/56d3f6ece16b2dba51776e95a3c847c9c4b68e8b/src/Uno.UI.Dispatching/Core/CoreDispatcher.wasm.cs#L17
+    private static bool IsWebAssemblyThreadingSupported { get; }
+        = Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_MONO_RUNTIME_FEATURES")
+            ?.Split(',').Any(v => v.Equals("threads", StringComparison.OrdinalIgnoreCase)) ?? false;
+
+    private static bool IsWebAssembly { get; }
+        = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+#endif
+
+    /// <summary>
+    /// Compatibility method to determine if the current thread can access a <see cref="DependencyObject"/>
+    /// </summary>
+    /// <param name="instance">The instance to check</param>
+    /// <returns><c>true</c> if the current thread has access to the instance, otherwise <c>false</c></returns>
+    public static bool CheckAccess(this DependencyObject instance)
     {
-#if HAS_UNO_WINUI
-        // Related to :
-        // https://github.com/dotnet/runtime/issues/76959
-        // https://github.com/unoplatform/uno/blob/56d3f6ece16b2dba51776e95a3c847c9c4b68e8b/src/Uno.UI.Dispatching/Core/CoreDispatcher.wasm.cs#L17
-        private static bool IsWebAssemblyThreadingSupported { get; }
-            = Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_MONO_RUNTIME_FEATURES")
-                ?.Split(',').Any(v => v.Equals("threads", StringComparison.OrdinalIgnoreCase)) ?? false;
-
-        private static bool IsWebAssembly { get; }
-            = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
-#endif
-
-        /// <summary>
-        /// Compatibility method to determine if the current thread can access a <see cref="DependencyObject"/>
-        /// </summary>
-        /// <param name="instance">The instance to check</param>
-        /// <returns><c>true</c> if the current thread has access to the instance, otherwise <c>false</c></returns>
-        public static bool CheckAccess(this DependencyObject instance)
-#if HAS_WINUI
-#if HAS_UNO_WINUI
+#if UNO_WASM
+        if (IsWebAssembly && !IsWebAssemblyThreadingSupported)
         {
-            if (IsWebAssembly && !IsWebAssemblyThreadingSupported)
-            {
-                // When threading is disabled, we need to return true 
-                return true;
-            }
-
-            return instance.DispatcherQueue.HasThreadAccess;
+            // When threading is disabled, we need to return true 
+            return true;
         }
-#else
-        => instance.DispatcherQueue.HasThreadAccess;
 #endif
-#else
-        => instance.Dispatcher.HasThreadAccess;
-#endif
+        return instance.DispatcherQueue.HasThreadAccess;
     }
 }

--- a/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
+++ b/src/Uno/Prism.Uno/Prism.Uno.WinUI.csproj
@@ -5,7 +5,6 @@
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <AssemblyName>Prism.Uno</AssemblyName>
     <RootNamespace>Prism</RootNamespace>
-    <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageId>Prism.Uno.WinUI</PackageId>
     <ImplicitUsings>true</ImplicitUsings>

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -11,7 +11,7 @@ namespace Prism.Common
     /// </summary>
     public static class MvvmHelpers
     {
-#if HAS_WINUI
+#if UNO_WINUI
         /// <summary>
         /// Sets the AutowireViewModel property to true for the <paramref name="viewOrViewModel"/>.
         /// </summary>

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -13,7 +13,7 @@ namespace Prism.Common
     {
 #if HAS_WINUI
         /// <summary>
-        /// Sets the AutoWireViewModel property to true for the <paramref name="viewOrViewModel"/>.
+        /// Sets the AutowireViewModel property to true for the <paramref name="viewOrViewModel"/>.
         /// </summary>
         /// <remarks>
         /// The AutoWireViewModel property will only be set to true if the view

--- a/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
+++ b/src/Wpf/Prism.Wpf/Common/MvvmHelpers.cs
@@ -3,11 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Prism.Mvvm;
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
 
 namespace Prism.Common
 {

--- a/src/Wpf/Prism.Wpf/Common/ObservableObject.cs
+++ b/src/Wpf/Prism.Wpf/Common/ObservableObject.cs
@@ -30,18 +30,14 @@ namespace Prism.Common
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
         public T Value
         {
-            get { return (T)this.GetValue(ValueProperty); }
-            set { this.SetValue(ValueProperty, value); }
+            get => (T)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
         }
 
         private static void ValueChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             ObservableObject<T> thisInstance = ((ObservableObject<T>)d);
-            PropertyChangedEventHandler eventHandler = thisInstance.PropertyChanged;
-            if (eventHandler != null)
-            {
-                eventHandler(thisInstance, new PropertyChangedEventArgs("Value"));
-            }
+            thisInstance.PropertyChanged?.Invoke(thisInstance, new PropertyChangedEventArgs(nameof(Value)));
         }
     }
 }

--- a/src/Wpf/Prism.Wpf/Common/ObservableObject.cs
+++ b/src/Wpf/Prism.Wpf/Common/ObservableObject.cs
@@ -17,7 +17,7 @@ namespace Prism.Common
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1000:DoNotDeclareStaticMembersOnGenericTypes", Justification = "This is the pattern for WPF dependency properties")]
         public static readonly DependencyProperty ValueProperty =
-                DependencyProperty.Register("Value", typeof(T), typeof(ObservableObject<T>), new PropertyMetadata(null, ValueChangedCallback));
+                DependencyProperty.Register(nameof(Value), typeof(T), typeof(ObservableObject<T>), new PropertyMetadata(null, ValueChangedCallback));
 
         /// <summary>
         /// Event that gets invoked when the Value property changes.

--- a/src/Wpf/Prism.Wpf/Common/ObservableObject.cs
+++ b/src/Wpf/Prism.Wpf/Common/ObservableObject.cs
@@ -1,12 +1,4 @@
-
-
 using System.ComponentModel;
-
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
 
 namespace Prism.Common
 {

--- a/src/Wpf/Prism.Wpf/Dialogs/Dialog.cs
+++ b/src/Wpf/Prism.Wpf/Dialogs/Dialog.cs
@@ -1,9 +1,3 @@
-﻿#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Dialogs
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Dialogs/Dialog.cs
+++ b/src/Wpf/Prism.Wpf/Dialogs/Dialog.cs
@@ -34,7 +34,7 @@ namespace Prism.Dialogs
             obj.SetValue(WindowStyleProperty, value);
         }
 
-#if !HAS_WINUI
+#if !UNO_WINUI
         /// <summary>
         /// Identifies the WindowStartupLocation attached property.
         /// </summary>

--- a/src/Wpf/Prism.Wpf/Dialogs/IDialogServiceCompatExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Dialogs/IDialogServiceCompatExtensions.cs
@@ -7,7 +7,7 @@ namespace Prism.Dialogs
     /// </summary>
     public static class IDialogServiceCompatExtensions
     {
-#if !HAS_WINUI
+#if !UNO_WINUI
         /// <summary>
         /// Shows a non-modal dialog.
         /// </summary>

--- a/src/Wpf/Prism.Wpf/Dialogs/KnownDialogParameters.cs
+++ b/src/Wpf/Prism.Wpf/Dialogs/KnownDialogParameters.cs
@@ -10,7 +10,7 @@ public static class KnownDialogParameters
     /// </summary>
     public const string WindowName = "windowName";
 
-#if HAS_WINUI
+#if UNO_WINUI
     /// <summary>
     /// The <see cref="Microsoft.UI.Xaml.Controls.ContentDialogPlacement"/> to use when showing the dialog
     /// </summary>

--- a/src/Wpf/Prism.Wpf/Extensions/DependencyObjectExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Extensions/DependencyObjectExtensions.cs
@@ -2,14 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Data;
-#else
-using System.Windows;
-using System.Windows.Data;
-#endif
-
 namespace Prism
 {
     internal static partial class DependencyObjectExtensions

--- a/src/Wpf/Prism.Wpf/Extensions/DependencyObjectExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Extensions/DependencyObjectExtensions.cs
@@ -12,11 +12,7 @@ namespace Prism
         /// <param name="instance">The to use to search for the property</param>
         /// <param name="property">The property to search</param>
         /// <returns><c>true</c> if there is an active binding, otherwise <c>false</c></returns>
-        public static bool HasBinding(this FrameworkElement instance, DependencyProperty property)
-#if HAS_WINUI
-            => instance.GetBindingExpression(property) != null;
-#else
-            => BindingOperations.GetBinding(instance, property) != null;
-#endif
+        public static bool HasBinding(this FrameworkElement instance, DependencyProperty property) =>
+            BindingOperations.GetBinding(instance, property) is not null;
     }
 }

--- a/src/Wpf/Prism.Wpf/Interactivity/CommandBehaviorBase.cs
+++ b/src/Wpf/Prism.Wpf/Interactivity/CommandBehaviorBase.cs
@@ -1,14 +1,6 @@
 using System;
 using System.Windows.Input;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-#else
-using System.Windows;
-using System.Windows.Controls;
-#endif
-
 namespace Prism.Interactivity
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Interactivity/CommandBehaviorBase.cs
+++ b/src/Wpf/Prism.Wpf/Interactivity/CommandBehaviorBase.cs
@@ -105,7 +105,7 @@ namespace Prism.Interactivity
             }
             else if (Command != null)
             {
-#if HAS_WINUI
+#if UNO_WINUI
                 if (AutoEnable && TargetObject is Control control)
                     control.IsEnabled = Command.CanExecute(CommandParameter);
 #else

--- a/src/Wpf/Prism.Wpf/Interactivity/InvokeCommandAction.cs
+++ b/src/Wpf/Prism.Wpf/Interactivity/InvokeCommandAction.cs
@@ -17,7 +17,7 @@ namespace Prism.Interactivity
         /// Dependency property identifying if the associated element should automatically be enabled or disabled based on the result of the Command's CanExecute
         /// </summary>
         public static readonly DependencyProperty AutoEnableProperty =
-            DependencyProperty.Register("AutoEnable", typeof(bool), typeof(InvokeCommandAction),
+            DependencyProperty.Register(nameof(AutoEnable), typeof(bool), typeof(InvokeCommandAction),
                 new PropertyMetadata(true, (d, e) => ((InvokeCommandAction)d).OnAllowDisableChanged((bool)e.NewValue)));
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Prism.Interactivity
         /// Dependency property identifying the command to execute when invoked.
         /// </summary>
         public static readonly DependencyProperty CommandProperty =
-            DependencyProperty.Register("Command", typeof(ICommand), typeof(InvokeCommandAction),
+            DependencyProperty.Register(nameof(Command), typeof(ICommand), typeof(InvokeCommandAction),
                 new PropertyMetadata(null, (d, e) => ((InvokeCommandAction)d).OnCommandChanged((ICommand)e.NewValue)));
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Prism.Interactivity
         /// Dependency property identifying the command parameter to supply on command execution.
         /// </summary>
         public static readonly DependencyProperty CommandParameterProperty =
-            DependencyProperty.Register("CommandParameter", typeof(object), typeof(InvokeCommandAction),
+            DependencyProperty.Register(nameof(CommandParameter), typeof(object), typeof(InvokeCommandAction),
                 new PropertyMetadata(null, (d, e) => ((InvokeCommandAction)d).OnCommandParameterChanged(e.NewValue)));
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Prism.Interactivity
         /// Dependency property identifying the TriggerParameterPath to be parsed to identify the child property of the trigger parameter to be used as the command parameter.
         /// </summary>
         public static readonly DependencyProperty TriggerParameterPathProperty =
-            DependencyProperty.Register("TriggerParameterPath", typeof(string), typeof(InvokeCommandAction),
+            DependencyProperty.Register(nameof(TriggerParameterPath), typeof(string), typeof(InvokeCommandAction),
                 new PropertyMetadata(null, (d, e) => { }));
 
         /// <summary>

--- a/src/Wpf/Prism.Wpf/Mvvm/ViewModelLocator.cs
+++ b/src/Wpf/Prism.Wpf/Mvvm/ViewModelLocator.cs
@@ -40,9 +40,7 @@ namespace Prism.Mvvm
 
         private static void AutoWireViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-#if !HAS_WINUI
             if (!DesignerProperties.GetIsInDesignMode(d))
-#endif
             {
                 var value = (bool?)e.NewValue;
                 if (value.HasValue && value.Value)

--- a/src/Wpf/Prism.Wpf/Mvvm/ViewModelLocator.cs
+++ b/src/Wpf/Prism.Wpf/Mvvm/ViewModelLocator.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-#if HAS_WINUI
+#if UNO_WINUI
 using Windows.UI.Xaml;
 #else
 using System.Windows;

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/BindRegionContextToDependencyObjectBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/BindRegionContextToDependencyObjectBehavior.cs
@@ -3,12 +3,6 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/ClearChildViewsRegionBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/ClearChildViewsRegionBehavior.cs
@@ -1,11 +1,5 @@
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/DelayedRegionCreationBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/DelayedRegionCreationBehavior.cs
@@ -4,12 +4,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/DelayedRegionCreationBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/DelayedRegionCreationBehavior.cs
@@ -149,7 +149,7 @@ namespace Prism.Navigation.Regions.Behaviors
                 return;
             }
 
-#if !HAS_WINUI
+#if !UNO_WINUI
             FrameworkContentElement fcElement = this.TargetElement as FrameworkContentElement;
             if (fcElement != null)
             {
@@ -178,7 +178,7 @@ namespace Prism.Navigation.Regions.Behaviors
                 return;
             }
 
-#if !HAS_WINUI
+#if !UNO_WINUI
             FrameworkContentElement fcElement = this.TargetElement as FrameworkContentElement;
             if (fcElement != null)
             {

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/IHostAwareRegionBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/IHostAwareRegionBehavior.cs
@@ -1,8 +1,4 @@
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
+
 
 namespace Prism.Navigation.Regions.Behaviors
 {

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionActiveAwareBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionActiveAwareBehavior.cs
@@ -3,12 +3,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using Prism.Common;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionManagerRegistrationBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionManagerRegistrationBehavior.cs
@@ -132,7 +132,7 @@ namespace Prism.Navigation.Regions.Behaviors
             }
 
             DependencyObject parent = null;
-#if HAS_WINUI
+#if UNO_WINUI
             parent = VisualTreeHelper.GetParent(dependencyObject);
 #else
             parent = LogicalTreeHelper.GetParent(dependencyObject);

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionManagerRegistrationBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionManagerRegistrationBehavior.cs
@@ -2,13 +2,6 @@ using System;
 using System.ComponentModel;
 using Prism.Properties;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/RegionMemberLifetimeBehavior.cs
@@ -4,12 +4,6 @@ using System.Linq;
 using System.Collections.Specialized;
 using Prism.Common;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/SelectorItemsSourceSyncBehavior.cs
@@ -3,18 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using Prism.Properties;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-#else
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/SyncRegionContextWithHostBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/SyncRegionContextWithHostBehavior.cs
@@ -2,12 +2,6 @@ using System;
 using Prism.Properties;
 using Prism.Common;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions.Behaviors
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/ContentControlRegionAdapter.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/ContentControlRegionAdapter.cs
@@ -3,15 +3,6 @@ using System;
 using System.Collections.Specialized;
 using System.Linq;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Data;
-#else
-using System.Windows.Controls;
-using System.Windows.Data;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/DefaultRegionManagerAccessor.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/DefaultRegionManagerAccessor.cs
@@ -1,11 +1,5 @@
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     internal class DefaultRegionManagerAccessor : IRegionManagerAccessor

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/INavigationAware.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/INavigationAware.cs
@@ -1,5 +1,6 @@
-﻿#if !HAS_UNO_WINUI && !HAS_WINUI
+﻿#if WPF
 
+// NOTE: This is for Legacy support for WPF apps only
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/IRegionManagerAccessor.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/IRegionManagerAccessor.cs
@@ -1,11 +1,5 @@
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/ItemMetadata.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/ItemMetadata.cs
@@ -1,11 +1,5 @@
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/ItemsControlRegionAdapter.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/ItemsControlRegionAdapter.cs
@@ -1,16 +1,6 @@
 using Prism.Properties;
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Data;
-#else
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Region.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Region.cs
@@ -6,16 +6,6 @@ using System.Linq;
 using Prism.Properties;
 using Prism.Ioc;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Data;
-#else
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionAdapterBase.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionAdapterBase.cs
@@ -3,13 +3,6 @@ using Prism.Navigation.Regions.Behaviors;
 using System;
 using System.Globalization;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Data;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionContext.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionContext.cs
@@ -1,12 +1,6 @@
 using Prism.Common;
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionManager.cs
@@ -232,11 +232,7 @@ namespace Prism.Navigation.Regions
 
         private static bool IsInDesignMode(DependencyObject element)
         {
-#if HAS_WINUI
-            return Windows.ApplicationModel.DesignMode.DesignModeEnabled;
-#else
             return DesignerProperties.GetIsInDesignMode(element);
-#endif
         }
 
         #endregion

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionManager.cs
@@ -14,13 +14,6 @@ using Prism.Properties;
 using Prism.Navigation.Regions.Behaviors;
 using Prism.Ioc.Internals;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionNavigationContentLoader.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionNavigationContentLoader.cs
@@ -7,13 +7,6 @@ using Prism.Ioc;
 using Prism.Ioc.Internals;
 using Prism.Properties;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionNavigationService.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionNavigationService.cs
@@ -6,12 +6,6 @@ using Prism.Common;
 using Prism.Properties;
 using Prism.Ioc;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml;
-#else
-using System.Windows;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/SelectorRegionAdapter.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/SelectorRegionAdapter.cs
@@ -1,12 +1,6 @@
 using Prism.Navigation.Regions.Behaviors;
 using System;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml.Controls.Primitives;
-#else
-using System.Windows.Controls.Primitives;
-#endif
-
 namespace Prism.Navigation.Regions
 {
     /// <summary>

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -18,7 +18,7 @@ namespace Prism
             });
         }
 
-#if HAS_WINUI
+#if UNO_WINUI
         internal static void RegisterRequiredTypes(this IContainerRegistry containerRegistry)
         {
             containerRegistry.TryRegisterSingleton<IModuleCatalog, ModuleCatalog>();
@@ -59,7 +59,7 @@ namespace Prism
             regionAdapterMappings.RegisterMapping<Selector, SelectorRegionAdapter>();
             regionAdapterMappings.RegisterMapping<ItemsControl, ItemsControlRegionAdapter>();
             regionAdapterMappings.RegisterMapping<ContentControl, ContentControlRegionAdapter>();
-#if HAS_WINUI
+#if UNO_WINUI
             regionAdapterMappings.RegisterMapping<NavigationView, NavigationViewRegionAdapter>();
 #endif
         }

--- a/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
+++ b/src/Wpf/Prism.Wpf/PrismInitializationExtensions.cs
@@ -6,14 +6,6 @@ using Prism.Navigation.Regions;
 using Prism.Navigation.Regions.Behaviors;
 using Prism.Dialogs;
 
-#if HAS_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-#else
-using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
-#endif
-
 namespace Prism
 {
     internal static class PrismInitializationExtensions

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewModelBase.cs
@@ -1,7 +1,8 @@
-﻿using Prism.Common;
+using Prism.Common;
 
 namespace Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
 
+#pragma warning disable CS0067 // The event is never used because this is a Mock
 public abstract class MockViewModelBase : IActiveAware, INavigationAware, IConfirmNavigation
 {
     private readonly IPageAccessor _pageAccessor;
@@ -49,3 +50,4 @@ public abstract class MockViewModelBase : IActiveAware, INavigationAware, IConfi
             Message = message;
     }
 }
+#pragma warning restore CS0067 // The event is never used because this is a Mock

--- a/tests/Prism.Core.Tests/Common/ListDictionaryFixture.cs
+++ b/tests/Prism.Core.Tests/Common/ListDictionaryFixture.cs
@@ -1,5 +1,3 @@
-
-
 using System;
 using System.Collections.Generic;
 using Prism.Common;
@@ -78,7 +76,7 @@ namespace Prism.Wpf.Tests
             list.Add("foo", value);
             list.RemoveValue("foo", value);
 
-            Assert.Equal(0, list["foo"].Count);
+            Assert.Empty(list["foo"]);
         }
 
         [Fact]
@@ -90,7 +88,7 @@ namespace Prism.Wpf.Tests
 
             list.RemoveValue(value);
 
-            Assert.Equal(0, list.Values.Count);
+            Assert.Empty(list.Values);
         }
 
         [Fact]
@@ -125,20 +123,19 @@ namespace Prism.Wpf.Tests
             bool removed = list.Remove("foo");
 
             Assert.True(removed);
-            Assert.Equal(0, list.Keys.Count);
+            Assert.Empty(list.Keys);
         }
 
         [Fact]
         public void CanSetList()
         {
-            List<object> values = new List<object>();
-            values.Add(new object());
+            List<object> values = [new object()];
             list.Add("foo", new object());
             list.Add("foo", new object());
 
             list["foo"] = values;
 
-            Assert.Equal(1, list["foo"].Count);
+            Assert.Single(list["foo"]);
         }
 
         [Fact]

--- a/tests/Prism.Core.Tests/Events/PubSubEventFixture.cs
+++ b/tests/Prism.Core.Tests/Events/PubSubEventFixture.cs
@@ -575,7 +575,7 @@ namespace Prism.Tests.Events
             Action<string> action = delegate { };
             var token = PubSubEvent.Subscribe(action, true);
 
-            Assert.Equal(1, PubSubEvent.BaseSubscriptions.Count);
+            Assert.Single(PubSubEvent.BaseSubscriptions);
             Assert.Equal(typeof(EventSubscription<string>), PubSubEvent.BaseSubscriptions.ElementAt(0).GetType());
         }
 
@@ -586,7 +586,7 @@ namespace Prism.Tests.Events
             Action action = delegate { };
             var token = pubSubEvent.Subscribe(action, true);
 
-            Assert.Equal(1, pubSubEvent.BaseSubscriptions.Count);
+            Assert.Single(pubSubEvent.BaseSubscriptions);
             Assert.Equal(typeof(EventSubscription), pubSubEvent.BaseSubscriptions.ElementAt(0).GetType());
         }
 

--- a/tests/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantA.cs
+++ b/tests/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantA.cs
@@ -1,6 +1,3 @@
-
-
-
 namespace Prism.IocContainer.Wpf.Tests.Support.Mocks
 {
     public class DependantA : IDependantA

--- a/tests/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantB.cs
+++ b/tests/Wpf/Prism.IocContainer.Wpf.Tests.Support/Mocks/DependantB.cs
@@ -1,6 +1,3 @@
-
-
-
 namespace Prism.IocContainer.Wpf.Tests.Support.Mocks
 {
     public class DependantB : IDependantB


### PR DESCRIPTION
﻿## Description of Change

Cleanup WPF/Uno code. 

- Removes compiler directives for namespaces
- Adds global namespaces via MSBuild Using items
- Refactors code for defined Constants
- Eliminates a number of Build warnings across Core, Uno, Wpf, and MAUI