### PR TITLE
Update RegionNavigationRegistrationExtensions.cs

### DIFF
--- a/src/Maui/Prism.Maui/Ioc/RegionNavigationRegistrationExtensions.cs
+++ b/src/Maui/Prism.Maui/Ioc/RegionNavigationRegistrationExtensions.cs
@@ -35,7 +35,10 @@ public static class RegionNavigationRegistrationExtensions
         where TViewModel : class =>
         containerRegistry.RegisterForNavigationWithViewModel(typeof(TView), typeof(TViewModel), name);
 
-    public static IContainerRegistry RegisterForNavigationWithViewModel(this IContainerRegistry containerRegistry, Type viewType, Type viewModelType, string name)
+    public static IContainerRegistry RegisterForRegionNavigation(this IContainerRegistry containerRegistry, Type viewType, Type viewModelType, string name = null)
+        => containerRegistry.RegisterForNavigationWithViewModel(viewType, viewModelType, name);
+
+    private static IContainerRegistry RegisterForNavigationWithViewModel(this IContainerRegistry containerRegistry, Type viewType, Type viewModelType, string name)
     {
         if (string.IsNullOrWhiteSpace(name))
             name = viewType.Name;
@@ -76,6 +79,9 @@ public static class RegionNavigationRegistrationExtensions
         where TView : View
         where TViewModel : class =>
         services.RegisterForNavigationWithViewModel(typeof(TView), typeof(TViewModel), name);
+
+    public static IServiceCollection RegisterForRegionNavigation(this IServiceCollection services, Type viewType, Type viewModelType, string name = null)
+        => services.RegisterForNavigationWithViewModel(viewType, viewModelType, name);
 
     private static IServiceCollection RegisterForNavigationWithViewModel(this IServiceCollection services, Type viewType, Type viewModelType, string name)
     {


### PR DESCRIPTION
My previous submission made RegisterForNavigationWithViewModel public, after more thought it makes sense that it would be private and instead an override of RegisterForRegionNavigation without the strong typing is more descriptive and conveys the intent better.

﻿## Description of Change

Reverted RegisterForNavigationWithViewModel  to be private and created overrides for RegisterForRegionNavigation that call existing method with non generic parameters.

Tests were not created as this doesn't change anything functionally that is not already covered.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard