### PR TITLE
Modularity Fix

### DIFF
--- a/src/Maui/Prism.Maui/Modularity/ModuleCatalog.cs
+++ b/src/Maui/Prism.Maui/Modularity/ModuleCatalog.cs
@@ -10,7 +10,7 @@ namespace Prism.Modularity;
 #else
 [ContentProperty(nameof(Items))]
 #endif
-public class ModuleCatalog : ModuleCatalogBase
+public class ModuleCatalog(IEnumerable<IModuleInfo> modules) : ModuleCatalogBase(modules)
 {
 
 }

--- a/src/Maui/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilder.cs
@@ -205,14 +205,20 @@ public sealed class PrismAppBuilder
         {
             try
             {
+                logger.LogDebug("Initializing modules.");
                 var manager = _container.Resolve<IModuleManager>();
                 manager.Run();
+                logger.LogDebug("Modules Initialized.");
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "An error ocurred while initializing the Modules.");
                 throw new PrismInitializationException("An error occurred while initializing the Modules.", ex);
             }
+        }
+        else
+        {
+            logger.LogDebug("No Modules found to initialize.");
         }
 
         var navRegistry = _container.Resolve<INavigationRegistry>();

--- a/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -11,8 +11,6 @@ namespace Prism;
 /// </summary>
 public static class PrismAppBuilderExtensions
 {
-    private static bool s_didRegisterModules = false;
-
     /// <summary>
     /// Configures the <see cref="MauiAppBuilder"/> to use Prism with a callback for the <see cref="PrismAppBuilder"/>
     /// </summary>
@@ -45,17 +43,13 @@ public static class PrismAppBuilderExtensions
     /// <param name="configureCatalog">Delegate to configure the <see cref="IModuleCatalog"/>.</param>
     public static PrismAppBuilder ConfigureModuleCatalog(this PrismAppBuilder builder, Action<IModuleCatalog> configureCatalog)
     {
-        if (!s_didRegisterModules)
+        builder.RegisterTypes(container =>
         {
-            builder.RegisterTypes(container =>
-            {
-                container.TryRegisterSingleton<IModuleCatalog, ModuleCatalog>();
-                container.TryRegisterSingleton<IModuleManager, ModuleManager>();
-                container.TryRegisterSingleton<IModuleInitializer, ModuleInitializer>();
-            });
-        }
+            container.TryRegisterSingleton<IModuleCatalog, ModuleCatalog>();
+            container.TryRegisterSingleton<IModuleManager, ModuleManager>();
+            container.TryRegisterSingleton<IModuleInitializer, ModuleInitializer>();
+        });
 
-        s_didRegisterModules = true;
         return builder.OnInitialized(container =>
         {
             var moduleCatalog = container.Resolve<IModuleCatalog>();

--- a/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Maui/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -47,10 +47,12 @@ public static class PrismAppBuilderExtensions
     {
         if (!s_didRegisterModules)
         {
-            var services = builder.MauiBuilder.Services;
-            services.AddSingleton<IModuleCatalog, ModuleCatalog>();
-            services.AddSingleton<IModuleManager, ModuleManager>();
-            services.AddSingleton<IModuleInitializer, ModuleInitializer>();
+            builder.RegisterTypes(container =>
+            {
+                container.TryRegisterSingleton<IModuleCatalog, ModuleCatalog>();
+                container.TryRegisterSingleton<IModuleManager, ModuleManager>();
+                container.TryRegisterSingleton<IModuleInitializer, ModuleInitializer>();
+            });
         }
 
         s_didRegisterModules = true;

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Modularity/ModuleCatalogTests.cs
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Fixtures/Modularity/ModuleCatalogTests.cs
@@ -1,0 +1,61 @@
+namespace Prism.DryIoc.Maui.Tests.Fixtures.Modularity;
+
+public class ModuleCatalogTests(ITestOutputHelper testOutputHelper) : TestBase(testOutputHelper)
+{
+    public readonly IModuleInfo ModuleA = new ModuleInfo(typeof(MockModuleA));
+
+    [Fact]
+    public void UsesCustomModuleCatalog()
+    {
+        var builder = CreateBuilder(prism =>
+        {
+            prism.RegisterTypes(c => c.RegisterSingleton<IModuleCatalog, CustomMoudleCatalog>())
+                 .ConfigureModuleCatalog(catalog => { });
+        });
+        var app = builder.Build();
+
+        var moduleCatalog = app.Services.GetService<IModuleCatalog>();
+        Assert.NotNull(moduleCatalog);
+        Assert.IsType<CustomMoudleCatalog>(moduleCatalog);
+    }
+
+    [Fact]
+    public void InjectsModulesFromDI()
+    {
+        var builder = CreateBuilder(prism =>
+        {
+            prism.RegisterTypes(c => c.RegisterInstance<IModuleInfo>(ModuleA))
+                 .ConfigureModuleCatalog(c => { });
+        });
+        var app = builder.Build();
+
+        var moduleCatalog = app.Services.GetService<IModuleCatalog>();
+        Assert.Single(moduleCatalog.Modules);
+        Assert.Equal(ModuleA.ModuleType, moduleCatalog.Modules.Single().ModuleType);
+    }
+
+    [Fact]
+    public void InjectsModulesFromConfigureDelegate()
+    {
+        var builder = CreateBuilder(prism =>
+            prism.ConfigureModuleCatalog(c => c.AddModule<MockModuleA>()));
+        var app = builder.Build();
+
+        var moduleCatalog = app.Services.GetService<IModuleCatalog>();
+        Assert.Single(moduleCatalog.Modules);
+        Assert.Equal(ModuleA.ModuleType, moduleCatalog.Modules.Single().ModuleType);
+    }
+
+    public class CustomMoudleCatalog : ModuleCatalogBase { }
+
+    public class MockModuleA : IModule
+    {
+        public void OnInitialized(IContainerProvider containerProvider)
+        {
+        }
+
+        public void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+        }
+    }
+}


### PR DESCRIPTION
﻿## Description of Change

This updates the registration logic for the Modules to avoid a static registration flag. This now is updated to use TryRegister.

This also updates the ModuleCatalog for MAUI/Uno to use a constructor that takes an `IEnumerable<IModuleInfo>` thus allowing instances of `IModuleInfo` to be registered with the container and later injected into the ModuleCatalog. *NOTE* you still need to call ConfigureModuleCatalog or register the services yourself if you prefer to use DI

### Bugs Fixed

- Unit Tests fail on reinitialization due to the static flag still being true.

### API Changes

- default ctor -> (IEnumerable<IModuleInfo>)

### Behavioral Changes

IModuleInfo can now be injected with DI into the ModuleCatalog on MAUI and Uno. This was not applied to WPF as we are still shipping Unity Container which does not support this.