### PR TITLE
Adding support for DefaultView property

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/Regions/Behaviors/AutoPopulateRegionBehavior.cs
+++ b/src/Maui/Prism.Maui/Navigation/Regions/Behaviors/AutoPopulateRegionBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Prism.Ioc;
 
 namespace Prism.Navigation.Regions.Behaviors;
@@ -61,7 +61,7 @@ public class AutoPopulateRegionBehavior : RegionBehavior
                 var registration = registry.Registrations.FirstOrDefault(x => x.View == type);
                 if (registration is not null)
                 {
-                    var view = registry.CreateView(container, registration.Name) as VisualElement;
+                    var view = registry.CreateView(container, registration.Name);
                     Region.Add(view);
                 }
             }

--- a/src/Uno/Prism.Uno/Navigation/Regions/NavigationViewRegionAdapter.cs
+++ b/src/Uno/Prism.Uno/Navigation/Regions/NavigationViewRegionAdapter.cs
@@ -27,8 +27,8 @@ public sealed class NavigationViewRegionAdapter : RegionAdapterBase<NavigationVi
         };
     }
 
-    protected override IRegion CreateRegion()
+    protected override IRegion CreateRegion(object regionTarget)
     {
-        return new SingleActiveRegion();
+        return new SingleActiveRegion(regionTarget);
     }
 }

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/AllActiveRegion.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/AllActiveRegion.cs
@@ -5,7 +5,7 @@ namespace Prism.Navigation.Regions
     /// <summary>
     /// Region that keeps all the views in it as active. Deactivation of views is not allowed.
     /// </summary>
-    public class AllActiveRegion : Region
+    public class AllActiveRegion(object target) : Region(target)
     {
         /// <summary>
         /// Gets a readonly view of the collection of all the active views in the region. These are all the added views.

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/AutoPopulateRegionBehavior.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Behaviors/AutoPopulateRegionBehavior.cs
@@ -44,6 +44,22 @@ namespace Prism.Navigation.Regions.Behaviors
                 AddViewIntoRegion(view);
             }
 
+            if (Region is ITargetAwareRegion targetAware && targetAware.Target is FrameworkElement target 
+                && target.GetValue(RegionManager.DefaultViewProperty) != null)
+            {
+                var defaultView = target.GetValue(RegionManager.DefaultViewProperty);
+                if (defaultView is string targetName)
+                    Region.Add(targetName);
+                else if (defaultView is UIElement element)
+                    Region.Add(element);
+                else if (defaultView is Type type)
+                {
+                    var container = ContainerLocator.Container;
+                    var view = container.Resolve(type);
+                    Region.Add(view);
+                }
+            }
+
             regionViewRegistry.ContentRegistered += OnViewRegistered;
         }
 

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/ContentControlRegionAdapter.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/ContentControlRegionAdapter.cs
@@ -53,9 +53,9 @@ namespace Prism.Navigation.Regions
         /// Creates a new instance of <see cref="SingleActiveRegion"/>.
         /// </summary>
         /// <returns>A new instance of <see cref="SingleActiveRegion"/>.</returns>
-        protected override IRegion CreateRegion()
+        protected override IRegion CreateRegion(object regionTarget)
         {
-            return new SingleActiveRegion();
+            return new SingleActiveRegion(regionTarget);
         }
     }
 }

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/ITargetAwareRegion.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/ITargetAwareRegion.cs
@@ -1,0 +1,6 @@
+namespace Prism.Navigation.Regions;
+
+public interface ITargetAwareRegion : IRegion
+{
+    object Target { get; }
+}

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/ItemsControlRegionAdapter.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/ItemsControlRegionAdapter.cs
@@ -56,9 +56,9 @@ namespace Prism.Navigation.Regions
         /// Creates a new instance of <see cref="AllActiveRegion"/>.
         /// </summary>
         /// <returns>A new instance of <see cref="AllActiveRegion"/>.</returns>
-        protected override IRegion CreateRegion()
+        protected override IRegion CreateRegion(object regionTarget)
         {
-            return new AllActiveRegion();
+            return new AllActiveRegion(regionTarget);
         }
     }
 }

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/Region.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/Region.cs
@@ -8,7 +8,7 @@ namespace Prism.Navigation.Regions
     /// <summary>
     /// Implementation of <see cref="IRegion"/> that allows multiple active views.
     /// </summary>
-    public class Region : IRegion
+    public class Region : ITargetAwareRegion
     {
         private ObservableCollection<ItemMetadata> _itemMetadataCollection;
         private string _name;
@@ -23,12 +23,19 @@ namespace Prism.Navigation.Regions
         /// <summary>
         /// Initializes a new instance of <see cref="Region"/>.
         /// </summary>
-        public Region()
+        /// <param name="target">The target view of the Region</param>
+        public Region(object target)
         {
             Behaviors = new RegionBehaviorCollection(this);
+            Target = target;
 
             _sort = DefaultSortComparison;
         }
+
+        /// <summary>
+        /// Gets the target view of the Region.
+        /// </summary>
+        public object Target { get; }
 
         /// <summary>
         /// Occurs when a property value changes.

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionAdapterBase.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionAdapterBase.cs
@@ -35,7 +35,7 @@ namespace Prism.Navigation.Regions
             if (regionName == null)
                 throw new ArgumentNullException(nameof(regionName));
 
-            IRegion region = CreateRegion();
+            IRegion region = CreateRegion(regionTarget);
             region.Name = regionName;
 
             SetObservableRegionOnHostingControl(region, regionTarget);
@@ -121,7 +121,7 @@ namespace Prism.Navigation.Regions
         /// that will be used to adapt the object.
         /// </summary>
         /// <returns>A new instance of <see cref="IRegion"/>.</returns>
-        protected abstract IRegion CreateRegion();
+        protected abstract IRegion CreateRegion(object regionTarget);
 
         private static T GetCastedObject(object regionTarget)
         {

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/RegionManager.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/RegionManager.cs
@@ -67,6 +67,40 @@ namespace Prism.Navigation.Regions
             return regionTarget.GetValue(RegionNameProperty) as string;
         }
 
+        /// <summary>
+        /// Sets the DefaultView on the specified region
+        /// </summary>
+        public static readonly DependencyProperty DefaultViewProperty =
+            DependencyProperty.RegisterAttached("DefaultView", typeof(object), typeof(RegionManager), null);
+
+        /// <summary>
+        /// Gets the Default View Instance, Type or Name
+        /// </summary>
+        /// <param name="regionTarget">The Region Target View</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static object GetDefaultView(DependencyObject regionTarget)
+        {
+            if (regionTarget == null)
+                throw new ArgumentNullException(nameof(regionTarget));
+
+            return regionTarget.GetValue(DefaultViewProperty);
+        }
+
+        /// <summary>
+        /// Sets the Default Region View Instance, Type or Name.
+        /// </summary>
+        /// <param name="regionTarget">The Region Target.</param>
+        /// <param name="viewNameTypeOrInstance">The view instance, type or name.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static void SetDefaultView(DependencyObject regionTarget, object viewNameTypeOrInstance)
+        {
+            if (regionTarget == null)
+                throw new ArgumentNullException(nameof(regionTarget));
+
+            regionTarget.SetValue(DefaultViewProperty, viewNameTypeOrInstance);
+        }
+
         private static readonly DependencyProperty ObservableRegionProperty =
             DependencyProperty.RegisterAttached("ObservableRegion", typeof(ObservableObject<IRegion>), typeof(RegionManager), null);
 

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/SelectorRegionAdapter.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/SelectorRegionAdapter.cs
@@ -55,9 +55,9 @@ namespace Prism.Navigation.Regions
         /// Creates a new instance of <see cref="Region"/>.
         /// </summary>
         /// <returns>A new instance of <see cref="Region"/>.</returns>
-        protected override IRegion CreateRegion()
+        protected override IRegion CreateRegion(object regionTarget)
         {
-            return new Region();
+            return new Region(regionTarget);
         }
     }
 }

--- a/src/Wpf/Prism.Wpf/Navigation/Regions/SingleActiveRegion.cs
+++ b/src/Wpf/Prism.Wpf/Navigation/Regions/SingleActiveRegion.cs
@@ -3,7 +3,7 @@ namespace Prism.Navigation.Regions
     /// <summary>
     /// Region that allows a maximum of one active view at a time.
     /// </summary>
-    public class SingleActiveRegion : Region
+    public class SingleActiveRegion(object target) : Region(target)
     {
         /// <summary>
         /// Marks the specified view as active.

--- a/tests/Wpf/Prism.Container.Wpf.Shared/Fixtures/Regions/RegionNavigationContentLoaderFixture.cs
+++ b/tests/Wpf/Prism.Container.Wpf.Shared/Fixtures/Regions/RegionNavigationContentLoaderFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Prism.Ioc;
 using Prism.IocContainer.Wpf.Tests.Support.Mocks.Views;
 using Prism.Navigation.Regions;
@@ -31,7 +31,7 @@ namespace Prism.Container.Wpf.Tests.Regions
 
             // We cannot access the UnityRegionNavigationContentLoader directly so we need to call its
             // GetCandidatesFromRegion method through a navigation request.
-            IRegion testRegion = new Region();
+            IRegion testRegion = new Region(new ContentControl());
 
             MockView view = new MockView();
             testRegion.Add(view);
@@ -54,7 +54,7 @@ namespace Prism.Container.Wpf.Tests.Regions
 
             // We cannot access the Container specific RegionNavigationContentLoader directly so we need to call its
             // GetCandidatesFromRegion method through a navigation request.
-            IRegion testRegion = new Region();
+            IRegion testRegion = new Region(new ContentControl());
 
             var view = _container.Resolve<object>("SomeView") as MockView;
             testRegion.Add(view);

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/AllActiveRegionFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/AllActiveRegionFixture.cs
@@ -12,7 +12,7 @@ namespace Prism.Wpf.Tests.Regions
         public void AddingViewsToRegionMarksThemAsActive()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new AllActiveRegion();
+            IRegion region = new AllActiveRegion(new ItemsControl());
             var view = new object();
 
             region.Add(view);
@@ -25,7 +25,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                IRegion region = new AllActiveRegion();
+                IRegion region = new AllActiveRegion(new ItemsControl());
                 var view = new object();
                 region.Add(view);
 

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/ClearChildViewsRegionBehaviorFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/ClearChildViewsRegionBehaviorFixture.cs
@@ -15,7 +15,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         {
             var regionManager = new MockRegionManager();
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
             region.RegionManager = regionManager;
 
             var behavior = new ClearChildViewsRegionBehavior();
@@ -37,7 +37,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         {
             var regionManager = new MockRegionManager();
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
             region.RegionManager = regionManager;
 
             var behavior = new ClearChildViewsRegionBehavior();
@@ -61,7 +61,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         {
             var regionManager = new MockRegionManager();
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
             region.RegionManager = regionManager;
 
             var behavior = new ClearChildViewsRegionBehavior();

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/RegionActiveAwareBehaviorFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/RegionActiveAwareBehaviorFixture.cs
@@ -131,7 +131,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         public void WhenParentViewGetsActivatedOrDeactivated_ThenChildViewIsNotUpdated()
         {
             var scopedRegionManager = new RegionManager();
-            var scopedRegion = new Region { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
+            var scopedRegion = new Region(new ContentControl()) { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
             scopedRegionManager.Regions.Add(scopedRegion);
             var behaviorForScopedRegion = new RegionActiveAwareBehavior { Region = scopedRegion };
             behaviorForScopedRegion.Attach();
@@ -160,7 +160,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         public void WhenParentViewGetsActivatedOrDeactivated_ThenSyncedChildViewIsUpdated()
         {
             var scopedRegionManager = new RegionManager();
-            var scopedRegion = new Region { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
+            var scopedRegion = new Region(new ContentControl()) { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
             scopedRegionManager.Regions.Add(scopedRegion);
             var behaviorForScopedRegion = new RegionActiveAwareBehavior { Region = scopedRegion };
             behaviorForScopedRegion.Attach();
@@ -189,7 +189,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         public void WhenParentViewGetsActivatedOrDeactivated_ThenSyncedChildViewWithAttributeInVMIsUpdated()
         {
             var scopedRegionManager = new RegionManager();
-            var scopedRegion = new Region { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
+            var scopedRegion = new Region(new ContentControl()) { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
             scopedRegionManager.Regions.Add(scopedRegion);
             var behaviorForScopedRegion = new RegionActiveAwareBehavior { Region = scopedRegion };
             behaviorForScopedRegion.Attach();
@@ -219,7 +219,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         public void WhenParentViewGetsActivatedOrDeactivated_ThenSyncedChildViewModelThatIsNotAFrameworkElementIsNotUpdated()
         {
             var scopedRegionManager = new RegionManager();
-            var scopedRegion = new Region { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
+            var scopedRegion = new Region(new ContentControl()) { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
             scopedRegionManager.Regions.Add(scopedRegion);
             var behaviorForScopedRegion = new RegionActiveAwareBehavior { Region = scopedRegion };
             behaviorForScopedRegion.Attach();
@@ -248,7 +248,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         public void WhenParentViewGetsActivatedOrDeactivated_ThenSyncedChildViewNotInActiveViewsIsNotUpdated()
         {
             var scopedRegionManager = new RegionManager();
-            var scopedRegion = new Region { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
+            var scopedRegion = new Region(new ContentControl()) { Name = "MyScopedRegion", RegionManager = scopedRegionManager };
             scopedRegionManager.Regions.Add(scopedRegion);
             var behaviorForScopedRegion = new RegionActiveAwareBehavior { Region = scopedRegion };
             behaviorForScopedRegion.Attach();
@@ -281,7 +281,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
         public void WhenParentViewWithoutScopedRegionGetsActivatedOrDeactivated_ThenSyncedChildViewIsNotUpdated()
         {
             var commonRegionManager = new RegionManager();
-            var nonScopedRegion = new Region { Name = "MyRegion", RegionManager = commonRegionManager };
+            var nonScopedRegion = new Region(new ContentControl()) { Name = "MyRegion", RegionManager = commonRegionManager };
             commonRegionManager.Regions.Add(nonScopedRegion);
             var behaviorForScopedRegion = new RegionActiveAwareBehavior { Region = nonScopedRegion };
             behaviorForScopedRegion.Attach();

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/RegionMemberLifetimeBehaviorFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/RegionMemberLifetimeBehaviorFixture.cs
@@ -21,10 +21,10 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
 
         protected virtual void Arrange()
         {
-            this.Region = new Region();
-            this.Behavior = new RegionMemberLifetimeBehavior();
-            this.Behavior.Region = this.Region;
-            this.Behavior.Attach();
+            Region = new Region(new ContentControl());
+            Behavior = new RegionMemberLifetimeBehavior();
+            Behavior.Region = Region;
+            Behavior.Attach();
         }
 
         [Fact]
@@ -257,10 +257,10 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
     {
         protected override void Arrange()
         {
-            this.Region = new SingleActiveRegion();
-            this.Behavior = new RegionMemberLifetimeBehavior();
-            this.Behavior.Region = this.Region;
-            this.Behavior.Attach();
+            Region = new SingleActiveRegion(new ContentControl());
+            Behavior = new RegionMemberLifetimeBehavior();
+            Behavior.Region = Region;
+            Behavior.Attach();
         }
     }
 }

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/SelectorItemsSourceSyncRegionBehaviorFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/Behaviors/SelectorItemsSourceSyncRegionBehaviorFixture.cs
@@ -208,7 +208,7 @@ namespace Prism.Wpf.Tests.Regions.Behaviors
 
         private SelectorItemsSourceSyncBehavior CreateBehavior()
         {
-            Region region = new Region();
+            Region region = new Region(new ContentControl());
             Selector selector = new TabControl();
 
             var behavior = new SelectorItemsSourceSyncBehavior();

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/ContentControlRegionAdapterFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/ContentControlRegionAdapterFixture.cs
@@ -158,7 +158,7 @@ namespace Prism.Wpf.Tests.Regions
 
             private MockPresentationRegion region = new MockPresentationRegion();
 
-            protected override IRegion CreateRegion()
+            protected override IRegion CreateRegion(object regionTarget)
             {
                 return region;
             }

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/ItemsControlRegionAdapterFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/ItemsControlRegionAdapterFixture.cs
@@ -111,7 +111,7 @@ namespace Prism.Wpf.Tests.Regions
 
             private MockPresentationRegion region = new MockPresentationRegion();
 
-            protected override IRegion CreateRegion()
+            protected override IRegion CreateRegion(object regionTarget)
             {
                 return region;
             }

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/LocatorNavigationTargetHandlerFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/LocatorNavigationTargetHandlerFixture.cs
@@ -19,7 +19,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view = new TestView();
 
@@ -48,7 +48,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1 = new TestView();
             var view2 = new Test2View();
@@ -79,7 +79,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1 = new TestView();
             var view2 = new Test2View();
@@ -110,7 +110,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewMock = new Mock<INavigationAware>();
             viewMock
@@ -144,7 +144,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var dataContextMock = new Mock<INavigationAware>();
             dataContextMock
@@ -180,7 +180,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view = new TestView();
 
@@ -210,7 +210,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewMock = new Mock<INavigationAware>();
             viewMock
@@ -248,7 +248,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var dataContextMock = new Mock<INavigationAware>();
             dataContextMock
@@ -285,7 +285,7 @@ namespace Prism.Wpf.Tests.Regions
 
             containerMock.Setup(sl => sl.Resolve(typeof(object), typeof(TestView).Name)).Throws<ActivationException>();
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var navigationContext = new NavigationContext(null, new Uri(typeof(TestView).Name, UriKind.Relative));
 
@@ -308,7 +308,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view = new TestView();
 
@@ -352,7 +352,7 @@ namespace Prism.Wpf.Tests.Regions
             var containerMock = new Mock<IContainerExtension>();
             ContainerLocator.SetContainerExtension(containerMock.Object);
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var navigationTargetHandler = new TestRegionNavigationContentLoader(containerMock.Object);
 

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/NavigationContextFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/NavigationContextFixture.cs
@@ -17,7 +17,7 @@ namespace Prism.Wpf.Tests.Regions
             var navigationJournalMock = new Mock<IRegionNavigationJournal>();
             var navigationServiceMock = new Mock<IRegionNavigationService>();
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             navigationServiceMock.SetupGet(n => n.Region).Returns(region);
             navigationServiceMock.SetupGet(x => x.Journal).Returns(navigationJournalMock.Object);
 

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionAdapterBaseFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionAdapterBaseFixture.cs
@@ -94,7 +94,7 @@ namespace Prism.Wpf.Tests.Regions
                 adaptArgumentRegionTarget = regionTarget;
             }
 
-            protected override IRegion CreateRegion()
+            protected override IRegion CreateRegion(object regionTarget)
             {
                 return CreateRegionReturnValue;
             }

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionFixture.cs
@@ -16,7 +16,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenRegionConstructed_SortComparisonIsDefault()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
 
             Assert.NotNull(region.SortComparison);
             Assert.Equal(region.SortComparison, Region.DefaultSortComparison);
@@ -26,7 +26,7 @@ namespace Prism.Wpf.Tests.Regions
         public void CanAddContentToRegion()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
 
             Assert.Empty(region.Views.Cast<object>());
 
@@ -39,7 +39,7 @@ namespace Prism.Wpf.Tests.Regions
         [Fact]
         public void CanRemoveContentFromRegion()
         {
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object view = new object();
 
             region.Add(view);
@@ -53,7 +53,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
                 object view = new object();
 
                 region.Remove(view);
@@ -67,7 +67,7 @@ namespace Prism.Wpf.Tests.Regions
         public void RegionExposesCollectionOfContainedViews()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
 
             object view = new object();
 
@@ -84,7 +84,7 @@ namespace Prism.Wpf.Tests.Regions
         public void CanAddAndRetrieveNamedViewInstance()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object myView = new object();
             region.Add(myView, "MyView");
             object returnedView = region.GetView("MyView");
@@ -98,7 +98,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 region.Add(new object(), "MyView");
                 region.Add(new object(), "MyView");
@@ -110,7 +110,7 @@ namespace Prism.Wpf.Tests.Regions
         public void AddNamedViewIsAlsoListedInViewsCollection()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object myView = new object();
 
             region.Add(myView, "MyView");
@@ -122,7 +122,7 @@ namespace Prism.Wpf.Tests.Regions
         [Fact]
         public void GetViewReturnsNullWhenViewDoesNotExistInRegion()
         {
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
 
             Assert.Null(region.GetView("InexistentView"));
         }
@@ -133,7 +133,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 region.GetView(string.Empty);
             });
@@ -146,7 +146,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 region.Add(new object(), string.Empty);
             });
@@ -157,7 +157,7 @@ namespace Prism.Wpf.Tests.Regions
         public void GetViewReturnsNullAfterRemovingViewFromRegion()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object myView = new object();
             region.Add(myView, "MyView");
             region.Remove(myView);
@@ -169,7 +169,7 @@ namespace Prism.Wpf.Tests.Regions
         public void AddViewPassesSameScopeByDefaultToView()
         {
             var regionManager = new MockRegionManager();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.RegionManager = regionManager;
             var myView = new MockDependencyObject();
 
@@ -183,7 +183,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new MockRegionManager();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.RegionManager = regionManager;
             var myView = new MockDependencyObject();
 
@@ -197,7 +197,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new MockRegionManager();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.RegionManager = regionManager;
             var myView = new MockDependencyObject();
 
@@ -212,7 +212,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new MockRegionManager();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.RegionManager = regionManager;
             var myView = new object();
 
@@ -226,7 +226,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new MockRegionManager();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.RegionManager = regionManager;
             var myView = new object();
 
@@ -239,7 +239,7 @@ namespace Prism.Wpf.Tests.Regions
         public void AddViewReturnsNewRegionManager()
         {
             var regionManager = new MockRegionManager();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.RegionManager = regionManager;
             var myView = new object();
 
@@ -251,7 +251,7 @@ namespace Prism.Wpf.Tests.Regions
         [Fact]
         public void AddingNonDependencyObjectToRegionDoesNotThrow()
         {
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object model = new object();
 
             region.Add(model);
@@ -264,7 +264,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 object nonAddedView = new object();
 
@@ -278,7 +278,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 object nonAddedView = new object();
 
@@ -292,7 +292,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<ArgumentNullException>(() =>
             {
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 region.Activate(null);
             });
@@ -305,7 +305,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             bool viewAddedCalled = false;
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Views.CollectionChanged += (sender, e) =>
                                                   {
                                                       if (e.Action == NotifyCollectionChangedAction.Add)
@@ -325,7 +325,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             object viewAdded = null;
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Views.CollectionChanged += (sender, e) =>
                                                   {
                                                       if (e.Action == NotifyCollectionChangedAction.Add)
@@ -347,7 +347,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             bool viewRemoved = false;
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object model = new object();
             region.Views.CollectionChanged += (sender, e) =>
                                                   {
@@ -369,7 +369,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             object removedView = null;
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Views.CollectionChanged += (sender, e) =>
                                                   {
                                                       if (e.Action == NotifyCollectionChangedAction.Remove)
@@ -389,7 +389,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             bool viewActivated = false;
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object model = new object();
             region.ActiveViews.CollectionChanged += (o, e) =>
                                                         {
@@ -408,7 +408,7 @@ namespace Prism.Wpf.Tests.Regions
         public void AddingSameViewTwiceThrows()
         {
             object view = new object();
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             try
@@ -430,7 +430,7 @@ namespace Prism.Wpf.Tests.Regions
         public void RemovingViewAlsoRemovesItFromActiveViews()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             object model = new object();
             region.Add(model);
             region.Activate(model);
@@ -445,7 +445,7 @@ namespace Prism.Wpf.Tests.Regions
         public void ShouldGetNotificationWhenContextChanges()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             bool contextChanged = false;
             region.PropertyChanged += (s, args) => { if (args.PropertyName == "Context") contextChanged = true; };
 
@@ -459,7 +459,7 @@ namespace Prism.Wpf.Tests.Regions
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                var region = new Region
+                var region = new Region(new ContentControl())
                 {
                     Name = "MyRegion"
                 };
@@ -566,7 +566,7 @@ namespace Prism.Wpf.Tests.Regions
             try
             {
                 // Prepare
-                IRegion region = new Region();
+                IRegion region = new Region(new ContentControl());
 
                 object view = new object();
                 region.Add(view);
@@ -599,7 +599,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenViewsWithSortHintsAdded_RegionSortsViews()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
 
             object view1 = new ViewOrder1();
             object view2 = new ViewOrder2();
@@ -619,7 +619,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenViewHasBeenRemovedAndRegionManagerPropertyCleared_ThenItCanBeAddedAgainToARegion()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new Region { RegionManager = new MockRegionManager() };
+            IRegion region = new Region(new ContentControl()) { RegionManager = new MockRegionManager() };
 
             var view = new MockFrameworkElement();
 

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionManagerFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionManagerFixture.cs
@@ -237,8 +237,8 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new RegionManager();
 
-            var region1 = new Region { Name = "region1" };
-            var region2 = new Region { Name = "region2" };
+            var region1 = new Region(new ContentControl()) { Name = "region1" };
+            var region2 = new Region(new ContentControl()) { Name = "region2" };
 
             NotifyCollectionChangedEventArgs args = null;
             regionManager.Regions.CollectionChanged += (s, e) => args = e;
@@ -266,8 +266,8 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new RegionManager();
 
-            var region1 = new Region { Name = "region1" };
-            var region2 = new Region { Name = "region2" };
+            var region1 = new Region(new ContentControl()) { Name = "region1" };
+            var region2 = new Region(new ContentControl()) { Name = "region2" };
 
             regionManager.Regions.Add(region1);
             regionManager.Regions.Add(region2);
@@ -298,7 +298,7 @@ namespace Prism.Wpf.Tests.Regions
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
             var regionManager = new RegionManager();
 
-            var region1 = new Region { Name = "region1" };
+            var region1 = new Region(new ContentControl()) { Name = "region1" };
 
             regionManager.Regions.Add(region1);
 

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationServiceFixture.new.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/RegionNavigationServiceFixture.new.cs
@@ -19,7 +19,7 @@ namespace Prism.Wpf.Tests.Regions
             object view = new object();
             Uri viewUri = new Uri(view.GetType().Name, UriKind.Relative);
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             string regionName = "RegionName";
@@ -55,7 +55,7 @@ namespace Prism.Wpf.Tests.Regions
             object view = new object();
             Uri viewUri = new Uri(view.GetType().Name + "?MyQuery=true", UriKind.Relative);
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             string regionName = "RegionName";
@@ -91,7 +91,7 @@ namespace Prism.Wpf.Tests.Regions
             object view = new object();
             Uri viewUri = new Uri(view.GetType().Name, UriKind.Relative);
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             string otherType = "OtherType";
@@ -129,7 +129,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingWithNullUri_Throws()
         {
             // Prepare
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
 
             var containerMock = new Mock<IContainerExtension>();
             containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
@@ -157,7 +157,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingAndViewImplementsINavigationAware_ThenNavigatedIsInvokedOnNavigation()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewMock = new Mock<INavigationAware>();
             viewMock.Setup(ina => ina.IsNavigationTarget(It.IsAny<NavigationContext>())).Returns(true);
@@ -189,7 +189,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingAndDataContextImplementsINavigationAware_ThenNavigatedIsInvokesOnNavigation()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             Mock<FrameworkElement> mockFrameworkElement = new Mock<FrameworkElement>();
             Mock<INavigationAware> mockINavigationAwareDataContext = new Mock<INavigationAware>();
@@ -224,7 +224,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingAndBothViewAndDataContextImplementINavigationAware_ThenNavigatedIsInvokesOnNavigation()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             Mock<FrameworkElement> mockFrameworkElement = new Mock<FrameworkElement>();
             Mock<INavigationAware> mockINavigationAwareView = mockFrameworkElement.As<INavigationAware>();
@@ -266,7 +266,7 @@ namespace Prism.Wpf.Tests.Regions
             object view = new object();
             Uri viewUri = new Uri(view.GetType().Name, UriKind.Relative);
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             string regionName = "RegionName";
@@ -306,7 +306,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingAndCurrentlyActiveViewImplementsINavigateWithVeto_ThenNavigationRequestQueriesForVeto()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewMock = new Mock<IConfirmNavigationRequest>();
             viewMock
@@ -342,7 +342,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigating_ThenNavigationRequestQueriesForVetoOnAllActiveViewsIfAllSucceed()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1Mock = new Mock<IConfirmNavigationRequest>();
             view1Mock
@@ -403,7 +403,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenRequestNavigateAwayAcceptsThroughCallback_ThenNavigationProceeds()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1Mock = new Mock<IConfirmNavigationRequest>();
             view1Mock
@@ -448,7 +448,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenRequestNavigateAwayRejectsThroughCallback_ThenNavigationDoesNotProceed()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1Mock = new Mock<IConfirmNavigationRequest>();
             view1Mock
@@ -493,7 +493,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingAndDataContextOnCurrentlyActiveViewImplementsINavigateWithVeto_ThenNavigationRequestQueriesForVeto()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewModelMock = new Mock<IConfirmNavigationRequest>();
             viewModelMock
@@ -533,7 +533,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenRequestNavigateAwayOnDataContextAcceptsThroughCallback_ThenNavigationProceeds()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1DataContextMock = new Mock<IConfirmNavigationRequest>();
             view1DataContextMock
@@ -580,7 +580,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenRequestNavigateAwayOnDataContextRejectsThroughCallback_ThenNavigationDoesNotProceed()
         {
             // Prepare
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var view1DataContextMock = new Mock<IConfirmNavigationRequest>();
             view1DataContextMock
@@ -626,7 +626,7 @@ namespace Prism.Wpf.Tests.Regions
         [Fact]
         public void WhenViewAcceptsNavigationOutAfterNewIncomingRequestIsReceived_ThenOriginalRequestIsIgnored()
         {
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewMock = new Mock<IConfirmNavigationRequest>();
             var view = viewMock.Object;
@@ -678,7 +678,7 @@ namespace Prism.Wpf.Tests.Regions
         [StaFact]
         public void WhenViewModelAcceptsNavigationOutAfterNewIncomingRequestIsReceived_ThenOriginalRequestIsIgnored()
         {
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewModelMock = new Mock<IConfirmNavigationRequest>();
 
@@ -738,7 +738,7 @@ namespace Prism.Wpf.Tests.Regions
             object view = new object();
             Uri viewUri = new Uri(view.GetType().Name, UriKind.Relative);
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             string regionName = "RegionName";
@@ -782,7 +782,7 @@ namespace Prism.Wpf.Tests.Regions
             object view = new object();
             Uri viewUri = new Uri(view.GetType().Name, UriKind.Relative);
 
-            IRegion region = new Region();
+            IRegion region = new Region(new ContentControl());
             region.Add(view);
 
             string regionName = "RegionName";
@@ -838,7 +838,7 @@ namespace Prism.Wpf.Tests.Regions
                 .Setup(v => v.ConfirmNavigationRequest(It.IsAny<NavigationContext>(), It.IsAny<Action<bool>>()))
                 .Callback<NavigationContext, Action<bool>>((nc, c) => { navigationCallback = c; });
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
             region.Add(viewMock.Object);
             region.Activate(viewMock.Object);
 
@@ -859,7 +859,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingFromViewThatIsNavigationAware_ThenNotifiesActiveViewNavigatingFrom()
         {
             // Arrange
-            var region = new Region();
+            var region = new Region(new ContentControl());
             var viewMock = new Mock<INavigationAware>();
             var view = viewMock.Object;
             region.Add(view);
@@ -896,7 +896,7 @@ namespace Prism.Wpf.Tests.Regions
 
             bool navigationFromInvoked = false;
 
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var viewMock = new Mock<INavigationAware>();
             viewMock
@@ -936,7 +936,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigatingFromActiveViewWithNavigatinAwareDataConext_NotifiesContextOfNavigatingFrom()
         {
             // Arrange
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var mockDataContext = new Mock<INavigationAware>();
 
@@ -974,7 +974,7 @@ namespace Prism.Wpf.Tests.Regions
         [Fact]
         public void WhenNavigatingWithNullCallback_ThenThrows()
         {
-            var region = new Region();
+            var region = new Region(new ContentControl());
 
             var navigationUri = new Uri("/", UriKind.Relative);
             IContainerExtension container = new Mock<IContainerExtension>().Object;
@@ -1019,7 +1019,7 @@ namespace Prism.Wpf.Tests.Regions
 
             RegionNavigationService target = new RegionNavigationService(container, contentLoader, journal)
             {
-                Region = new Region()
+                Region = new Region(new ContentControl())
             };
 
             Exception error = null;
@@ -1034,7 +1034,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigationFailsBecauseTheContentViewCannotBeRetrieved_ThenNavigationFailedIsRaised()
         {
             // Prepare
-            var region = new Region { Name = "RegionName" };
+            var region = new Region(new ContentControl()) { Name = "RegionName" };
 
             var containerMock = new Mock<IContainerExtension>();
             containerMock.Setup(x => x.Resolve(typeof(IRegionNavigationJournalEntry))).Returns(new RegionNavigationJournalEntry());
@@ -1076,7 +1076,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigationFailsBecauseActiveViewRejectsIt_ThenNavigationFailedIsRaised()
         {
             // Prepare
-            var region = new Region { Name = "RegionName" };
+            var region = new Region(new ContentControl()) { Name = "RegionName" };
 
             var view1Mock = new Mock<IConfirmNavigationRequest>();
             view1Mock
@@ -1136,7 +1136,7 @@ namespace Prism.Wpf.Tests.Regions
         public void WhenNavigationFailsBecauseDataContextForActiveViewRejectsIt_ThenNavigationFailedIsRaised()
         {
             // Prepare
-            var region = new Region { Name = "RegionName" };
+            var region = new Region(new ContentControl()) { Name = "RegionName" };
 
             var viewModel1Mock = new Mock<IConfirmNavigationRequest>();
             viewModel1Mock

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/SelectorRegionAdapterFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/SelectorRegionAdapterFixture.cs
@@ -108,9 +108,9 @@ namespace Prism.Wpf.Tests.Regions
             }
 
 
-            protected override IRegion CreateRegion()
+            protected override IRegion CreateRegion(object regionTarget)
             {
-                return new Region();
+                return new Region(regionTarget);
             }
         }
     }

--- a/tests/Wpf/Prism.Wpf.Tests/Regions/SingleActiveRegionFixture.cs
+++ b/tests/Wpf/Prism.Wpf.Tests/Regions/SingleActiveRegionFixture.cs
@@ -11,7 +11,7 @@ namespace Prism.Wpf.Tests.Regions
         public void ActivatingNewViewDeactivatesCurrent()
         {
             ContainerLocator.SetContainerExtension(Mock.Of<IContainerExtension>());
-            IRegion region = new SingleActiveRegion();
+            IRegion region = new SingleActiveRegion(new ContentControl());
             var view = new object();
             region.Add(view);
             region.Activate(view);


### PR DESCRIPTION
﻿## Description of Change

Aligns WPF & Uno Platform API with MAUI. Provides attached property for the default View. This could be an instance, type or name of the view that should be added when the View is initialized. 

### Bugs Fixed

- closes #3246

### API Changes

Added:

```xml
<ContentControl prism:RegionManager.DefaultView="SomeView" />
```