### PR TITLE
Implement NavigateFromAsync method without recreating a page.

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/INavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationService.cs
@@ -41,6 +41,15 @@ public interface INavigationService
     Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters);
 
     /// <summary>
+    /// Initiates navigation from the <paramref name="viewName"/> using the specified <paramref name="route"/>. 
+    /// </summary>
+    /// <param name="viewName">The name of the View to navigate from</param>
+    /// <param name="route">The route Uri to navigate from that view</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns>If <c>true</c> a navigate from operation was successful. If <c>false</c> the navigate from operation failed.</returns>
+    Task<INavigationResult> NavigateFromAsync(string viewName, Uri route, INavigationParameters parameters);
+
+    /// <summary>
     /// Selects a Tab of the TabbedPage parent and Navigates to a specified Uri
     /// </summary>
     /// <param name="name">The name of the tab to select</param>

--- a/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Maui/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -107,6 +107,15 @@ public static class INavigationServiceExtensions
     }
 
     /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="viewName"/> from the <paramref name="route"/>. 
+    /// </summary>
+    /// <param name="viewName">The name of the View to navigate to</param>
+    /// <param name="route">The route Uri to navigate to</param>
+    /// <returns>If <c>true</c> a navigate from operation was successful. If <c>false</c> the navigate from operation failed.</returns>
+    public static Task<INavigationResult> NavigateFromAsync(this INavigationService navigationService, string viewName, Uri route) =>
+        navigationService.NavigateFromAsync(viewName, route, new NavigationParameters());
+
+    /// <summary>
     /// Provides an easy to use way to provide an Error Callback without using await NavigationService
     /// </summary>
     /// <param name="navigationTask">The current Navigation Task</param>

--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -346,19 +346,16 @@ public class PageNavigationService : INavigationService, IRegistryAware
 
             var routeSegments = UriParsingHelper.GetUriSegments(route);
 
-            var page = GetPageFromWindow();
-            if (page is not null && ViewModelLocator.GetNavigationName(page) == viewName)
+            // Find a page that matches the viewName.
+            var page = GetCurrentPage();
+            while (page != null)
             {
-                await ProcessNavigation(page, routeSegments, parameters, null, null);
+                if (page is not null && ViewModelLocator.GetNavigationName(page) == viewName)
+                    break;
+                page = page.GetParentPage();
             }
-            else
-            {
-                var viewNameSegment = new Queue<string>();
-                viewNameSegment.Enqueue(viewName);
-                var navigationSegments = new Queue<string>(viewNameSegment.Concat(routeSegments));
 
-                await ProcessNavigationForAbsoluteUri(navigationSegments, parameters, null, null);
-            }
+            await ProcessNavigation(page, routeSegments, parameters, null, null);
 
             return Notify(route, parameters);
         }

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -510,59 +510,54 @@ public class NavigationTests : TestBase
     }
 
     [Fact]
-    public async Task Navigation_FromPageUsingRoot()
+    public async Task Navigation_FromPageUsingRoute()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockHome/NavigationPage/MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
-        Assert.IsAssignableFrom<MockHome>(window.Page);
-        var rootPage = (MockHome)window.Page;
-        Assert.NotNull(rootPage);
+        var pageNavigatingFrom = (MockHome)window.Page;
+        var navigationPage = (NavigationPage)pageNavigatingFrom.Detail;
+        Assert.IsType<MockViewA>(navigationPage.CurrentPage);
 
-        Assert.NotNull(rootPage.Detail);
-        Assert.IsAssignableFrom<NavigationPage>(rootPage.Detail);
-        var navigatingPage = (NavigationPage)rootPage.Detail;
-        Assert.NotNull(navigatingPage);
-        Assert.IsType<MockViewA>(navigatingPage.CurrentPage);
-
-        var result = await navigatingPage.CurrentPage.GetContainerProvider()
+        var result = await navigationPage.CurrentPage.GetContainerProvider()
             .Resolve<INavigationService>()
             .NavigateFromAsync("MockHome", UriParsingHelper.Parse("NavigationPage/MockViewB"), null);
 
         Assert.True(result.Success);
 
-        Assert.NotNull(rootPage.Detail);
-        var navigatedPage = (NavigationPage)rootPage.Detail;
-        Assert.IsType<MockViewB>(navigatedPage.CurrentPage);
+        // MockHome(FlyoutPage) has not been replaced.
+        var pageNavigatedFrom = (MockHome)window.Page;
+        Assert.Equal(pageNavigatingFrom, pageNavigatedFrom);
+
+        // Navigation should be succeeded.
+        navigationPage = (NavigationPage)pageNavigatedFrom.Detail;
+        Assert.IsType<MockViewB>(navigationPage.CurrentPage);
     }
 
     [Fact]
-    public async Task Navigation_FromNotRootPageUsingRoot()
+    public async Task Navigation_FromIntermediatePageUsingRoute()
     {
         var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockHome/NavigationPage/MockViewA"))
             .Build();
         var window = GetWindow(mauiApp);
 
-        Assert.IsAssignableFrom<MockHome>(window.Page);
-        var rootPage = (MockHome)window.Page;
-        Assert.NotNull(rootPage);
+        var mockHome = (MockHome)window.Page;
+        var pageNavigatingFrom = (NavigationPage)mockHome.Detail;
+        Assert.IsType<MockViewA>(pageNavigatingFrom.CurrentPage);
 
-        Assert.NotNull(rootPage.Detail);
-        Assert.IsAssignableFrom<NavigationPage>(rootPage.Detail);
-        var navigatingPage = (NavigationPage)rootPage.Detail;
-        Assert.NotNull(navigatingPage);
-        Assert.IsType<MockViewA>(navigatingPage.CurrentPage);
-
-        var result = await navigatingPage.CurrentPage.GetContainerProvider()
+        var result = await pageNavigatingFrom.CurrentPage.GetContainerProvider()
             .Resolve<INavigationService>()
             .NavigateFromAsync("NavigationPage", UriParsingHelper.Parse("MockViewB"), null);
 
         Assert.True(result.Success);
 
-        Assert.NotNull(rootPage.Detail);
-        var navigatedPage = (NavigationPage)rootPage.Detail;
-        Assert.IsType<MockViewB>(navigatedPage.CurrentPage);
+        // NavigationPage has not been replaced.
+        var pageNavigatedFrom = (NavigationPage)mockHome.Detail;
+        Assert.Equal(pageNavigatingFrom, pageNavigatedFrom); 
+
+        // Navigation should be succeeded.
+        Assert.IsType<MockViewB>(pageNavigatedFrom.CurrentPage);
     }
 
     [Theory]

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -509,6 +509,62 @@ public class NavigationTests : TestBase
         Assert.False(push.Animated);
     }
 
+    [Fact]
+    public async Task Navigation_FromPageUsingRoot()
+    {
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockHome/NavigationPage/MockViewA"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        Assert.IsAssignableFrom<MockHome>(window.Page);
+        var rootPage = (MockHome)window.Page;
+        Assert.NotNull(rootPage);
+
+        Assert.NotNull(rootPage.Detail);
+        Assert.IsAssignableFrom<NavigationPage>(rootPage.Detail);
+        var navigatingPage = (NavigationPage)rootPage.Detail;
+        Assert.NotNull(navigatingPage);
+        Assert.IsType<MockViewA>(navigatingPage.CurrentPage);
+
+        var result = await navigatingPage.CurrentPage.GetContainerProvider()
+            .Resolve<INavigationService>()
+            .NavigateFromAsync("MockHome", UriParsingHelper.Parse("NavigationPage/MockViewB"), null);
+
+        Assert.True(result.Success);
+
+        Assert.NotNull(rootPage.Detail);
+        var navigatedPage = (NavigationPage)rootPage.Detail;
+        Assert.IsType<MockViewB>(navigatedPage.CurrentPage);
+    }
+
+    [Fact]
+    public async Task Navigation_FromNotRootPageUsingRoot()
+    {
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow("MockHome/NavigationPage/MockViewA"))
+            .Build();
+        var window = GetWindow(mauiApp);
+
+        Assert.IsAssignableFrom<MockHome>(window.Page);
+        var rootPage = (MockHome)window.Page;
+        Assert.NotNull(rootPage);
+
+        Assert.NotNull(rootPage.Detail);
+        Assert.IsAssignableFrom<NavigationPage>(rootPage.Detail);
+        var navigatingPage = (NavigationPage)rootPage.Detail;
+        Assert.NotNull(navigatingPage);
+        Assert.IsType<MockViewA>(navigatingPage.CurrentPage);
+
+        var result = await navigatingPage.CurrentPage.GetContainerProvider()
+            .Resolve<INavigationService>()
+            .NavigateFromAsync("NavigationPage", UriParsingHelper.Parse("MockViewB"), null);
+
+        Assert.True(result.Success);
+
+        Assert.NotNull(rootPage.Detail);
+        var navigatedPage = (NavigationPage)rootPage.Detail;
+        Assert.IsType<MockViewB>(navigatedPage.CurrentPage);
+    }
+
     [Theory]
     [InlineData("MockViewA", "MockViewB", null)]
     [InlineData("NavigationPage/MockViewA", "MockViewB?useModalNavigation=true", true)]


### PR DESCRIPTION
﻿## Description of Change

Adding NavigateFromAsync methods without recreating a page.

### Bugs Fixed

- fixes https://github.com/PrismLibrary/Prism/issues/3118

### API Changes

List all API changes here (or just put None), example:

Added:

- Task<INavigationResult> INavigationService.NavigateFromAsync(string viewName, Uri route, INavigationParameters parameters);
- Task<INavigationResult> INavigationServiceExtensions.NavigateFromAsync(this INavigationService navigationService, string viewName, Uri route)

### Behavioral Changes

No changes. Only additions of features.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard