### PR TITLE
Package Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       name: Build Prism.Core
       solution-path: PrismLibrary_Core.slnf
-      code-sign: true
+      # code-sign: true
       artifact-name: Core
     secrets:
       codeSignKeyVault: ${{ secrets.CodeSignKeyVault }}
@@ -43,7 +43,7 @@ jobs:
     with:
       name: Build Prism.Wpf
       solution-path: PrismLibrary_Wpf.slnf
-      code-sign: true
+      # code-sign: true
       artifact-name: Wpf
     secrets:
       codeSignKeyVault: ${{ secrets.CodeSignKeyVault }}
@@ -64,7 +64,7 @@ jobs:
       uno-check-version: 1.24.0
       uno-check-parameters: '--skip xcode --skip gtk3 --skip vswin --skip androidemulator --skip androidsdk --skip vsmac --skip dotnetnewunotemplates'
       run-tests: false
-      code-sign: true
+      # code-sign: true
       artifact-name: Uno
     secrets:
       codeSignKeyVault: ${{ secrets.CodeSignKeyVault }}
@@ -79,7 +79,7 @@ jobs:
       name: Build Prism.Maui
       solution-path: PrismLibrary_Maui.slnf
       install-workload: maui maui-tizen
-      code-sign: true
+      # code-sign: true
       artifact-name: Maui
     secrets:
       codeSignKeyVault: ${{ secrets.CodeSignKeyVault }}
@@ -93,7 +93,7 @@ jobs:
     with:
       name: Build Prism.Avalonia
       solution-path: PrismLibrary_Avalonia.slnf
-      code-sign: true
+      # code-sign: true
       artifact-name: Avalonia
     secrets:
       codeSignKeyVault: ${{ secrets.CodeSignKeyVault }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,17 +1,17 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="PolySharp" Version="1.14.1" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Prism.Container.Abstractions" Version="9.0.114" />
     <PackageVersion Include="Prism.Container.DryIoc" Version="9.0.114" />
     <PackageVersion Include="Prism.Container.Unity" Version="9.0.114" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="Xamarin.Forms" Version="5.0.0.2401" />
-    <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
+    <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
   </ItemGroup>
   <!-- Maui -->
   <ItemGroup Condition=" $(UseMaui) == 'true' ">
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.20" Condition="$(MSBuildProjectName.StartsWith('Prism.'))" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.90" Condition="$(MSBuildProjectName.StartsWith('Prism.'))" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" Condition="!$(MSBuildProjectName.StartsWith('Prism.'))" />
   </ItemGroup>
   <!-- Uno
@@ -57,28 +57,28 @@
   </ItemGroup>
   <!-- Avalonia -->
   <ItemGroup Condition=" $(IsAvaloniaProject) == 'true' ">
-    <PackageVersion Include="Avalonia" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.3" />
+    <PackageVersion Include="Avalonia" Version="11.3.2" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.2" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.2" />
     <PackageVersion Include="Avalonia.LinuxFramebuffer" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.3.2" />
     <PackageVersion Include="Avalonia.Themes.Simple" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.1.3" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.2" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.2" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageVersion Include="System.CodeDom" Version="8.0.0" />
   </ItemGroup>
-    <!-- Tests -->
+  <!-- Tests -->
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.70" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />
   </ItemGroup>
   <ItemGroup Condition=" $(UseMaui) != 'true' ">
@@ -96,7 +96,7 @@
   <ItemGroup>
     <!-- Global Packages -->
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.141" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/e2e/Avalonia/PrismAvaloniaDemo/PrismAvaloniaDemo.csproj
+++ b/e2e/Avalonia/PrismAvaloniaDemo/PrismAvaloniaDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
 

--- a/e2e/Maui/MauiModule/MauiModule.csproj
+++ b/e2e/Maui/MauiModule/MauiModule.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>
   </PropertyGroup>

--- a/e2e/Maui/MauiRegionsModule/MauiRegionsModule.csproj
+++ b/e2e/Maui/MauiRegionsModule/MauiRegionsModule.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>
   </PropertyGroup>

--- a/e2e/Maui/PrismMauiDemo/PrismMauiDemo.csproj
+++ b/e2e/Maui/PrismMauiDemo/PrismMauiDemo.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>PrismMauiDemo</RootNamespace>
     <UseMaui>true</UseMaui>

--- a/e2e/Wpf/HelloWorld.Bootstraper/HelloWorld.Bootstrapper.csproj
+++ b/e2e/Wpf/HelloWorld.Bootstraper/HelloWorld.Bootstrapper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>HelloWorld</RootNamespace>
     <ApplicationIcon>..\HelloWorld\prism-sandbox.ico</ApplicationIcon>

--- a/e2e/Wpf/HelloWorld.Core/HelloWorld.Core.csproj
+++ b/e2e/Wpf/HelloWorld.Core/HelloWorld.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/e2e/Wpf/HelloWorld/HelloWorld.csproj
+++ b/e2e/Wpf/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>HelloWorld</RootNamespace>
     <AssemblyName>HelloWorld</AssemblyName>

--- a/e2e/Wpf/Modules/HelloWorld.Modules.ModuleA/HelloWorld.Modules.ModuleA.csproj
+++ b/e2e/Wpf/Modules/HelloWorld.Modules.ModuleA/HelloWorld.Modules.ModuleA.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.56",
     "MSBuild.Sdk.Extras": "3.0.44",
-    "Uno.Sdk": "5.3.31"
+    "Uno.Sdk": "6.1.23"
   }
 }

--- a/src/Avalonia/Prism.Avalonia/Prism.Avalonia.csproj
+++ b/src/Avalonia/Prism.Avalonia/Prism.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Prism.Avalonia is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices. Prism.Avalonia provides an implementation of a collection of design patterns that are helpful in writing well structured, maintainable, and testable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared library targeting the .NET Framework and .NET Standard. Features that need to be platform specific are implemented in the respective libraries for the target platform (Avalonia, WPF, Uno Platform, and Xamarin Forms).
 
 Prism.Avalonia helps you more easily design and build rich, flexible, and easy to maintain cross-platform Avalonia desktop applications. This library provides user interface composition as well as modularity support.</Description>

--- a/src/Avalonia/Prism.DryIoc.Avalonia/Prism.DryIoc.Avalonia.csproj
+++ b/src/Avalonia/Prism.DryIoc.Avalonia/Prism.DryIoc.Avalonia.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Prism.DryIoc</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>This extension is used to build Prism.Avalonia applications based on DryIoc. Users must install the Prism.Avalonia NuGet package as well.</Description>
     <Authors>Damian Suess, Suess Labs, various contributors</Authors>
     <Copyright>Copyright (c) 2024 Xeno Innovations, Inc.</Copyright>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition=" $(IsUnoProject) AND '$(TargetFramework)' == 'net8.0' ">
+    <When Condition=" $(IsUnoProject) AND '$(TargetFramework)' == 'net9.0' ">
       <PropertyGroup>
         <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
       </PropertyGroup>
@@ -25,8 +25,8 @@
   </Choose>
 
   <PropertyGroup Condition=" $(IsUnoProject) ">
-    <UnoTargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-macos</UnoTargetFrameworks>
-    <UnoTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(UnoTargetFrameworks);net8.0-windows10.0.19041</UnoTargetFrameworks>
+    <UnoTargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-macos</UnoTargetFrameworks>
+    <UnoTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(UnoTargetFrameworks);net9.0-windows10.0.19041</UnoTargetFrameworks>
     <RuntimeIdentifiers Condition="$(TargetFramework.Contains('windows10'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/Maui/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
+++ b/src/Maui/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>
     <ImplicitUsings>true</ImplicitUsings>

--- a/src/Maui/Prism.Maui.Rx/Prism.Maui.Rx.csproj
+++ b/src/Maui/Prism.Maui.Rx/Prism.Maui.Rx.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
     <Description>Prism.Maui.Rx is a support package for .NET MAUI developers. This package provides some helpers to access an IObservable for globally handling Navigation Request Results.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Maui/Prism.Maui/Prism.Maui.csproj
+++ b/src/Maui/Prism.Maui/Prism.Maui.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;</TargetFrameworks>
+    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
     <Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured, maintainable, and testable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared library targeting the .NET Framework and .NET. Features that need to be platform specific are implemented in the respective libraries for the target platform (WPF, Uno Platform, .NET MAUI and Xamarin Forms).
 

--- a/src/Prism.Core/Commands/AsyncDelegateCommand.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand.cs
@@ -24,7 +24,7 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// </summary>
     /// <param name="executeMethod">The <see cref="Func{Task}"/> to invoke when <see cref="ICommand.Execute(object)"/> is called.</param>
     public AsyncDelegateCommand(Func<Task> executeMethod)
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         : this (c => executeMethod().WaitAsync(c), () => true)
 #else
         : this(c => executeMethod(), () => true)
@@ -50,7 +50,7 @@ public class AsyncDelegateCommand : DelegateCommandBase, IAsyncCommand
     /// <param name="executeMethod">The <see cref="Func{Task}"/> to invoke when <see cref="ICommand.Execute"/> is called.</param>
     /// <param name="canExecuteMethod">The delegate to invoke when <see cref="ICommand.CanExecute"/> is called</param>
     public AsyncDelegateCommand(Func<Task> executeMethod, Func<bool> canExecuteMethod)
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         : this(c => executeMethod().WaitAsync(c), canExecuteMethod)
 #else
         : this(c => executeMethod(), canExecuteMethod)

--- a/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
+++ b/src/Prism.Core/Commands/AsyncDelegateCommand{T}.cs
@@ -25,7 +25,7 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// </summary>
     /// <param name="executeMethod">The <see cref="Func{T, Task}"/> to invoke when <see cref="ICommand.Execute(object)"/> is called.</param>
     public AsyncDelegateCommand(Func<T, Task> executeMethod)
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         : this((p,t) => executeMethod(p).WaitAsync(t), _ => true)
 #else
         : this((p, t) => executeMethod(p), _ => true)
@@ -51,7 +51,7 @@ public class AsyncDelegateCommand<T> : DelegateCommandBase, IAsyncCommand
     /// <param name="executeMethod">The <see cref="Func{T, Task}"/> to invoke when <see cref="ICommand.Execute"/> is called.</param>
     /// <param name="canExecuteMethod">The delegate to invoke when <see cref="ICommand.CanExecute"/> is called</param>
     public AsyncDelegateCommand(Func<T, Task> executeMethod, Func<T, bool> canExecuteMethod)
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         : this((p, c) => executeMethod(p).WaitAsync(c), canExecuteMethod)
 #else
         : this((p, c) => executeMethod(p), canExecuteMethod)

--- a/src/Prism.Core/Common/MulticastExceptionHandler.cs
+++ b/src/Prism.Core/Common/MulticastExceptionHandler.cs
@@ -82,7 +82,7 @@ public readonly struct MulticastExceptionHandler
         {
             await task;
         }
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         else if (result is ValueTask valueTask)
         {
             await valueTask;

--- a/src/Prism.Core/Modularity/ModularityException.Desktop.cs
+++ b/src/Prism.Core/Modularity/ModularityException.Desktop.cs
@@ -25,7 +25,7 @@ namespace Prism.Modularity
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-#if !NET6_0_OR_GREATER
+#if !NET8_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.SerializationFormatter)]
 #endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/src/Prism.Core/Prism.Core.csproj
+++ b/src/Prism.Core/Prism.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net47;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net47;net8.0</TargetFrameworks>
     <AssemblyName>Prism</AssemblyName>
     <PackageId>Prism.Core</PackageId>
     <RootNamespace>Prism</RootNamespace>

--- a/src/Prism.Events/Prism.Events.csproj
+++ b/src/Prism.Events/Prism.Events.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net47;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net47;net8.0</TargetFrameworks>
     <!-- Summary is not actually supported at this time. Including the summary for future support. -->
     <!--<Summary>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured and maintainable applications.</Summary>-->
     <Description>Prism.Events is a library that facilitates communication between loosely coupled components in an application. It provides an event aggregator service that allows publishers and subscribers to interact through events without direct references. With multicast publish/subscribe functionality, multiple publishers can raise the same event, and multiple subscribers can listen to it, enabling flexible and efficient communication.</Description>

--- a/src/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
+++ b/src/Wpf/Prism.DryIoc.Wpf/Prism.DryIoc.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net47;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.DryIoc</RootNamespace>
     <PackageId>Prism.DryIoc</PackageId>

--- a/src/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
+++ b/src/Wpf/Prism.Unity.Wpf/Prism.Unity.Wpf.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net47;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <RootNamespace>Prism.Unity</RootNamespace>
     <PackageId>Prism.Unity</PackageId>

--- a/src/Wpf/Prism.Wpf/Prism.Wpf.csproj
+++ b/src/Wpf/Prism.Wpf/Prism.Wpf.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Prism</RootNamespace>
-    <TargetFrameworks>net462;net47;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net8.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <!--<Summary>Prism libraries related to user interface composition, regions, and modularity for WPF.</Summary>-->
     <Description>Prism provides an implementation of a collection of design patterns that are helpful in writing well structured, maintainable, and testable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared library targeting the .NET Framework and .NET. Features that need to be platform specific are implemented in the respective libraries for the target platform (WPF, Uno Platform, .NET MAUI and Xamarin Forms).

--- a/tests/Maui/Prism.DryIoc.Maui.Tests/Prism.DryIoc.Maui.Tests.csproj
+++ b/tests/Maui/Prism.DryIoc.Maui.Tests/Prism.DryIoc.Maui.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Maui/Prism.Maui.Tests/Prism.Maui.Tests.csproj
+++ b/tests/Maui/Prism.Maui.Tests/Prism.Maui.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Prism.Core.Tests/Prism.Core.Tests.csproj
+++ b/tests/Prism.Core.Tests/Prism.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
﻿## Description of Change

This updates the base packages.

- WPF - Updated to net8.0 as the latest LTS 
- .NET MAUI, Uno Platform, Avalonia - Updated to net9.0 as mobile developers should remain on the latest version due to platform specific SDK updates.
- Uno Platform also updated to 6.1 as they have released a major version bump from Prism 9.0

This also temporarily disables package signing as this will not directly affect the Commercial Plus feed. We will need to update the certificate prior to shipping 9.1.