### PR TITLE
Align registration return type

### DIFF
--- a/src/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
+++ b/src/Wpf/Prism.Wpf/Ioc/IContainerRegistryExtensions.cs
@@ -14,10 +14,8 @@ namespace Prism.Ioc
         /// <typeparam name="TView">The Type of object to register as the dialog</typeparam>
         /// <param name="containerRegistry"></param>
         /// <param name="name">The unique name to register with the dialog.</param>
-        public static void RegisterDialog<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView>(this IContainerRegistry containerRegistry, string name = null)
-        {
+        public static IContainerRegistry RegisterDialog<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView>(this IContainerRegistry containerRegistry, string name = null) =>
             containerRegistry.RegisterForNavigation<TView>(name);
-        }
 
         /// <summary>
         /// Registers an object to be used as a dialog in the IDialogService.
@@ -26,20 +24,16 @@ namespace Prism.Ioc
         /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the dialog</typeparam>
         /// <param name="containerRegistry"></param>
         /// <param name="name">The unique name to register with the dialog.</param>
-        public static void RegisterDialog<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TViewModel>(this IContainerRegistry containerRegistry, string name = null) where TViewModel : Dialogs.IDialogAware
-        {
+        public static IContainerRegistry RegisterDialog<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TViewModel>(this IContainerRegistry containerRegistry, string name = null) where TViewModel : Dialogs.IDialogAware =>
             containerRegistry.RegisterForNavigation<TView, TViewModel>(name);
-        }
 
         /// <summary>
         /// Registers an object that implements IDialogWindow to be used to host all dialogs in the IDialogService.
         /// </summary>
         /// <typeparam name="TWindow">The Type of the Window class that will be used to host dialogs in the IDialogService</typeparam>
         /// <param name="containerRegistry"></param>
-        public static void RegisterDialogWindow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TWindow>(this IContainerRegistry containerRegistry) where TWindow : Dialogs.IDialogWindow
-        {
+        public static IContainerRegistry RegisterDialogWindow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TWindow>(this IContainerRegistry containerRegistry) where TWindow : Dialogs.IDialogWindow => 
             containerRegistry.Register(typeof(Dialogs.IDialogWindow), typeof(TWindow));
-        }
 
         /// <summary>
         /// Registers an object that implements IDialogWindow to be used to host all dialogs in the IDialogService.
@@ -47,10 +41,8 @@ namespace Prism.Ioc
         /// <typeparam name="TWindow">The Type of the Window class that will be used to host dialogs in the IDialogService</typeparam>
         /// <param name="containerRegistry"></param>
         /// <param name="name">The name of the dialog window</param>
-        public static void RegisterDialogWindow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TWindow>(this IContainerRegistry containerRegistry, string name) where TWindow : Dialogs.IDialogWindow
-        {
+        public static IContainerRegistry RegisterDialogWindow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TWindow>(this IContainerRegistry containerRegistry, string name) where TWindow : Dialogs.IDialogWindow =>
             containerRegistry.Register(typeof(Dialogs.IDialogWindow), typeof(TWindow), name);
-        }
 
         /// <summary>
         /// Registers an object for navigation
@@ -58,10 +50,8 @@ namespace Prism.Ioc
         /// <param name="containerRegistry"></param>
         /// <param name="type">The type of object to register</param>
         /// <param name="name">The unique name to register with the object.</param>
-        public static void RegisterForNavigation(this IContainerRegistry containerRegistry, Type type, string name)
-        {
+        public static IContainerRegistry RegisterForNavigation(this IContainerRegistry containerRegistry, Type type, string name) =>
             containerRegistry.Register(typeof(object), type, name);
-        }
 
         /// <summary>
         /// Registers an object for navigation.
@@ -69,11 +59,11 @@ namespace Prism.Ioc
         /// <typeparam name="T">The Type of the object to register as the view</typeparam>
         /// <param name="containerRegistry"></param>
         /// <param name="name">The unique name to register with the object.</param>
-        public static void RegisterForNavigation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(this IContainerRegistry containerRegistry, string name = null)
+        public static IContainerRegistry RegisterForNavigation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(this IContainerRegistry containerRegistry, string name = null)
         {
             Type type = typeof(T);
             string viewName = string.IsNullOrWhiteSpace(name) ? type.Name : name;
-            containerRegistry.RegisterForNavigation(type, viewName);
+            return containerRegistry.RegisterForNavigation(type, viewName);
         }
 
         /// <summary>
@@ -83,18 +73,16 @@ namespace Prism.Ioc
         /// <typeparam name="TViewModel">The ViewModel to use as the DataContext for the view</typeparam>
         /// <param name="containerRegistry"></param>
         /// <param name="name">The unique name to register with the view</param>
-        public static void RegisterForNavigation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TViewModel>(this IContainerRegistry containerRegistry, string name = null)
-        {
+        public static IContainerRegistry RegisterForNavigation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TView, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TViewModel>(this IContainerRegistry containerRegistry, string name = null) =>
             containerRegistry.RegisterForNavigationWithViewModel<TViewModel>(typeof(TView), name);
-        }
 
-        private static void RegisterForNavigationWithViewModel<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TViewModel>(this IContainerRegistry containerRegistry, Type viewType, string name)
+        private static IContainerRegistry RegisterForNavigationWithViewModel<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] TViewModel>(this IContainerRegistry containerRegistry, Type viewType, string name)
         {
             if (string.IsNullOrWhiteSpace(name))
                 name = viewType.Name;
 
             ViewModelLocationProvider.Register(viewType.ToString(), typeof(TViewModel));
-            containerRegistry.RegisterForNavigation(viewType, name);
+            return containerRegistry.RegisterForNavigation(viewType, name);
         }
     }
 }


### PR DESCRIPTION
﻿## Description of Change

While in Xamarin.Forms and .NET MAUI we have always returned the IContainerRegistry from the Dialog and Navigation registration extensions, WPF / Uno extensions have not. This PR aligns the behavior between the platforms so that the IContainerProvider is returned allowing you to chain your registration like:

```cs
containerRegistry.RegisterForNavigation<ViewA, ViewAViewModel>()
                 .RegisterForNavigation<ViewB, ViewBViewModel>();
```