### PR TITLE
Fix #1978 — Add XML docs for DelegateCommand and CompositeCommand

### DIFF
--- a/src/Prism.Core/Commands/CompositeCommand.cs
+++ b/src/Prism.Core/Commands/CompositeCommand.cs
@@ -11,6 +11,19 @@ namespace Prism.Commands
     /// <summary>
     /// The CompositeCommand composes one or more ICommands.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CompositeCommand"/> allows you to register multiple commands and execute them all with a single call.
+    /// This is useful for scenarios where an action should trigger multiple operations across different parts of an application.
+    /// </para>
+    /// <para>
+    /// The composite command can optionally monitor the activity of its registered commands if they implement <see cref="IActiveAware"/>.
+    /// When monitoring is enabled, the composite command will only execute commands that are active.
+    /// </para>
+    /// <para>
+    /// The <see cref="CanExecute(object)"/> method returns <see langword="true"/> only if all registered commands can execute.
+    /// </para>
+    /// </remarks>
     public class CompositeCommand : ICommand
     {
         private readonly List<ICommand> _registeredCommands = new();
@@ -21,6 +34,9 @@ namespace Prism.Commands
         /// <summary>
         /// Initializes a new instance of <see cref="CompositeCommand"/>.
         /// </summary>
+        /// <remarks>
+        /// By default, the composite command will not monitor the activity of registered commands.
+        /// </remarks>
         public CompositeCommand()
         {
             _onRegisteredCommandCanExecuteChangedHandler = new EventHandler(OnRegisteredCommandCanExecuteChanged);
@@ -30,7 +46,11 @@ namespace Prism.Commands
         /// <summary>
         /// Initializes a new instance of <see cref="CompositeCommand"/>.
         /// </summary>
-        /// <param name="monitorCommandActivity">Indicates when the command activity is going to be monitored.</param>
+        /// <param name="monitorCommandActivity">Indicates when the command activity is going to be monitored.
+        /// When <see langword="true"/>, the composite command will only execute registered commands that are active (if they implement <see cref="IActiveAware"/>).</param>
+        /// <remarks>
+        /// When activity monitoring is enabled, only commands that are active will be executed.
+        /// </remarks>
         public CompositeCommand(bool monitorCommandActivity)
             : this()
         {
@@ -41,11 +61,19 @@ namespace Prism.Commands
         /// Adds a command to the collection and signs up for the <see cref="ICommand.CanExecuteChanged"/> event of it.
         /// </summary>
         ///  <remarks>
+        /// <para>
         /// If this command is set to monitor command activity, and <paramref name="command"/> 
         /// implements the <see cref="IActiveAware"/> interface, this method will subscribe to its
         /// <see cref="IActiveAware.IsActiveChanged"/> event.
+        /// </para>
+        /// <para>
+        /// The same command cannot be registered twice, and a composite command cannot be registered within itself.
+        /// </para>
         /// </remarks>
         /// <param name="command">The command to register.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="command"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown when attempting to register a composite command within itself.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the same command is registered twice.</exception>
         public virtual void RegisterCommand(ICommand command)
         {
             if (command == null) throw new ArgumentNullException(nameof(command));
@@ -79,6 +107,7 @@ namespace Prism.Commands
         /// Removes a command from the collection and removes itself from the <see cref="ICommand.CanExecuteChanged"/> event of it.
         /// </summary>
         /// <param name="command">The command to unregister.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="command"/> is <see langword="null"/>.</exception>
         public virtual void UnregisterCommand(ICommand command)
         {
             if (command == null) throw new ArgumentNullException(nameof(command));

--- a/src/Prism.Core/Commands/DelegateCommand.cs
+++ b/src/Prism.Core/Commands/DelegateCommand.cs
@@ -10,8 +10,19 @@ namespace Prism.Commands
     /// <summary>
     /// An <see cref="ICommand"/> whose delegates do not take any parameters for <see cref="Execute()"/> and <see cref="CanExecute()"/>.
     /// </summary>
-    /// <see cref="DelegateCommandBase"/>
-    /// <see cref="DelegateCommand{T}"/>
+    /// <remarks>
+    /// <para>
+    /// <see cref="DelegateCommand"/> is a command implementation that allows you to define the execute and canExecute logic
+    /// using delegates. Unlike UI-based commands, DelegateCommand does not accept parameters.
+    /// </para>
+    /// <para>
+    /// DelegateCommand supports fluent syntax through methods like <see cref="ObservesProperty{T}(Expression{Func{T}})"/>,
+    /// <see cref="ObservesCanExecute(Expression{Func{bool}})"/>, and <see cref="Catch(Action{Exception})"/> to make creating
+    /// and configuring commands easier.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="DelegateCommandBase"/>
+    /// <seealso cref="DelegateCommand{T}"/>
     public class DelegateCommand : DelegateCommandBase
     {
         Action _executeMethod;
@@ -21,6 +32,7 @@ namespace Prism.Commands
         /// Creates a new instance of <see cref="DelegateCommand"/> with the <see cref="Action"/> to invoke on execution.
         /// </summary>
         /// <param name="executeMethod">The <see cref="Action"/> to invoke when <see cref="ICommand.Execute(object)"/> is called.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="executeMethod"/> is <see langword="null"/>.</exception>
         public DelegateCommand(Action executeMethod)
             : this(executeMethod, () => true)
         {
@@ -33,6 +45,10 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="executeMethod">The <see cref="Action"/> to invoke when <see cref="ICommand.Execute"/> is called.</param>
         /// <param name="canExecuteMethod">The <see cref="Func{TResult}"/> to invoke when <see cref="ICommand.CanExecute"/> is called</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="executeMethod"/> or <paramref name="canExecuteMethod"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// Both delegates must be non-null. If either is null, an <see cref="ArgumentNullException"/> will be thrown.
+        /// </remarks>
         public DelegateCommand(Action executeMethod, Func<bool> canExecuteMethod)
             : base()
         {
@@ -46,6 +62,10 @@ namespace Prism.Commands
         ///<summary>
         /// Executes the command.
         ///</summary>
+        /// <remarks>
+        /// Calls the delegate registered during construction. If an exception occurs and has been registered
+        /// with <see cref="Catch(Action{Exception})"/>, it will be handled; otherwise, the exception is rethrown.
+        /// </remarks>
         public void Execute()
         {
             try
@@ -65,6 +85,9 @@ namespace Prism.Commands
         /// Determines if the command can be executed.
         /// </summary>
         /// <returns>Returns <see langword="true"/> if the command can execute,otherwise returns <see langword="false"/>.</returns>
+        /// <remarks>
+        /// Calls the canExecute delegate registered during construction. If an exception occurs, it will return <see langword="false"/>.
+        /// </remarks>
         public bool CanExecute()
         {
             try
@@ -94,7 +117,7 @@ namespace Prism.Commands
         /// <summary>
         /// Handle the internal invocation of <see cref="ICommand.CanExecute(object)"/>
         /// </summary>
-        /// <param name="parameter"></param>
+        /// <param name="parameter">Command Parameter (ignored by this implementation)</param>
         /// <returns><see langword="true"/> if the Command Can Execute, otherwise <see langword="false" /></returns>
         protected override bool CanExecute(object? parameter)
         {
@@ -107,6 +130,9 @@ namespace Prism.Commands
         /// <typeparam name="T">The object type containing the property specified in the expression.</typeparam>
         /// <param name="propertyExpression">The property expression. Example: ObservesProperty(() => PropertyName).</param>
         /// <returns>The current instance of DelegateCommand</returns>
+        /// <remarks>
+        /// This method enables automatic notification of command execution state changes when observed properties change.
+        /// </remarks>
         public DelegateCommand ObservesProperty<T>(Expression<Func<T>> propertyExpression)
         {
             ObservesPropertyInternal(propertyExpression);
@@ -118,6 +144,10 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="canExecuteExpression">The property expression. Example: ObservesCanExecute(() => PropertyName).</param>
         /// <returns>The current instance of DelegateCommand</returns>
+        /// <remarks>
+        /// This method replaces the canExecute delegate provided during construction with the compiled expression,
+        /// and automatically raises CanExecuteChanged when the observed property changes.
+        /// </remarks>
         public DelegateCommand ObservesCanExecute(Expression<Func<bool>> canExecuteExpression)
         {
             _canExecuteMethod = canExecuteExpression.Compile();
@@ -130,6 +160,9 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="catch">The Callback</param>
         /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        /// <remarks>
+        /// The exception handler will be invoked only for exceptions of type <see cref="Exception"/>.
+        /// </remarks>
         public DelegateCommand Catch(Action<Exception> @catch)
         {
             ExceptionHandler.Register<Exception>(@catch);
@@ -141,6 +174,9 @@ namespace Prism.Commands
         /// </summary>
         /// <param name="catch">The Callback</param>
         /// <returns>The current instance of <see cref="DelegateCommand"/></returns>
+        /// <remarks>
+        /// The exception handler will be invoked with both the exception and the command parameter.
+        /// </remarks>
         public DelegateCommand Catch(Action<Exception, object> @catch)
         {
             ExceptionHandler.Register<Exception>(@catch);


### PR DESCRIPTION
## Description of Change

Added missing XML documentation comments to command-related APIs to improve IntelliSense support and API discoverability.

This PR focuses on improving developer guidance when using Prism command APIs.

### Bugs Fixed

- Fixes #1978

### API Changes

None

### Behavioral Changes

None

### Files Updated

- CompositeCommand
- DelegateCommand

### PR Checklist

- [ ] Has tests (not required for documentation-only changes)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard