### PR TITLE
fix: BindingContext is cleared before the View is unloaded

### DIFF
--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -63,8 +63,14 @@ public static class MvvmHelpers
 
             if (view is Page page)
             {
-                page.Behaviors?.Clear();
-                page.BindingContext = null;
+                page.Unloaded += Page_Unloaded;
+                void Page_Unloaded(object sender, EventArgs args)
+                {
+                    page.Behaviors?.Clear();
+                    page.BindingContext = null;
+                    page.Unloaded -= Page_Unloaded;
+                }
+
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
﻿## Description of Change

Updates Destroy logic to ensure that the BindingContext isn't cleared until the View is unloaded.

### Bugs Fixed

- fixes #3113

### API Changes

- n/a

### Behavioral Changes

The MvvmHelpers Destroy method will now defer clearing the BindingContext until the Page is unloaded.