### PR TITLE
fix: GetCurrentPage for PrismWindow.Page throwing exception

### DIFF
--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -304,7 +304,7 @@ public static class MvvmHelpers
                 return page.Parent switch
                 {
                     Page parentPage => GetTarget(parentPage),
-                    PrismWindow prismWindow => GetTarget(prismWindow.Page),
+                    Window window => GetTarget(window.Page),
                     _ => throw new InvalidOperationException("Unable to determine the current page.")
                 };
             }

--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -284,8 +284,9 @@ public static class MvvmHelpers
         {
             FlyoutPage flyout => GetTarget(flyout.Detail),
             TabbedPage tabbed => GetTarget(tabbed.CurrentPage),
-            NavigationPage navigation => GetTarget(navigation.CurrentPage),
+            NavigationPage navigation => GetTarget(navigation.CurrentPage) ?? navigation,
             ContentPage page => page,
+            null => null,
             _ => throw new NotSupportedException($"The page type '{target.GetType().FullName}' is not supported.")
         };
     }

--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -299,10 +299,18 @@ public static class MvvmHelpers
 
         if (target is { } page)
         {
+            if (target is IDialogContainer)
+            {
+                return page.Parent switch
+                {
+                    Page parentPage => GetTarget(parentPage),
+                    PrismWindow prismWindow => GetTarget(prismWindow.Page),
+                    _ => throw new InvalidOperationException("Unable to determine the current page.")
+                };
+            }
+
             return page.Parent switch
             {
-                Page parent when page is IDialogContainer => GetTarget(parent),
-                PrismWindow prismWindow when page is IDialogContainer => GetTarget(prismWindow.Page),
                 TabbedPage tab when tab.CurrentPage != target => EvaluateCurrentPage(tab.CurrentPage),
                 NavigationPage nav when nav.CurrentPage != target => EvaluateCurrentPage(nav.CurrentPage),
                 _ => target

--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -88,12 +88,14 @@ public static class MvvmHelpers
                 {
                     DestroyPage(item);
                 }
+
                 break;
             case NavigationPage navigationPage:
                 foreach (var item in navigationPage.Navigation.NavigationStack.Reverse())
                 {
                     DestroyPage(item);
                 }
+
                 break;
         }
     }
@@ -104,11 +106,12 @@ public static class MvvmHelpers
         {
             DestroyPage(childPage);
         }
+
         DestroyPage(page);
     }
 
     public static T? GetImplementerFromViewOrViewModel<T>(object view)
-            where T : class
+        where T : class
     {
         if (view is T viewAsT)
         {
@@ -301,6 +304,11 @@ public static class MvvmHelpers
                 if (page.Parent is Page parentPage)
                 {
                     return GetTarget(parentPage);
+                }
+
+                if (page.Parent is PrismWindow prismWindow)
+                {
+                    return GetTarget(prismWindow.Page);
                 }
 
                 throw new InvalidOperationException("Unable to determine the current page.");

--- a/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Maui/Prism.Maui/Common/MvvmHelpers.cs
@@ -299,23 +299,10 @@ public static class MvvmHelpers
 
         if (target is { } page)
         {
-            if (target is IDialogContainer)
-            {
-                if (page.Parent is Page parentPage)
-                {
-                    return GetTarget(parentPage);
-                }
-
-                if (page.Parent is PrismWindow prismWindow)
-                {
-                    return GetTarget(prismWindow.Page);
-                }
-
-                throw new InvalidOperationException("Unable to determine the current page.");
-            }
-
             return page.Parent switch
             {
+                Page parent when page is IDialogContainer => GetTarget(parent),
+                PrismWindow prismWindow when page is IDialogContainer => GetTarget(prismWindow.Page),
                 TabbedPage tab when tab.CurrentPage != target => EvaluateCurrentPage(tab.CurrentPage),
                 NavigationPage nav when nav.CurrentPage != target => EvaluateCurrentPage(nav.CurrentPage),
                 _ => target

--- a/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
+++ b/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
@@ -12,16 +12,16 @@ public class MvvmHelperFixture
     public async Task GetCurrentPageFromFlyoutPageWithModalReturnsDetailPage()
     {
         // Given
-        FlyoutPage flyout = new FlyoutPage
+        var flyout = new FlyoutPage
             { Flyout = new ContentPage { Title = "Title" }, Detail = new NavigationPage(), };
-        PrismWindow window = new PrismWindow { Page = flyout };
+        var window = new PrismWindow { Page = flyout };
         await window.Navigation.PushModalAsync(new DialogContainerPage());
 
         // When
         var result = MvvmHelpers.GetCurrentPage(window.Page);
 
         // Then
-        Assert.Equal(result, flyout.Detail);
+        Assert.Equal(flyout.Detail, result);
     }
 
     /// <summary>
@@ -32,14 +32,14 @@ public class MvvmHelperFixture
     public async Task GetCurrentPageFromComplexFlyoutPageWithModalReturnsCorrectPage()
     {
         // Given
-        ContentPage current = new ContentPage { Title = "D" };
+        var expected = new ContentPage { Title = "D" };
         var navigationPage = new NavigationPage();
         await navigationPage.PushAsync(new ContentPage { Title = "A" });
         await navigationPage.PushAsync(new ContentPage { Title = "B" });
         await navigationPage.PushAsync(new ContentPage { Title = "C" });
-        await navigationPage.PushAsync(current);
+        await navigationPage.PushAsync(expected);
 
-        PrismWindow window = new PrismWindow
+        var window = new Window
         {
             Page = new FlyoutPage
                 { Flyout = new ContentPage { Title = "Title" }, Detail = navigationPage, }
@@ -51,7 +51,7 @@ public class MvvmHelperFixture
         var result = MvvmHelpers.GetCurrentPage(window.Page);
 
         // Then
-        Assert.Equal(result, current);
+        Assert.Equal(expected, result);
     }
 
     /// <summary>
@@ -62,16 +62,15 @@ public class MvvmHelperFixture
     public async Task GetCurrentPageFromNavigationPageWithModalReturnsContentPage()
     {
         // Given
-        var contentPage = new ContentPage();
-        NavigationPage navigationPage = new NavigationPage(contentPage);
-        PrismWindow window = new PrismWindow { Page = navigationPage };
+        var expected = new ContentPage();
+        var window = new Window { Page = new NavigationPage(expected) };
         await window.Navigation.PushModalAsync(new DialogContainerPage());
 
         // When
         var result = MvvmHelpers.GetCurrentPage(window.Page);
 
         // Then
-        Assert.Equal(result, contentPage);
+        Assert.Equal(expected, result);
     }
 
     /// <summary>
@@ -82,14 +81,55 @@ public class MvvmHelperFixture
     public async Task GetCurrentPageFromContentPageWithModalReturnsContentPage()
     {
         // Given
-        ContentPage contentPage = new ContentPage { Title = "Title" };
-        PrismWindow window = new PrismWindow { Page = contentPage };
+        var expected = new ContentPage { Title = "Title" };
+        var window = new Window { Page = expected };
         await window.Navigation.PushModalAsync(new DialogContainerPage());
 
         // When
         var result = MvvmHelpers.GetCurrentPage(window.Page);
 
         // Then
-        Assert.Equal(result, contentPage);
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// This test was introduced to verify GH3143
+    /// </summary>
+    /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
+    [Fact(Skip = "System.InvalidOperationException\nBindableObject was not instantiated on a thread with a dispatcher nor does the current application have a dispatcher.")]
+    public async Task GetCurrentPageFromTabbedPageWithModalReturnsContentPage()
+    {
+        // Given
+        var expected = new ContentPage();
+        var tabbedPage = new TabbedPage { Title = "Tab", Children = { expected }};
+        var window = new Window { Page = tabbedPage };
+        await window.Navigation.PushModalAsync(new DialogContainerPage());
+
+        // When
+        var result = MvvmHelpers.GetCurrentPage(window.Page);
+
+        // Then
+        Assert.Equal(expected, result);
+    }
+
+    /// <summary>
+    /// This test was introduced to verify GH3143
+    /// </summary>
+    /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
+    [Fact(Skip = "System.InvalidOperationException\nBindableObject was not instantiated on a thread with a dispatcher nor does the current application have a dispatcher.")]
+    public async Task GetCurrentPageFromTabbedNavigationPageWithModalReturnsContentPage()
+    {
+        // Given
+        var expected = new ContentPage();
+        var navigationPage = new NavigationPage(expected);
+        var tabbedPage = new TabbedPage { Title = "Tab", Children = { navigationPage }};
+        var window = new Window { Page = tabbedPage };
+        await window.Navigation.PushModalAsync(new DialogContainerPage());
+
+        // When
+        var result = MvvmHelpers.GetCurrentPage(window.Page);
+
+        // Then
+        Assert.Equal(expected, result);
     }
 }

--- a/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
+++ b/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
@@ -1,6 +1,4 @@
-using System.Collections;
 using Prism.Common;
-using Prism.Maui.Tests.Mocks.Views;
 
 namespace Prism.Maui.Tests.Fixtures.Common;
 
@@ -10,40 +8,88 @@ public class MvvmHelperFixture
     /// This test was introduced to verify GH3143
     /// </summary>
     /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
-    /// <param name="window">The window representing the root of the navigation.</param>
-    /// <param name="page">The actual page we expect to return.</param>
-    /// <param name="modal">The model page we are pushing on the stack that causes the problem.</param>
-    [Theory]
-    [ClassData(typeof(GetCurrentPageTestData))]
-    public async Task GetCurrentPageWithModalReturnsPrismWindowPage(Window window, Page page, Page modal)
+    [Fact]
+    public async Task GetCurrentPageFromFlyoutPageWithModalReturnsDetailPage()
     {
         // Given
-        await window.Navigation.PushModalAsync(modal);
+        FlyoutPage flyout = new FlyoutPage
+            { Flyout = new ContentPage { Title = "Title" }, Detail = new NavigationPage(), };
+        PrismWindow window = new PrismWindow { Page = flyout };
+        await window.Navigation.PushModalAsync(new DialogContainerPage());
 
         // When
         var result = MvvmHelpers.GetCurrentPage(window.Page);
 
         // Then
-        Assert.Equal(result, page);
+        Assert.Equal(result, flyout.Detail);
     }
 
-    private class GetCurrentPageTestData : IEnumerable<object[]>
+    /// <summary>
+    /// This test was introduced to verify GH3143
+    /// </summary>
+    /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
+    [Fact]
+    public async Task GetCurrentPageFromComplexFlyoutPageWithModalReturnsCorrectPage()
     {
-        public IEnumerator<object[]> GetEnumerator()
+        // Given
+        ContentPage current = new ContentPage { Title = "D" };
+        var navigationPage = new NavigationPage();
+        await navigationPage.PushAsync(new ContentPage { Title = "A" });
+        await navigationPage.PushAsync(new ContentPage { Title = "B" });
+        await navigationPage.PushAsync(new ContentPage { Title = "C" });
+        await navigationPage.PushAsync(current);
+
+        PrismWindow window = new PrismWindow
         {
-            ContentPage contentPage = new ContentPage { Title = "Title" };
-            NavigationPage navigationPage = new NavigationPage();
-            // TabbedPage tabbedPage = new TabbedPage { CurrentPage = contentPage };
-            FlyoutPage flyout = new FlyoutPage { Flyout = contentPage, Detail = new NavigationPage(), };
-            DialogContainerPage dialogContainerPage = new DialogContainerPage();
-            yield return new object[] { PrismWindow(contentPage), contentPage, dialogContainerPage };
-            yield return new object[] { PrismWindow(navigationPage), navigationPage, dialogContainerPage };
-            // yield return new object[] { PrismWindow(tabbedPage), tabbedPage, dialogContainerPage };
-            yield return new object[] { PrismWindow(flyout), flyout.Detail, dialogContainerPage };
-        }
+            Page = new FlyoutPage
+                { Flyout = new ContentPage { Title = "Title" }, Detail = navigationPage, }
+        };
 
-        private static PrismWindow PrismWindow(Page page) => new() { Page = page };
+        await window.Navigation.PushModalAsync(new DialogContainerPage());
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        // When
+        var result = MvvmHelpers.GetCurrentPage(window.Page);
+
+        // Then
+        Assert.Equal(result, current);
+    }
+
+    /// <summary>
+    /// This test was introduced to verify GH3143
+    /// </summary>
+    /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
+    [Fact]
+    public async Task GetCurrentPageFromNavigationPageWithModalReturnsContentPage()
+    {
+        // Given
+        var contentPage = new ContentPage();
+        NavigationPage navigationPage = new NavigationPage(contentPage);
+        PrismWindow window = new PrismWindow { Page = navigationPage };
+        await window.Navigation.PushModalAsync(new DialogContainerPage());
+
+        // When
+        var result = MvvmHelpers.GetCurrentPage(window.Page);
+
+        // Then
+        Assert.Equal(result, contentPage);
+    }
+
+    /// <summary>
+    /// This test was introduced to verify GH3143
+    /// </summary>
+    /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
+    [Fact]
+    public async Task GetCurrentPageFromContentPageWithModalReturnsContentPage()
+    {
+        // Given
+        ContentPage contentPage = new ContentPage { Title = "Title" };
+        PrismWindow window = new PrismWindow { Page = contentPage };
+        await window.Navigation.PushModalAsync(new DialogContainerPage());
+
+        // When
+        var result = MvvmHelpers.GetCurrentPage(window.Page);
+
+        // Then
+        Assert.Equal(result, contentPage);
     }
 }

--- a/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
+++ b/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
@@ -1,0 +1,21 @@
+using Prism.Common;
+
+namespace Prism.Maui.Tests.Fixtures.Common;
+
+public class MvvmHelperFixture
+{
+    [Fact]
+    public async Task GetCurrentPageWithModalReturnsPrismWindowPage()
+    {
+        // Given
+        var contentPage = new ContentPage();
+        var prismWindow = new PrismWindow { Page = contentPage };
+        await prismWindow.Navigation.PushModalAsync(new DialogContainerPage());
+
+        // When
+        var result = MvvmHelpers.GetCurrentPage(prismWindow.Page);
+
+        // Then
+        Assert.Equal(result, contentPage);
+    }
+}

--- a/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
+++ b/tests/Maui/Prism.Maui.Tests/Fixtures/Common/MvvmHelperFixture.cs
@@ -1,21 +1,49 @@
+using System.Collections;
 using Prism.Common;
+using Prism.Maui.Tests.Mocks.Views;
 
 namespace Prism.Maui.Tests.Fixtures.Common;
 
 public class MvvmHelperFixture
 {
-    [Fact]
-    public async Task GetCurrentPageWithModalReturnsPrismWindowPage()
+    /// <summary>
+    /// This test was introduced to verify GH3143
+    /// </summary>
+    /// <a href="https://github.com/PrismLibrary/Prism/issues/3143">Git Hub Issue 3143</a>
+    /// <param name="window">The window representing the root of the navigation.</param>
+    /// <param name="page">The actual page we expect to return.</param>
+    /// <param name="modal">The model page we are pushing on the stack that causes the problem.</param>
+    [Theory]
+    [ClassData(typeof(GetCurrentPageTestData))]
+    public async Task GetCurrentPageWithModalReturnsPrismWindowPage(Window window, Page page, Page modal)
     {
         // Given
-        var contentPage = new ContentPage();
-        var prismWindow = new PrismWindow { Page = contentPage };
-        await prismWindow.Navigation.PushModalAsync(new DialogContainerPage());
+        await window.Navigation.PushModalAsync(modal);
 
         // When
-        var result = MvvmHelpers.GetCurrentPage(prismWindow.Page);
+        var result = MvvmHelpers.GetCurrentPage(window.Page);
 
         // Then
-        Assert.Equal(result, contentPage);
+        Assert.Equal(result, page);
+    }
+
+    private class GetCurrentPageTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            ContentPage contentPage = new ContentPage { Title = "Title" };
+            NavigationPage navigationPage = new NavigationPage();
+            // TabbedPage tabbedPage = new TabbedPage { CurrentPage = contentPage };
+            FlyoutPage flyout = new FlyoutPage { Flyout = contentPage, Detail = new NavigationPage(), };
+            DialogContainerPage dialogContainerPage = new DialogContainerPage();
+            yield return new object[] { PrismWindow(contentPage), contentPage, dialogContainerPage };
+            yield return new object[] { PrismWindow(navigationPage), navigationPage, dialogContainerPage };
+            // yield return new object[] { PrismWindow(tabbedPage), tabbedPage, dialogContainerPage };
+            yield return new object[] { PrismWindow(flyout), flyout.Detail, dialogContainerPage };
+        }
+
+        private static PrismWindow PrismWindow(Page page) => new() { Page = page };
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }


### PR DESCRIPTION
﻿## Description of Change

Fixed a bug that causes the sample application to crash given a `PrismWindow` is somewhere on the navigation stack.

### Bugs Fixed

- #3143 

### API Changes

Changed:

- checking `PrismWindow` for the `Page` property on it and passing it to the `GetTarget` method

### Behavioral Changes

Ensured the `PrismWindow` gets properly handled and passed the `Page` property on to find the target if available.
### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard