### PR TITLE
Configure TabbedPage Title

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/Builder/ITabbedSegmentBuilder.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/ITabbedSegmentBuilder.cs
@@ -18,6 +18,13 @@ public interface ITabbedSegmentBuilder
     /// <param name="segmentName">The name of the tab to select.</param>
     /// <returns>The current instance of the <see cref="ITabbedSegmentBuilder"/>.</returns>
     ITabbedSegmentBuilder SelectedTab(string segmentName);
+    
+    /// <summary>
+    /// Sets the tabbed page title
+    /// </summary>
+    /// <param name="title">The title of the tabbed page.</param>
+    /// <returns>The current instance of the <see cref="ITabbedSegmentBuilder"/>.</returns>
+    ITabbedSegmentBuilder Title(string title);
 
     /// <summary>
     /// Adds a parameter to the current tab segment.

--- a/src/Maui/Prism.Maui/Navigation/Builder/TabbedSegmentBuilder.cs
+++ b/src/Maui/Prism.Maui/Navigation/Builder/TabbedSegmentBuilder.cs
@@ -73,6 +73,11 @@ internal class TabbedSegmentBuilder : ITabbedSegmentBuilder, IConfigurableSegmen
         return AddSegmentParameter(KnownNavigationParameters.SelectedTab, segmentName);
     }
 
+    public ITabbedSegmentBuilder Title(string title)
+    {
+        return AddSegmentParameter(KnownNavigationParameters.Title, title);
+    }
+
     private string BuildSegment()
     {
         if (!_parameters.Any())

--- a/src/Maui/Prism.Maui/Navigation/KnownNavigationParameters.cs
+++ b/src/Maui/Prism.Maui/Navigation/KnownNavigationParameters.cs
@@ -11,6 +11,11 @@ public static class KnownNavigationParameters
     /// Used to select an existing Tab when navigating to a TabbedPage.
     /// </summary>
     public const string SelectedTab = "selectedTab";
+    
+    /// <summary>
+    /// Used to set the title to a TabbedPage.
+    /// </summary>
+    public const string Title = "title";
 
     /// <summary>
     /// Used to control the navigation stack. If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync.

--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -928,6 +928,10 @@ public class PageNavigationService : INavigationService, IRegistryAware
     {
         var tabParameters = UriParsingHelper.GetSegmentParameters(segment, parameters);
 
+        if (tabParameters.GetValue<string>(KnownNavigationParameters.Title) is string title)
+        {
+            tabbedPage.Title = title;
+        }
         var tabsToCreate = tabParameters.GetValues<string>(KnownNavigationParameters.CreateTab);
         foreach (var tabToCreateEncoded in tabsToCreate ?? Array.Empty<string>())
         {

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/DynamicTabbedPageNavigationFixture.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/DynamicTabbedPageNavigationFixture.cs
@@ -29,6 +29,26 @@ public class DynamicTabbedPageNavigationFixture : TestBase
 
         Assert.Same(tabbedPage.Children[0], tabbedPage.CurrentPage);
     }
+    
+    [Fact]
+    public void CreatesTab_WithTitleAndSingleContentPage()
+    {
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow(navigation =>
+            navigation.CreateBuilder()
+                .AddTabbedSegment(t =>
+                {
+                    t.Title("MyTitle");
+                    t.CreateTab("MockViewA");
+                })
+                .NavigateAsync())).Build();
+        
+        var window = GetWindow(mauiApp);
+        Assert.IsType<TabbedPage>(window.Page);
+        var tabbedPage = (TabbedPage)window.Page;
+        Assert.Single(tabbedPage.Children);
+        Assert.IsType<MockViewA>(tabbedPage.Children[0]);
+        Assert.Equal("MyTitle", window.Page.Title);
+    }
 
     [Fact]
     public void CreatesTabs_WithNavigationPageAndContentPage()
@@ -52,6 +72,36 @@ public class DynamicTabbedPageNavigationFixture : TestBase
         Assert.IsType<MockViewB>(tab1.CurrentPage);
 
         Assert.Same(tabbedPage.Children[0], tabbedPage.CurrentPage);
+    }
+    
+    [Fact]
+    public void CreatesTabs_WithNavigationPageAndContentPageTitlesSet()
+    {
+        var mauiApp = CreateBuilder(prism => prism.CreateWindow(navigation =>
+            navigation.CreateBuilder()
+                .AddTabbedSegment(t =>
+                {
+                    t.Title("MyTitle");
+                    t.CreateTab(ct => ct.AddNavigationPage().AddSegment("MockViewA"))
+                        .CreateTab(ct => ct.AddNavigationPage().AddSegment("MockViewB"));
+                })
+                .NavigateAsync())).Build();
+        var window = GetWindow(mauiApp);
+        Assert.IsType<TabbedPage>(window.Page);
+        var tabbedPage = (TabbedPage)window.Page;
+
+        Assert.Equal(2, tabbedPage.Children.Count);
+        Assert.IsType<PrismNavigationPage>(tabbedPage.Children[0]);
+        var tab0 = (NavigationPage)tabbedPage.Children[0];
+        Assert.IsType<MockViewA>(tab0.CurrentPage);
+        Assert.IsType<PrismNavigationPage>(tabbedPage.Children[1]);
+        var tab1 = (NavigationPage)tabbedPage.Children[1];
+        Assert.IsType<MockViewB>(tab1.CurrentPage);
+
+        Assert.Same(tabbedPage.Children[0], tabbedPage.CurrentPage);
+        Assert.Equal("MyTitle", tabbedPage.Title);
+        Assert.Equal(MockViewA.ExpectedTitle, tab0.Title);
+        Assert.Equal(MockViewB.ExpectedTitle, tab1.Title);
     }
 
     [Fact]

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -414,6 +414,53 @@ public class NavigationTests : TestBase
         Assert.Equal(navPage.Title, navPage.RootPage.Title);
         Assert.Equal(MockViewA.ExpectedTitle, navPage.Title);
     }
+    
+    [Fact]
+    public async Task NavigationPage_UsesTabbedPageTitle()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+                .CreateWindow(n => n.CreateBuilder()
+                    .AddNavigationPage()
+                    .AddTabbedSegment(s => s
+                        .CreateTab("MockViewA"))
+                    .NavigateAsync()))
+            .Build();
+        
+        var window = GetWindow(mauiApp);
+        Assert.IsAssignableFrom<NavigationPage>(window.Page);
+        var navPage = window.Page as NavigationPage;
+        Assert.IsAssignableFrom<TabbedPage>(navPage.RootPage);
+        var tabbed = navPage.RootPage as TabbedPage;
+
+        Assert.NotNull(tabbed);
+        Assert.Single(tabbed.Children);
+        Assert.Equal(navPage.Title, tabbed.Title);
+    }
+    
+    [Fact]
+    public async Task NavigationPage_OverrideTabbedPageTitle()
+    {
+        var mauiApp = CreateBuilder(prism => prism
+                .CreateWindow(n => n.CreateBuilder()
+                    .AddNavigationPage()
+                    .AddTabbedSegment(s =>
+                        {
+                            s.CreateTab("MockViewA");
+                            s.Title("MyTitle");
+                        })
+                    .NavigateAsync()))
+            .Build();
+        
+        var window = GetWindow(mauiApp);
+        Assert.IsAssignableFrom<NavigationPage>(window.Page);
+        var navPage = window.Page as NavigationPage;
+        Assert.IsAssignableFrom<TabbedPage>(navPage.RootPage);
+        var tabbed = navPage.RootPage as TabbedPage;
+
+        Assert.NotNull(tabbed);
+        Assert.Single(tabbed.Children);
+        Assert.Equal("MyTitle", tabbed.Title);
+    }
 
     [Fact]
     public async Task Navigation_HasDefault_AnimatedIsNull()

--- a/tests/Maui/Prism.Maui.Tests/Fixtures/Navigation/NavigationBuilderFixture.cs
+++ b/tests/Maui/Prism.Maui.Tests/Fixtures/Navigation/NavigationBuilderFixture.cs
@@ -83,6 +83,53 @@ public class NavigationBuilderFixture
 
         Assert.Equal("TabbedPage?createTab=ViewA&createTab=ViewB&createTab=ViewC", uri.ToString());
     }
+    
+    [Fact]
+    public void GeneratesTabbedPageUriWithTitle()
+    {
+        var container = new TestContainer();
+        container.RegisterForNavigation<TabbedPage>();
+
+        var navigationService = new Mock<INavigationService>();
+        navigationService
+            .As<IRegistryAware>()
+            .Setup(x => x.Registry)
+            .Returns(container.Resolve<NavigationRegistry>());
+        var uri = navigationService.Object
+            .CreateBuilder()
+            .AddTabbedSegment(b =>
+            {
+                b.Title("MyTitle");
+            })
+            .Uri;
+
+        Assert.Equal("TabbedPage?title=MyTitle", uri.ToString());
+    }
+    
+    [Fact]
+    public void GeneratesTabbedPageUriWithCreatedTabsWithTitle()
+    {
+        var container = new TestContainer();
+        container.RegisterForNavigation<TabbedPage>();
+
+        var navigationService = new Mock<INavigationService>();
+        navigationService
+            .As<IRegistryAware>()
+            .Setup(x => x.Registry)
+            .Returns(container.Resolve<NavigationRegistry>());
+        var uri = navigationService.Object
+            .CreateBuilder()
+            .AddTabbedSegment(b =>
+            {
+                b.CreateTab("ViewA")
+                    .CreateTab("ViewB")
+                    .CreateTab("ViewC");
+                b.Title("MyTitle");
+            })
+            .Uri;
+
+        Assert.Equal("TabbedPage?createTab=ViewA&createTab=ViewB&createTab=ViewC&title=MyTitle", uri.ToString());
+    }
 
     [Fact]
     public void GeneratesTabbedPageUriWithCreatedTabsWithParameters()
@@ -114,6 +161,39 @@ public class NavigationBuilderFixture
         Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewA?id=5");
         Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewB?foo=bar");
     }
+    
+    [Fact]
+    public void GeneratesTabbedPageUriWithCreatedTabsWithParametersWithTitle()
+    {
+        var container = new TestContainer();
+        container.RegisterForNavigation<TabbedPage>();
+
+        var navigationService = new Mock<INavigationService>();
+        navigationService
+            .As<IRegistryAware>()
+            .Setup(x => x.Registry)
+            .Returns(container.Resolve<NavigationRegistry>());
+        var uri = navigationService.Object
+            .CreateBuilder()
+            .AddTabbedSegment(b =>
+            {
+                b.CreateTab("ViewA", t => t.AddParameter("id", 5))
+                    .CreateTab("ViewB", t => t.AddParameter("foo", "bar"))
+                    .CreateTab("ViewC");
+                b.Title("MyTitle");
+            })
+            .Uri;
+
+        Assert.Equal("TabbedPage?createTab=ViewA%3Fid%3D5&createTab=ViewB%3Ffoo%3Dbar&createTab=ViewC&title=MyTitle", uri.ToString());
+
+        var parameters = UriParsingHelper.GetSegmentParameters(uri.ToString());
+        Assert.Equal(4, parameters.Count);
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.CreateTab));
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.Title));
+
+        Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewA?id=5");
+        Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewB?foo=bar");
+    }
 
     [Fact]
     public void GeneratesCustomTabbedPageUriWithCreatedTabs()
@@ -138,6 +218,29 @@ public class NavigationBuilderFixture
             .Uri;
 
         Assert.Equal("TabbedPageEmptyMock?createTab=ViewA&createTab=ViewB&createTab=ViewC", uri.ToString());
+    }
+    
+    [Fact]
+    public void GeneratesCustomTabbedPageUriWithTitle()
+    {
+        var container = new TestContainer();
+        container.RegisterForNavigation<TabbedPage>();
+        container.RegisterForNavigation<TabbedPageEmptyMock>();
+
+        var navigationService = new Mock<INavigationService>();
+        navigationService
+            .As<IRegistryAware>()
+            .Setup(x => x.Registry)
+            .Returns(container.Resolve<NavigationRegistry>());
+        var uri = navigationService.Object
+            .CreateBuilder()
+            .AddTabbedSegment("TabbedPageEmptyMock", b =>
+            {
+                b.Title("MyTitle");
+            })
+            .Uri;
+
+        Assert.Equal("TabbedPageEmptyMock?title=MyTitle", uri.ToString());
     }
 
     [Fact]
@@ -167,6 +270,40 @@ public class NavigationBuilderFixture
         var parameters = UriParsingHelper.GetSegmentParameters(uri.ToString());
         Assert.Equal(3, parameters.Count);
         Assert.True(parameters.All(x => x.Key == KnownNavigationParameters.CreateTab));
+
+        Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewA?id=5");
+        Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewB?foo=bar");
+    }
+    
+    [Fact]
+    public void GeneratesCustomTabbedPageUriWithCreatedTabsWithTitleWithParameters()
+    {
+        var container = new TestContainer();
+        container.RegisterForNavigation<TabbedPage>();
+        container.RegisterForNavigation<TabbedPageEmptyMock>();
+
+        var navigationService = new Mock<INavigationService>();
+        navigationService
+            .As<IRegistryAware>()
+            .Setup(x => x.Registry)
+            .Returns(container.Resolve<NavigationRegistry>());
+        var uri = navigationService.Object
+            .CreateBuilder()
+            .AddTabbedSegment("TabbedPageEmptyMock", b =>
+            {
+                b.CreateTab("ViewA", t => t.AddParameter("id", 5))
+                    .CreateTab("ViewB", t => t.AddParameter("foo", "bar"))
+                    .CreateTab("ViewC");
+                b.Title("MyTitle");
+            })
+            .Uri;
+
+        Assert.Equal("TabbedPageEmptyMock?createTab=ViewA%3Fid%3D5&createTab=ViewB%3Ffoo%3Dbar&createTab=ViewC&title=MyTitle", uri.ToString());
+
+        var parameters = UriParsingHelper.GetSegmentParameters(uri.ToString());
+        Assert.Equal(4, parameters.Count);
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.CreateTab));
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.Title));
 
         Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewA?id=5");
         Assert.Contains(parameters, x => HttpUtility.UrlDecode(x.Value.ToString()) == "ViewB?foo=bar");

--- a/tests/Maui/Prism.Maui.Tests/Fixtures/PageNavigationServiceFixture.cs
+++ b/tests/Maui/Prism.Maui.Tests/Fixtures/PageNavigationServiceFixture.cs
@@ -1499,6 +1499,36 @@ namespace Prism.Maui.Tests.Navigation
             Assert.NotNull(tabbedPage.CurrentPage);
             Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
         }
+        
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_WithTitleWithSelectedTab()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _app);
+            var rootPage = new ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.SelectedTab}=Tab2&{KnownNavigationParameters.Title}=MyTitle");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.NotNull(tabbedPage.CurrentPage);
+            Assert.IsType<Tab2Mock>(tabbedPage.CurrentPage);
+            Assert.Equal("MyTitle", tabbedPage.Title);
+        }
+        
+        [Fact]
+        public async void Navigate_FromContentPage_ToTabbedPage_WithTitle()
+        {
+            var navigationService = new PageNavigationServiceMock(_container, _app);
+            var rootPage = new ContentPage();
+            ((IPageAware)navigationService).Page = rootPage;
+
+            await navigationService.NavigateAsync($"TabbedPage?{KnownNavigationParameters.Title}=MyTitle");
+
+            var tabbedPage = rootPage.Navigation.ModalStack[0] as TabbedPageMock;
+            Assert.NotNull(tabbedPage);
+            Assert.Equal("MyTitle", tabbedPage.Title);
+        }
 
         [Fact]
         public async void Navigate_FromContentPage_ToTabbedPage_SelectedTab_NavigationPage()


### PR DESCRIPTION
﻿## Description of Change

Configure `TabbedPage.Title`
#3188

### API Changes

Added:

- ITabbedSegmentBuilder ITabbedSegmentBuilder.Title();
- string KnownNavigationParameters.Title

### Behavioral Changes

The `Title` of dynamically created `TabbedPagges` is now configurable through the builder.

### PR Checklist

- [x] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard