### PR TITLE
Fix double back on Android

### DIFF
--- a/src/Maui/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilder.cs
@@ -78,6 +78,11 @@ public sealed class PrismAppBuilder
                     if (window is null)
                         return false;
 
+                    if (window.CurrentPage?.Parent is NavigationPage)
+                    {
+                        return true;
+                    }
+
                     if(window.IsRootPage)
                     {
                         return false;


### PR DESCRIPTION
﻿## Description of Change

Fixes issue where pressing the back button can cause a double back when the Current Page's parent is a NavigationPage