### PR TITLE
chore: enable nullability for mvvm helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,9 @@ FakesAssemblies/
 
 # Binlog
 *.binlog
+
+# macOS
+.DS_Store
+
+# VSCode
+.mono

--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.ComponentModel;
 using System.Reflection;
 using Prism.Dialogs;
@@ -11,14 +12,14 @@ namespace Prism.Common;
 
 public static class MvvmHelpers
 {
-    public static void InvokeViewAndViewModelAction<T>(object view, Action<T> action) where T : class
+    public static void InvokeViewAndViewModelAction<T>(object? view, Action<T> action) where T : class
     {
         if (view is T viewAsT)
         {
             action(viewAsT);
         }
 
-        if (view is BindableObject element && element.BindingContext is T viewModelAsT)
+        if (view is BindableObject { BindingContext: T viewModelAsT })
         {
             action(viewModelAsT);
         }
@@ -32,14 +33,14 @@ public static class MvvmHelpers
         }
     }
 
-    public static async Task InvokeViewAndViewModelActionAsync<T>(object view, Func<T, Task> action) where T : class
+    public static async Task InvokeViewAndViewModelActionAsync<T>(object? view, Func<T, Task> action) where T : class
     {
         if (view is T viewAsT)
         {
             await action(viewAsT);
         }
 
-        if (view is BindableObject element && element.BindingContext is T viewModelAsT)
+        if (view is BindableObject { BindingContext: T viewModelAsT })
         {
             await action(viewModelAsT);
         }
@@ -49,11 +50,11 @@ public static class MvvmHelpers
             var children = page.GetChildRegions();
             if (children is not null)
                 foreach (var child in children)
-                    await InvokeViewAndViewModelActionAsync<T>(child, action);
+                    await InvokeViewAndViewModelActionAsync(child, action);
         }
     }
 
-    public static void DestroyPage(IView view)
+    public static void DestroyPage(IView? view)
     {
         try
         {
@@ -96,7 +97,7 @@ public static class MvvmHelpers
         }
     }
 
-    public static void DestroyWithModalStack(Page page, IList<Page> modalStack)
+    public static void DestroyWithModalStack(Page? page, IList<Page?> modalStack)
     {
         foreach (var childPage in modalStack.Reverse())
         {
@@ -105,7 +106,7 @@ public static class MvvmHelpers
         DestroyPage(page);
     }
 
-    public static T GetImplementerFromViewOrViewModel<T>(object view)
+    public static T? GetImplementerFromViewOrViewModel<T>(object view)
             where T : class
     {
         if (view is T viewAsT)
@@ -113,7 +114,7 @@ public static class MvvmHelpers
             return viewAsT;
         }
 
-        if (view is VisualElement element && element.BindingContext is T vmAsT)
+        if (view is VisualElement { BindingContext: T vmAsT })
         {
             return vmAsT;
         }
@@ -136,12 +137,12 @@ public static class MvvmHelpers
         return path == viewType.Name || path == viewType.FullName;
     }
 
-    public static void OnNavigatedFrom(object view, NavigationContext navigationContext)
+    public static void OnNavigatedFrom(object? view, NavigationContext navigationContext)
     {
         InvokeViewAndViewModelAction<IRegionAware>(view, x => x.OnNavigatedFrom(navigationContext));
     }
 
-    public static void OnNavigatedTo(object view, NavigationContext navigationContext)
+    public static void OnNavigatedTo(object? view, NavigationContext navigationContext)
     {
         InvokeViewAndViewModelAction<IRegionAware>(view, x => x.OnNavigatedTo(navigationContext));
     }
@@ -161,13 +162,13 @@ public static class MvvmHelpers
         return implementer?.CanNavigate(parameters) ?? true;
     }
 
-    public static void OnNavigatedFrom(object page, INavigationParameters parameters)
+    public static void OnNavigatedFrom(object? page, INavigationParameters parameters)
     {
         if (page != null)
             InvokeViewAndViewModelAction<INavigatedAware>(page, v => v.OnNavigatedFrom(parameters));
     }
 
-    public static async Task OnInitializedAsync(object page, INavigationParameters parameters)
+    public static async Task OnInitializedAsync(object? page, INavigationParameters parameters)
     {
         if (page is null) return;
 
@@ -177,19 +178,19 @@ public static class MvvmHelpers
 
     private static bool HasKey(this IEnumerable<KeyValuePair<string, object>> parameters, string name, out string key)
     {
-        key = parameters.Select(x => x.Key).FirstOrDefault(k => k.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+        key = parameters.Select(x => x.Key).FirstOrDefault(k => k.Equals(name, StringComparison.InvariantCultureIgnoreCase)) ?? string.Empty;
         return !string.IsNullOrEmpty(key);
     }
 
-    public static void OnNavigatedTo(object page, INavigationParameters parameters)
+    public static void OnNavigatedTo(object? page, INavigationParameters parameters)
     {
         if (page != null)
             InvokeViewAndViewModelAction<INavigatedAware>(page, v => v.OnNavigatedTo(parameters));
     }
 
-    public static Page GetOnNavigatedToTarget(Page page, IView mainPage, bool useModalNavigation)
+    public static Page? GetOnNavigatedToTarget(Page page, IView? mainPage, bool useModalNavigation)
     {
-        Page target;
+        Page? target;
         if (useModalNavigation)
         {
             var previousPage = GetPreviousPage(page, page.Navigation.ModalStack);
@@ -210,9 +211,9 @@ public static class MvvmHelpers
         return target;
     }
 
-    public static Page GetOnNavigatedToTargetFromChild(IView target)
+    public static Page? GetOnNavigatedToTargetFromChild(IView? target)
     {
-        Page child = null;
+        Page? child = null;
 
         if (target is FlyoutPage flyout)
             child = flyout.Detail;
@@ -230,9 +231,9 @@ public static class MvvmHelpers
         return null;
     }
 
-    public static Page GetPreviousPage(Page currentPage, System.Collections.Generic.IReadOnlyList<Page> navStack)
+    public static Page? GetPreviousPage(Page currentPage, IReadOnlyList<Page?> navStack)
     {
-        Page previousPage = null;
+        Page? previousPage = null;
 
         int currentPageIndex = GetCurrentPageIndex(currentPage, navStack);
         int previousPageIndex = currentPageIndex - 1;
@@ -242,7 +243,7 @@ public static class MvvmHelpers
         return previousPage;
     }
 
-    public static int GetCurrentPageIndex(Page currentPage, System.Collections.Generic.IReadOnlyList<Page> navStack)
+    public static int GetCurrentPageIndex(Page currentPage, IReadOnlyList<Page?> navStack)
     {
         int stackCount = navStack.Count;
         for (int x = 0; x < stackCount; x++)
@@ -255,14 +256,14 @@ public static class MvvmHelpers
         return stackCount - 1;
     }
 
-    public static Page GetCurrentPage(Page mainPage) =>
+    public static Page? GetCurrentPage(Page mainPage) =>
         _getCurrentPage(mainPage);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static void SetCurrentPageDelegate(Func<Page, Page> getCurrentPageDelegate) =>
+    public static void SetCurrentPageDelegate(Func<Page, Page?> getCurrentPageDelegate) =>
         _getCurrentPage = getCurrentPageDelegate;
 
-    private static Func<Page, Page> _getCurrentPage = mainPage =>
+    private static Func<Page, Page?> _getCurrentPage = mainPage =>
     {
         var page = mainPage;
 
@@ -273,7 +274,7 @@ public static class MvvmHelpers
         return EvaluateCurrentPage(page);
     };
 
-    private static Page GetTarget(Page target)
+    private static Page? GetTarget(Page? target)
     {
         return target switch
         {
@@ -285,14 +286,14 @@ public static class MvvmHelpers
         };
     }
 
-    private static Page EvaluateCurrentPage(Page target)
+    private static Page? EvaluateCurrentPage(Page? target)
     {
-        Page child = GetTarget(target);
+        Page? child = GetTarget(target);
 
         if (child is not null)
             target = GetOnNavigatedToTargetFromChild(child);
 
-        if (target is Page page)
+        if (target is { } page)
         {
             if (target is IDialogContainer)
             {
@@ -319,9 +320,9 @@ public static class MvvmHelpers
     {
         var navigationService = Navigation.Xaml.Navigation.GetNavigationService(navigationPage.CurrentPage);
         var result = await navigationService.GoBackAsync();
-        if (result.Exception is NavigationException navEx && navEx.Message == NavigationException.CannotPopApplicationMainPage)
+        if (result.Exception is NavigationException { Message: NavigationException.CannotPopApplicationMainPage })
         {
-            Application.Current.Quit();
+            Application.Current?.Quit();
         }
     }
 
@@ -335,13 +336,13 @@ public static class MvvmHelpers
             },
         };
         var result = await navigationService.GoBackAsync(navParams);
-        if (result.Exception is NavigationException navEx && navEx.Message == NavigationException.CannotPopApplicationMainPage)
+        if (result.Exception is NavigationException { Message: NavigationException.CannotPopApplicationMainPage })
         {
-            Application.Current.Quit();
+            Application.Current?.Quit();
         }
     }
 
-    public static void HandleSystemGoBack(IView previousPage, IView currentPage)
+    public static void HandleSystemGoBack(IView? previousPage, IView? currentPage)
     {
         var parameters = new NavigationParameters();
         parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
@@ -352,22 +353,22 @@ public static class MvvmHelpers
 
     internal static bool HasDirectNavigationPageParent(Page page)
     {
-        return page?.Parent != null && page?.Parent is NavigationPage;
+        return page.Parent is NavigationPage;
     }
 
     internal static bool HasNavigationPageParent(Page page) =>
         HasNavigationPageParent(page, out var _);
 
-    internal static bool HasNavigationPageParent(Page page, out NavigationPage navigationPage)
+    internal static bool HasNavigationPageParent(Page page, out NavigationPage? navigationPage)
     {
-        if (page?.Parent != null)
+        if (page.Parent != null)
         {
             if (page.Parent is NavigationPage navParent)
             {
                 navigationPage = navParent;
                 return true;
             }
-            else if ((page.Parent is TabbedPage) && page.Parent?.Parent is NavigationPage navigationParent)
+            else if (page.Parent is TabbedPage && page.Parent?.Parent is NavigationPage navigationParent)
             {
                 navigationPage = navigationParent;
                 return true;

--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Prism.Dialogs;
 using Prism.Navigation;
@@ -176,9 +177,9 @@ public static class MvvmHelpers
         await InvokeViewAndViewModelActionAsync<IInitializeAsync>(page, async v => await v.InitializeAsync(parameters));
     }
 
-    private static bool HasKey(this IEnumerable<KeyValuePair<string, object>> parameters, string name, out string key)
+    private static bool HasKey(this IEnumerable<KeyValuePair<string, object>> parameters, string name, [MaybeNullWhen(returnValue: false)] out string key)
     {
-        key = parameters.Select(x => x.Key).FirstOrDefault(k => k.Equals(name, StringComparison.InvariantCultureIgnoreCase)) ?? string.Empty;
+        key = parameters.Select(x => x.Key).FirstOrDefault(k => k.Equals(name, StringComparison.InvariantCultureIgnoreCase));
         return !string.IsNullOrEmpty(key);
     }
 

--- a/src/Prism.Core/Navigation/NavigationResult.cs
+++ b/src/Prism.Core/Navigation/NavigationResult.cs
@@ -31,7 +31,7 @@ public class NavigationResult : INavigationResult
     /// Initializes a new NavigationResult with an <see cref="Exception"/>
     /// </summary>
     /// <param name="ex">The <see cref="Exception"/> encountered as part of the navigation.</param>
-    public NavigationResult(Exception ex)
+    public NavigationResult(Exception? ex)
     {
         Exception = ex;
     }


### PR DESCRIPTION
﻿## Description of Change

This change is the first of a few to enable nullability in Prism.

### Bugs Fixed

None.

### API Changes

List all API changes here (or just put None), example:

Added:
None

Changed:

- MvvmHelpers
- NavigationResult

### Behavioral Changes

There should be no behavioral changes given nullability is backwards compatible.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard