### PR TITLE
removed check for empty events args object

### DIFF
--- a/src/Maui/Prism.Maui/Behaviors/EventToCommandBehavior.cs
+++ b/src/Maui/Prism.Maui/Behaviors/EventToCommandBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
@@ -234,7 +234,7 @@ public class EventToCommandBehavior : BehaviorBase<BindableObject>
             parameter = propertyValue;
         }
 
-        if (parameter == null && eventArgs != null && eventArgs != EventArgs.Empty && EventArgsConverter != null)
+        if (parameter == null && eventArgs != null && EventArgsConverter != null)
         {
             parameter = EventArgsConverter.Convert(eventArgs, typeof(object), EventArgsConverterParameter,
                 CultureInfo.CurrentUICulture);


### PR DESCRIPTION
Fixed #3063

Although #3063 as reported wasn't a bug, just a very problematic code base, it did  lead me to find an actual bug. When the event args of a control event didn't have any custom properties, it would not invoke the event args converter logic, which is not what we want. So I removed that check to fix it.