### PR TITLE
Add generic GoBack and remove legacy GoBackTo

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Prism.Navigation.Builder;
+namespace Prism.Navigation.Builder;
 
 public interface INavigationBuilder
 {
@@ -12,7 +12,9 @@ public interface INavigationBuilder
     INavigationBuilder UseAbsoluteNavigation(bool absolute);
     INavigationBuilder UseRelativeNavigation();
 
+    [Obsolete($"Use {nameof(GoBackAsync)} instead.")]
     Task<INavigationResult> GoBackTo<TViewModel>(INavigationParameters parameters);
+    Task<INavigationResult> GoBackAsync<TViewModel>();
     Task<INavigationResult> NavigateAsync();
     Task NavigateAsync(Action<Exception> onError);
     Task NavigateAsync(Action onSuccess, Action<Exception> onError);

--- a/src/Maui/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
@@ -12,8 +12,6 @@ public interface INavigationBuilder
     INavigationBuilder UseAbsoluteNavigation(bool absolute);
     INavigationBuilder UseRelativeNavigation();
 
-    [Obsolete($"Use {nameof(GoBackAsync)} instead.")]
-    Task<INavigationResult> GoBackTo<TViewModel>(INavigationParameters parameters);
     Task<INavigationResult> GoBackAsync<TViewModel>();
     Task<INavigationResult> NavigateAsync();
     Task NavigateAsync(Action<Exception> onError);

--- a/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Prism.Common;
+using Prism.Common;
 using Prism.Mvvm;
 
 namespace Prism.Navigation.Builder;
@@ -53,10 +53,17 @@ internal class NavigationBuilder : INavigationBuilder, IRegistryAware
         return this;
     }
 
+    [Obsolete($"Use {nameof(GoBackAsync)} instead.")]
     public async Task<INavigationResult> GoBackTo<TViewModel>(INavigationParameters parameters)
     {
         var name = NavigationBuilderExtensions.GetNavigationKey<TViewModel>(this);
-        return await _navigationService.GoBackToAsync(name, parameters);
+        return await _navigationService.GoBackAsync(name, parameters);
+    }
+
+    public async Task<INavigationResult> GoBackAsync<TViewModel>()
+    {
+        var name = NavigationBuilderExtensions.GetNavigationKey<TViewModel>(this);
+        return await _navigationService.GoBackAsync(name, _navigationParameters);
     }
 
     public Task<INavigationResult> NavigateAsync()

--- a/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
@@ -53,13 +53,6 @@ internal class NavigationBuilder : INavigationBuilder, IRegistryAware
         return this;
     }
 
-    [Obsolete($"Use {nameof(GoBackAsync)} instead.")]
-    public async Task<INavigationResult> GoBackTo<TViewModel>(INavigationParameters parameters)
-    {
-        var name = NavigationBuilderExtensions.GetNavigationKey<TViewModel>(this);
-        return await _navigationService.GoBackAsync(name, parameters);
-    }
-
     public async Task<INavigationResult> GoBackAsync<TViewModel>()
     {
         var name = NavigationBuilderExtensions.GetNavigationKey<TViewModel>(this);

--- a/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
@@ -13,10 +13,6 @@ public static class NavigationBuilderExtensions
     public static INavigationBuilder CreateBuilder(this INavigationService navigationService) =>
            new NavigationBuilder(navigationService);
 
-    [Obsolete($"Use {nameof(INavigationBuilder.GoBackAsync)} instead.")]
-    public static Task<INavigationResult> GoBackTo<TViewModel>(this INavigationBuilder builder) =>
-        builder.GoBackAsync<TViewModel>();
-
     internal static string GetNavigationKey<TViewModel>(object builder)
     {
         var vmType = typeof(TViewModel);

--- a/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Prism.Common;
+using Prism.Common;
 using Prism.Navigation.Builder;
 
 namespace Prism.Navigation;
@@ -13,8 +13,9 @@ public static class NavigationBuilderExtensions
     public static INavigationBuilder CreateBuilder(this INavigationService navigationService) =>
            new NavigationBuilder(navigationService);
 
+    [Obsolete($"Use {nameof(INavigationBuilder.GoBackAsync)} instead.")]
     public static Task<INavigationResult> GoBackTo<TViewModel>(this INavigationBuilder builder) =>
-        builder.GoBackTo<TViewModel>(null);
+        builder.GoBackAsync<TViewModel>();
 
     internal static string GetNavigationKey<TViewModel>(object builder)
     {

--- a/src/Maui/Prism.Maui/Navigation/INavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationService.cs
@@ -1,18 +1,10 @@
-﻿namespace Prism.Navigation;
+namespace Prism.Navigation;
 
 /// <summary>
 /// Provides page based navigation for ViewModels.
 /// </summary>
 public interface INavigationService
 {
-    /// <summary>
-    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-    /// </summary>
-    /// <param name="name">The name of the View to navigate back to</param>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-    Task<INavigationResult> GoBackToAsync(string name, INavigationParameters parameters);
-
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>

--- a/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -10,16 +10,6 @@ public static class INavigationServiceExtensions
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
-    /// <param name="navigationService">Service for handling navigation between views</param>
-    /// <param name="name">The name of the View to navigate back to</param>
-    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-    [Obsolete($"Use {nameof(GoBackAsync)} instead.")]
-    public static Task<INavigationResult> GoBackToAsync(this INavigationService navigationService, string name) =>
-        navigationService.GoBackAsync(name, null);
-
-    /// <summary>
-    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-    /// </summary>
     /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
     public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService) =>
         navigationService.GoBackAsync(new NavigationParameters());

--- a/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -13,8 +13,9 @@ public static class INavigationServiceExtensions
     /// <param name="navigationService">Service for handling navigation between views</param>
     /// <param name="name">The name of the View to navigate back to</param>
     /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    [Obsolete($"Use {nameof(GoBackAsync)} instead.")]
     public static Task<INavigationResult> GoBackToAsync(this INavigationService navigationService, string name) =>
-        navigationService.GoBackToAsync(name, null);
+        navigationService.GoBackAsync(name, null);
 
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.

--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -69,15 +69,6 @@ public class PageNavigationService : INavigationService, IRegistryAware
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
-    /// <param name="name">The name of the View to navigate back to</param>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-    public virtual Task<INavigationResult> GoBackToAsync(string name, INavigationParameters parameters)
-        => GoBackAsync(name, parameters);
-
-    /// <summary>
-    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-    /// </summary>
     /// <param name="parameters">The navigation parameters</param>
     /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
     public virtual async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -223,7 +223,7 @@ public class NavigationTests : TestBase
     }
 
     [Fact]
-    public async Task GoBackTo_Name_PopsToSpecifiedView()
+    public async Task GoBack_Name_PopsToSpecifiedView()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
             .Build();
@@ -237,7 +237,7 @@ public class NavigationTests : TestBase
 
         var result = await navigationPage.CurrentPage.GetContainerProvider()
             .Resolve<INavigationService>()
-            .GoBackToAsync("MockViewC");
+            .GoBackAsync("MockViewC");
 
         Assert.True(result.Success);
 
@@ -245,7 +245,7 @@ public class NavigationTests : TestBase
     }
 
     [Fact]
-    public async Task GoBackTo_ViewModel_PopsToSpecifiedView()
+    public async Task GoBack_ViewModel_PopsToSpecifiedView()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
             .Build();
@@ -260,7 +260,7 @@ public class NavigationTests : TestBase
         var result = await navigationPage.CurrentPage.GetContainerProvider()
             .Resolve<INavigationService>()
             .CreateBuilder()
-            .GoBackTo<MockViewCViewModel>();
+            .GoBackAsync<MockViewCViewModel>();
 
         Assert.True(result.Success);
 


### PR DESCRIPTION
﻿## Description of Change

With #2818 the behavior of `GoBack` was extended to support navigating back to a specific `viewName` in the stack.
But there is currently no generic version of GoBack in the `NavigationBuilder`.

This PR adds the generic `GoBack<TViewModel>()` to the `NavigationBuilder`.

As suggested by [dansiegel](https://github.com/PrismLibrary/Prism/pull/3101#discussion_r1538450909) I have removed the legacy  `GoBackTo<TViewModel>()` instead of marking it as obsolete.

The old `GoBackTo` worked differently and popped each page and called `CanNavigateAsync`, `OnNavigatedFrom`, and `OnNavigatedTo` of each page. Maybe there are cases when this is the desired behavior. So if you want to keep the old behavior, I suggest giving this methods a clear name to easily distinguish `GoBack` and `GoBackTo`. Just let me know and I can update the PR.

### Bugs Fixed

None

### API Changes

List all API changes here (or just put None), example:

Added:

- Task<INavigationResult> INavigationBuilder.GoBackAsync<TViewModel>();

Removed:

- Task<INavigationResult> PageNavigationService.GoBackToAsync(string name, INavigationParameters parameters) calls GoBackAsync(name, parameters)
- Task<INavigationResult> INavigationServiceExtensions.GoBackToAsync(this INavigationService navigationService, string name)
- Task<INavigationResult> INavigationBuilder.GoBackTo<TViewModel>(INavigationParameters parameters);
- Task<INavigationResult> NavigationBuilderExtensions.GoBackTo<TViewModel>(this INavigationBuilder builder)


### Behavioral Changes

GoBackTo was removed and GoBack works without calling `CanNavigateAsync`, `OnNavigatedFrom`, and `OnNavigatedTo` of each page.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard