### PR TITLE
Avoid waiting more than necessary between navigations

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -418,7 +418,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
         TimeSpan timeSinceLastNav = DateTime.Now - _lastNavigate;
         if (timeSinceLastNav < _minTimeBetweenNavigations)
         {
-            await Task.Delay(_minTimeBetweenNavigations - timePassedSinceLastNav);
+            await Task.Delay(_minTimeBetweenNavigations - timeSinceLastNav);
         }
     }
 

--- a/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Maui/Prism.Maui/Navigation/PageNavigationService.cs
@@ -14,6 +14,7 @@ namespace Prism.Navigation;
 public class PageNavigationService : INavigationService, IRegistryAware
 {
     private static readonly SemaphoreSlim _semaphore = new (1, 1);
+    private static readonly TimeSpan _minTimeBetweenNavigations = TimeSpan.FromMilliseconds(150);
     private static DateTime _lastNavigate;
     internal const string RemovePageRelativePath = "../";
     internal const string RemovePageInstruction = "__RemovePage/";
@@ -414,9 +415,10 @@ public class PageNavigationService : INavigationService, IRegistryAware
     {
         await _semaphore.WaitAsync();
         // Ensure adequate time has passed since last navigation so that UI Refresh can Occur
-        if (DateTime.Now - _lastNavigate < TimeSpan.FromMilliseconds(150))
+        TimeSpan timeSinceLastNav = DateTime.Now - _lastNavigate;
+        if (timeSinceLastNav < _minTimeBetweenNavigations)
         {
-            await Task.Delay(150);
+            await Task.Delay(_minTimeBetweenNavigations - timePassedSinceLastNav);
         }
     }
 


### PR DESCRIPTION
﻿## Description of Change
Reduced the wait time between navigations to only be 150 milliseconds.

### Bugs Fixed

### API Changes
None

### Behavioral Changes
This change will be hardly noticeable.

### PR Checklist
- [ ] Has tests (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard