### PR TITLE
Fix #1978 — Add XML docs for modularity APIs

### DIFF
--- a/src/Prism.Core/Modularity/IModule.cs
+++ b/src/Prism.Core/Modularity/IModule.cs
@@ -5,16 +5,37 @@ namespace Prism.Modularity
     /// <summary>
     /// Defines the contract for the modules deployed in the application.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IModule"/> is the base interface for modular components in Prism applications.
+    /// Modules are self-contained units that encapsulate specific features or domain logic and can be
+    /// developed, tested, and deployed independently.
+    /// </para>
+    /// <para>
+    /// Each module must implement the registration of its types during the initialization phase
+    /// and can perform additional setup in the OnInitialized method.
+    /// </para>
+    /// </remarks>
     public interface IModule
     {
         /// <summary>
         /// Used to register types with the container that will be used by your application.
         /// </summary>
+        /// <param name="containerRegistry">The container registry where types can be registered.</param>
+        /// <remarks>
+        /// This method is called during the module initialization phase, before OnInitialized.
+        /// Use this to register all services, views, and other components provided by this module.
+        /// </remarks>
         void RegisterTypes(IContainerRegistry containerRegistry);
 
         /// <summary>
         /// Notifies the module that it has been initialized.
         /// </summary>
+        /// <param name="containerProvider">The container provider that can be used to resolve services.</param>
+        /// <remarks>
+        /// This method is called after all modules have registered their types.
+        /// Use this to initialize the module's functionality, register views with regions, or set up event subscriptions.
+        /// </remarks>
         void OnInitialized(IContainerProvider containerProvider);
     }
 }

--- a/src/Prism.Core/Modularity/IModuleManager.cs
+++ b/src/Prism.Core/Modularity/IModuleManager.cs
@@ -6,32 +6,67 @@ namespace Prism.Modularity
     /// <summary>
     /// Defines the interface for the service that will retrieve and initialize the application's modules.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IModuleManager"/> orchestrates the loading and initialization of all modules in the application.
+    /// It works with the <see cref="IModuleCatalog"/> to determine which modules to load and when to load them,
+    /// based on their <see cref="InitializationMode"/>.
+    /// </para>
+    /// <para>
+    /// The module manager handles the complete lifecycle of modules from discovery through initialization,
+    /// including error handling and reporting progress during module loading.
+    /// </para>
+    /// </remarks>
     public interface IModuleManager
     {
         /// <summary>
         /// Gets all the <see cref="IModuleInfo"/> classes that are in the <see cref="IModuleCatalog"/>.
         /// </summary>
+        /// <value>An enumerable collection of all registered modules.</value>
+        /// <remarks>
+        /// This provides a read-only view of all modules that have been registered with the module catalog.
+        /// </remarks>
         IEnumerable<IModuleInfo> Modules { get; }
 
         /// <summary>
         /// Initializes the modules marked as <see cref="InitializationMode.WhenAvailable"/> on the <see cref="IModuleCatalog"/>.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method starts the module loading process. Only modules marked with <see cref="InitializationMode.WhenAvailable"/>
+        /// will be loaded. Modules with <see cref="InitializationMode.OnDemand"/> must be explicitly loaded using <see cref="LoadModule(string)"/>.
+        /// </para>
+        /// <para>
+        /// Events will be raised as modules load or fail to load.
+        /// </para>
+        /// </remarks>
         void Run();
 
         /// <summary>
         /// Loads and initializes the module on the <see cref="IModuleCatalog"/> with the name <paramref name="moduleName"/>.
         /// </summary>
         /// <param name="moduleName">Name of the module requested for initialization.</param>
+        /// <remarks>
+        /// This method can be used to load modules on-demand at runtime. The module will be loaded regardless of its
+        /// <see cref="InitializationMode"/> setting.
+        /// </remarks>
         void LoadModule(string moduleName);
 
         /// <summary>
         /// Raised repeatedly to provide progress as modules are downloaded.
         /// </summary>
+        /// <remarks>
+        /// This event is raised during module loading to report progress. It can be used to show loading progress in the UI.
+        /// </remarks>
         event EventHandler<ModuleDownloadProgressChangedEventArgs> ModuleDownloadProgressChanged;
 
         /// <summary>
         /// Raised when a module is loaded or fails to load.
         /// </summary>
+        /// <remarks>
+        /// This event is raised for each module when its loading completes, either successfully or with an error.
+        /// Check the <see cref="LoadModuleCompletedEventArgs.IsLoaded"/> property to determine if the module loaded successfully.
+        /// </remarks>
         event EventHandler<LoadModuleCompletedEventArgs> LoadModuleCompleted;
     }
 }


### PR DESCRIPTION
## Description of Change

Added missing XML documentation comments to modularity-related APIs to improve IntelliSense support and API discoverability.

This PR enhances developer guidance when working with Prism modules.

### Bugs Fixed

- Fixes #1978

### API Changes

None

### Behavioral Changes

None

### Files Updated

- IModule
- IModuleManager

### PR Checklist

- [ ] Has tests (not required for documentation-only changes)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard