### PR TITLE
Update RegionNavigationRegistrationExtensions.cs

### DIFF
--- a/src/Maui/Prism.Maui/Ioc/RegionNavigationRegistrationExtensions.cs
+++ b/src/Maui/Prism.Maui/Ioc/RegionNavigationRegistrationExtensions.cs
@@ -35,7 +35,7 @@ public static class RegionNavigationRegistrationExtensions
         where TViewModel : class =>
         containerRegistry.RegisterForNavigationWithViewModel(typeof(TView), typeof(TViewModel), name);
 
-    private static IContainerRegistry RegisterForNavigationWithViewModel(this IContainerRegistry containerRegistry, Type viewType, Type viewModelType, string name)
+    public static IContainerRegistry RegisterForNavigationWithViewModel(this IContainerRegistry containerRegistry, Type viewType, Type viewModelType, string name)
     {
         if (string.IsNullOrWhiteSpace(name))
             name = viewType.Name;


### PR DESCRIPTION
Allow for registering a view for navigation using type. This method already exists but is currently private. This is existing function so no tests created.

﻿## Description of Change

Make existing function public.

Changed:

- private static IContainerRegistry RegisterForRegionNavigation => public static IContainerRegistry RegisterForRegionNavigation

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard