### PR TITLE
Add 'AddOrReplace' to IRegionBehaviorFactory

### DIFF
--- a/PrismLibrary.sln
+++ b/PrismLibrary.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33213.308
@@ -92,6 +91,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Events", "src\Prism.Events\Prism.Events.csproj", "{8610485A-BE9F-4938-86D4-E9F1FA1739A0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Uno.WinUI.Markup", "src\Uno\Prism.Uno.Markup\Prism.Uno.WinUI.Markup.csproj", "{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrismRegionsFlyout", "..\..\..\Desktop\PrismRegionsFlyout\PrismRegionsFlyout\PrismRegionsFlyout.csproj", "{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -415,6 +416,24 @@ Global
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x64.Build.0 = Release|Any CPU
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x86.ActiveCfg = Release|Any CPU
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x86.Build.0 = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x64.Build.0 = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x64.Deploy.0 = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x86.Build.0 = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x86.Deploy.0 = Debug|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x64.ActiveCfg = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x64.Build.0 = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x64.Deploy.0 = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x86.ActiveCfg = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x86.Build.0 = Release|Any CPU
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x86.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -455,6 +474,7 @@ Global
 		{8711D306-1118-4A11-9399-EF14AA13015E} = {540CEEC1-D541-4614-BF0B-18056A83E434}
 		{8610485A-BE9F-4938-86D4-E9F1FA1739A0} = {F3664D7A-6FF5-4D1F-9F5F-26EE87F032D3}
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D} = {8F959801-D494-4CAF-9437-90F30472E169}
+		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB} = {24639CEB-266D-40E1-B0A8-B78BB6F8CEF8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7433AE2-B1A0-4C1A-887E-5CAA7AAF67A6}

--- a/PrismLibrary.sln
+++ b/PrismLibrary.sln
@@ -1,3 +1,4 @@
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33213.308
@@ -91,8 +92,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Events", "src\Prism.Events\Prism.Events.csproj", "{8610485A-BE9F-4938-86D4-E9F1FA1739A0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Uno.WinUI.Markup", "src\Uno\Prism.Uno.Markup\Prism.Uno.WinUI.Markup.csproj", "{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrismRegionsFlyout", "..\..\..\Desktop\PrismRegionsFlyout\PrismRegionsFlyout\PrismRegionsFlyout.csproj", "{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -416,24 +415,6 @@ Global
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x64.Build.0 = Release|Any CPU
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x86.ActiveCfg = Release|Any CPU
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D}.Release|x86.Build.0 = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x64.Build.0 = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x64.Deploy.0 = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x86.Build.0 = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Debug|x86.Deploy.0 = Debug|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x64.ActiveCfg = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x64.Build.0 = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x64.Deploy.0 = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x86.ActiveCfg = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x86.Build.0 = Release|Any CPU
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB}.Release|x86.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -474,7 +455,6 @@ Global
 		{8711D306-1118-4A11-9399-EF14AA13015E} = {540CEEC1-D541-4614-BF0B-18056A83E434}
 		{8610485A-BE9F-4938-86D4-E9F1FA1739A0} = {F3664D7A-6FF5-4D1F-9F5F-26EE87F032D3}
 		{0EA416B6-0AB6-464B-9F4D-206FFCFB262D} = {8F959801-D494-4CAF-9437-90F30472E169}
-		{A34FBA36-CFAA-4252-8E32-B64BAD491ACB} = {24639CEB-266D-40E1-B0A8-B78BB6F8CEF8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7433AE2-B1A0-4C1A-887E-5CAA7AAF67A6}

--- a/src/Prism.Core/Navigation/Regions/IRegionBehaviorFactory.cs
+++ b/src/Prism.Core/Navigation/Regions/IRegionBehaviorFactory.cs
@@ -17,6 +17,13 @@ namespace Prism.Navigation.Regions
         void AddIfMissing(string behaviorKey, Type behaviorType);
 
         /// <summary>
+        /// Adds or replaces a particular type of RegionBehavior. the <paramref name="behaviorKey"/> string is used to check if the behavior is already present
+        /// </summary>
+        /// <param name="behaviorKey">The behavior key that's used to find if a certain behavior is already added.</param>
+        /// <param name="behaviorType">Type of the behavior to add.</param>
+        void AddOrReplace(string behaviorKey, Type behaviorType);
+
+        /// <summary>
         /// Determines whether a behavior with the specified key already exists
         /// </summary>
         /// <param name="behaviorKey">The behavior key.</param>

--- a/src/Prism.Core/Navigation/Regions/IRegionBehaviorFactoryExtensions.cs
+++ b/src/Prism.Core/Navigation/Regions/IRegionBehaviorFactoryExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Prism.Navigation.Regions
+namespace Prism.Navigation.Regions
 {
     /// <summary>
     /// Extension methods for the IRegionBehaviorFactory.
@@ -17,6 +17,17 @@
         }
 
         /// <summary>
+        /// Adds or replaces a particular type of RegionBehavior. the Type Name is used to check if the behavior is already present
+        /// </summary>
+        /// <typeparam name="T">Type of the behavior to add.</typeparam>
+        /// <param name="regionBehaviorFactory">The IRegionBehaviorFactory instance</param>
+        public static void AddOrReplace<T>(this IRegionBehaviorFactory regionBehaviorFactory) where T : IRegionBehavior
+        {
+            var behaviorType = typeof(T);
+            regionBehaviorFactory.AddOrReplace(typeof(T).Name, behaviorType);
+        }
+
+        /// <summary>
         /// Adds a particular type of RegionBehavior if it was not already registered. the <paramref name="behaviorKey"/> string is used to check if the behavior is already present
         /// </summary>
         /// <typeparam name="T">Type of the behavior to add.</typeparam>
@@ -26,6 +37,18 @@
         {
             var behaviorType = typeof(T);
             regionBehaviorFactory.AddIfMissing(behaviorKey, behaviorType);
+        }
+
+        /// <summary>
+        /// Adds or replaces a particular type of RegionBehavior. the <paramref name="behaviorKey"/> string is used to check if the behavior is already present
+        /// </summary>
+        /// <typeparam name="T">Type of the behavior to add.</typeparam>
+        /// <param name="regionBehaviorFactory">The IRegionBehaviorFactory instance</param>
+        /// <param name="behaviorKey">The behavior key that's used to find if a certain behavior is already added.</param>
+        public static void AddOrReplace<T>(this IRegionBehaviorFactory regionBehaviorFactory, string behaviorKey) where T : IRegionBehavior
+        {
+            var behaviorType = typeof(T);
+            regionBehaviorFactory.AddOrReplace(behaviorKey, behaviorType);
         }
     }
 }

--- a/src/Prism.Core/Navigation/Regions/RegionBehaviorFactory.cs
+++ b/src/Prism.Core/Navigation/Regions/RegionBehaviorFactory.cs
@@ -59,6 +59,22 @@ namespace Prism.Navigation.Regions
         }
 
         /// <summary>
+        /// Adds or replaces a particular type of RegionBehavior. The <paramref name="behaviorKey"/> string is used to check if the behavior is already present
+        /// </summary>
+        /// <param name="behaviorKey">The behavior key that's used to find if a certain behavior is already added.</param>
+        /// <param name="behaviorType">Type of the behavior to add.</param>
+        public void AddOrReplace(string behaviorKey, Type behaviorType)
+        {
+            if (_registeredBehaviors.ContainsKey(behaviorKey)
+                && _registeredBehaviors[behaviorKey].Equals(behaviorType) == false)
+            {
+                _registeredBehaviors.Remove(behaviorKey);
+            }
+
+            AddIfMissing(behaviorKey, behaviorType);
+        }
+
+        /// <summary>
         /// Creates an instance of the behavior <see cref="Type"/> that is registered using the specified key.
         /// </summary>
         /// <param name="key">The key that is used to register a behavior type.</param>

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionBehaviorFixture.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionBehaviorFixture.cs
@@ -1,0 +1,46 @@
+using Prism.DryIoc.Maui.Tests.Mocks.Regions.Behaviors;
+using Prism.Navigation.Regions.Behaviors;
+
+namespace Prism.DryIoc.Maui.Tests.Fixtures.Regions;
+public class RegionBehaviorFixture : TestBase
+{
+    public RegionBehaviorFixture(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [Fact]
+    public void ExistingBehavior_IsReplaced_WithCustomBehavior()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+            .ConfigureRegionBehaviors(behaviors =>
+            {
+                behaviors.AddOrReplace<RegionBehaviorBMock>(RegionBehaviorAMock.BehaviorKey);
+            }))
+            .Build();
+
+        var regionBehaviorFactory = mauiApp.Services.GetRequiredService<IRegionBehaviorFactory>();
+
+        Assert.NotEmpty(regionBehaviorFactory);
+        Assert.Contains(regionBehaviorFactory, x => x == RegionBehaviorAMock.BehaviorKey);
+        Assert.DoesNotContain(regionBehaviorFactory, x => x == RegionBehaviorBMock.BehaviorKey);
+        Assert.IsType<RegionBehaviorBMock>(regionBehaviorFactory.CreateFromKey(RegionBehaviorAMock.BehaviorKey));
+    }
+
+    [Fact]
+    public void MissingBehavior_IsAdded()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+            .ConfigureRegionBehaviors(behaviors =>
+            {
+                behaviors.AddOrReplace<RegionBehaviorAMock>(RegionBehaviorAMock.BehaviorKey);
+            }))
+            .Build();
+
+        var regionBehaviorFactory = mauiApp.Services.GetRequiredService<IRegionBehaviorFactory>();
+
+        Assert.NotEmpty(regionBehaviorFactory);
+        Assert.Contains(regionBehaviorFactory, x => x == RegionBehaviorAMock.BehaviorKey);
+        Assert.IsType<RegionBehaviorAMock>(regionBehaviorFactory.CreateFromKey(RegionBehaviorAMock.BehaviorKey));
+    }
+}

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/Regions/Behaviors/RegionBehaviorAMock.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/Regions/Behaviors/RegionBehaviorAMock.cs
@@ -1,0 +1,12 @@
+namespace Prism.DryIoc.Maui.Tests.Mocks.Regions.Behaviors;
+internal class RegionBehaviorAMock : RegionBehavior
+{
+    public const string BehaviorKey = "RegionBehaviorAMock";
+    public RegionBehaviorAMock()
+    {
+
+    }
+    protected override void OnAttach()
+    {
+    }
+}

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/Regions/Behaviors/RegionBehaviorBMock.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Mocks/Regions/Behaviors/RegionBehaviorBMock.cs
@@ -1,0 +1,12 @@
+namespace Prism.DryIoc.Maui.Tests.Mocks.Regions.Behaviors;
+internal class RegionBehaviorBMock : RegionBehavior
+{
+    public const string BehaviorKey = "RegionBehaviorBMock";
+    public RegionBehaviorBMock()
+    {
+
+    }
+    protected override void OnAttach()
+    {
+    }
+}

--- a/tests/Wpf/Prism.Wpf.Tests/Mocks/MockRegionBehaviorB.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Mocks/MockRegionBehaviorB.cs
@@ -1,0 +1,21 @@
+using Prism.Navigation.Regions;
+
+namespace Prism.Wpf.Tests.Mocks
+{
+    public class MockRegionBehaviorB : IRegionBehavior
+    {
+        public IRegion Region
+        {
+            get; set;
+        }
+
+        public Func<object> OnAttach;
+
+        public void Attach()
+        {
+            if (OnAttach != null)
+                OnAttach();
+
+        }
+    }
+}

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionBehaviorFactoryFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionBehaviorFactoryFixture.cs
@@ -75,5 +75,38 @@ namespace Prism.Wpf.Tests.Regions
 
         }
 
+        [Fact]
+        public void ExistingBehavior_IsReplaced_WithCustomBehavior()
+        {
+            var expectedBehavior = new MockRegionBehaviorB();
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(c => c.Resolve(typeof(MockRegionBehaviorB))).Returns(expectedBehavior);
+
+            RegionBehaviorFactory factory = new RegionBehaviorFactory(containerMock.Object);
+
+            factory.AddIfMissing<MockRegionBehavior>("key1");
+            factory.AddOrReplaceIfMissing<MockRegionBehaviorB>("key1");
+
+            Assert.Single(factory);
+            Assert.True(factory.ContainsKey("key1"));
+            Assert.IsType<MockRegionBehaviorB>(factory.CreateFromKey("key1"));
+        }
+
+        [Fact]
+        public void MissingBehavior_IsAdded()
+        {
+            var expectedBehavior = new MockRegionBehaviorB();
+            var containerMock = new Mock<IContainerExtension>();
+            containerMock.Setup(c => c.Resolve(typeof(MockRegionBehaviorB))).Returns(expectedBehavior);
+
+            RegionBehaviorFactory factory = new RegionBehaviorFactory(containerMock.Object);
+
+            factory.AddOrReplaceIfMissing<MockRegionBehaviorB>("key1");
+
+            Assert.Single(factory);
+            Assert.True(factory.ContainsKey("key1"));
+            Assert.IsType<MockRegionBehaviorB>(factory.CreateFromKey("key1"));
+        }
+
     }
 }

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionBehaviorFactoryFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionBehaviorFactoryFixture.cs
@@ -85,7 +85,7 @@ namespace Prism.Wpf.Tests.Regions
             RegionBehaviorFactory factory = new RegionBehaviorFactory(containerMock.Object);
 
             factory.AddIfMissing<MockRegionBehavior>("key1");
-            factory.AddOrReplaceIfMissing<MockRegionBehaviorB>("key1");
+            factory.AddOrReplace<MockRegionBehaviorB>("key1");
 
             Assert.Single(factory);
             Assert.True(factory.ContainsKey("key1"));
@@ -101,7 +101,7 @@ namespace Prism.Wpf.Tests.Regions
 
             RegionBehaviorFactory factory = new RegionBehaviorFactory(containerMock.Object);
 
-            factory.AddOrReplaceIfMissing<MockRegionBehaviorB>("key1");
+            factory.AddOrReplace<MockRegionBehaviorB>("key1");
 
             Assert.Single(factory);
             Assert.True(factory.ContainsKey("key1"));


### PR DESCRIPTION
﻿## Description of Change

Added API to replace an existing behavior with a custom behavior(this is already possible for region adapters). 

### Bugs Fixed

- N/a

### API Changes

Added:

- void IRegionBehaviorFactory.AddOrReplace(string behaviorKey, Type behaviorType)


### Behavioral Changes

Existing behaviors can be replaced with custom behaviors.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard