### PR TITLE
Fix navigating to unregistered region error

### DIFF
--- a/src/Maui/Prism.Maui/Navigation/Regions/Navigation/RegionNavigationContentLoader.cs
+++ b/src/Maui/Prism.Maui/Navigation/Regions/Navigation/RegionNavigationContentLoader.cs
@@ -115,7 +115,7 @@ public class RegionNavigationContentLoader : IRegionNavigationContentLoader
         {
             var registry = region.Container().Resolve<IRegionNavigationRegistry>();
             var registration = registry.Registrations.FirstOrDefault(x => x.Type == ViewType.Region && (x.Name == candidateNavigationContract || x.View.Name == candidateNavigationContract || x.View.FullName == candidateNavigationContract));
-            if (registration is null)
+            if (registration is not null)
             {
                 RegionNavigationContentLoader.GetCandidatesFromRegionViews(region, registration.View.FullName);
             }


### PR DESCRIPTION
﻿## Description of Change

Fixes `NullReferenceException` being the navigation exception when navigating to an unregistered region

### Bugs Fixed

- #3328

### API Changes

None

### Behavioral Changes

None

### PR Checklist

- [X] Has tests (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard ?