### PR TITLE
Updated README link to prismlibrary.com documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Prism Team would first and foremost like to thank all of those developers wh
 
 ## Support
 
-- Documentation is maintained in [the Prism-Documentation repo](https://github.com/PrismLibrary/Prism-Documentation) under /docs and can be found in a readable format on [the website](http://prismlibrary.com/docs/).
+- Documentation is maintained in [the Prism-Documentation repo](https://github.com/PrismLibrary/Prism-Documentation) under /docs and can be found in a readable format on [the website](https://docs.prismlibrary.com/docs/).
 - StackOverflow: **NOTE** The Prism Team no longer supports or engages with questions posted on StackOverflow. Questions posted there may or may not receive correct answers.
 - For general questions and support, post your questions in [GitHub Discussions](https://github.com/PrismLibrary/Prism/discussions).
 - You can enter bugs and feature requests in our [Issues](https://github.com/PrismLibrary/Prism/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Prism Team would first and foremost like to thank all of those developers wh
 
 ## Support
 
-- Documentation is maintained in [the Prism-Documentation repo](https://github.com/PrismLibrary/Prism-Documentation) under /docs and can be found in a readable format on [the website](https://docs.prismlibrary.com/docs/).
+- Documentation is maintained in [the Prism-Documentation repo](https://github.com/PrismLibrary/Prism-Documentation) under /docs and can be found in a readable format on [the website](https://docs.prismlibrary.com/).
 - StackOverflow: **NOTE** The Prism Team no longer supports or engages with questions posted on StackOverflow. Questions posted there may or may not receive correct answers.
 - For general questions and support, post your questions in [GitHub Discussions](https://github.com/PrismLibrary/Prism/discussions).
 - You can enter bugs and feature requests in our [Issues](https://github.com/PrismLibrary/Prism/issues/new/choose).


### PR DESCRIPTION
﻿## Description of Change

Updated README.md's broken link to the Prism website's documentation.

I apologize for not creating an issue for this first. If need be, I can do so for formality.

### Bugs Fixed

- The link would resolve to a 404 Not Found

### API Changes

None

Changed:

- The ReadMe link previously pointed to `https://prismlibrary.com/docs/` which it is now, `https://docs.prismlibrary.com/docs/`

### Behavioral Changes

N/A

### PR Checklist

- [X] Has tests (if omitted, state reason in the description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard