### PR TITLE
chore: build Prism on macOS

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -8,11 +8,13 @@
           ConsoleToMsBuild="true" />
 
     <Exec Command="type $(MSBuildThisFileDirectory)ReadMe.md >> $(IntermediateOutputPath)\ReadMe.md"
-          ConsoleToMsBuild="true" />
+          ConsoleToMsBuild="true"
+          Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'" />
   </Target>
 
   <Target Name="PackNuGetReadMe"
-          AfterTargets="CopyNuGetReadme">
+          AfterTargets="CopyNuGetReadme"
+          Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">
     <PropertyGroup>
       <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -9,7 +9,7 @@
 
     <Exec Command="type $(MSBuildThisFileDirectory)ReadMe.md >> $(IntermediateOutputPath)\ReadMe.md"
           ConsoleToMsBuild="true"
-          Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'" />
+          Condition="$([MSBuild]::IsOSPlatform('windows'))" />
   </Target>
 
   <Target Name="PackNuGetReadMe"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,7 +14,7 @@
 
   <Target Name="PackNuGetReadMe"
           AfterTargets="CopyNuGetReadme"
-          Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">
+          Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <PropertyGroup>
       <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     </PropertyGroup>


### PR DESCRIPTION
This Pull Request allows me to build Prism Library and run the Prism Demos on macOS without having to locally comment out packaging concerns