### PR TITLE
Fix #1978 — Add XML documentation for Prism navigation and region int…

### DIFF
--- a/src/Prism.Core/Navigation/IDestructible.cs
+++ b/src/Prism.Core/Navigation/IDestructible.cs
@@ -3,11 +3,26 @@
     /// <summary>
     /// Interface for objects that require cleanup of resources prior to Disposal
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IDestructible"/> is implemented by Views and ViewModels that need to clean up resources
+    /// when they are being removed or destroyed. This is particularly important in modular applications
+    /// where views are dynamically loaded and unloaded.
+    /// </para>
+    /// <para>
+    /// When a view is removed from a region or a dialog is closed, Prism will check if the view or its
+    /// ViewModel implements this interface and call the <see cref="Destroy"/> method.
+    /// </para>
+    /// </remarks>
     public interface IDestructible
     {
         /// <summary>
         /// This method allows cleanup of any resources used by your View/ViewModel 
         /// </summary>
+        /// <remarks>
+        /// This method is called when the view is being removed from a region or when a dialog is being closed.
+        /// Use this to unsubscribe from events, dispose of resources, or perform any other cleanup operations.
+        /// </remarks>
         void Destroy();
     }
 }

--- a/src/Prism.Core/Navigation/Regions/INavigateAsync.cs
+++ b/src/Prism.Core/Navigation/Regions/INavigateAsync.cs
@@ -6,20 +6,32 @@ namespace Prism.Navigation.Regions
     /// Provides methods to perform navigation.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// <see cref="INavigateAsync"/> is used to request navigation within a region. Navigation can involve loading a new view,
+    /// activating an existing view, or passing parameters between views.
+    /// </para>
+    /// <para>
     /// Convenience overloads for the methods in this interface can be found as extension methods on the
     /// <see cref="NavigationAsyncExtensions"/> class.
+    /// </para>
     /// </remarks>
     public interface INavigateAsync
     {
         /// <summary>
         /// Initiates navigation to the target specified by the <see cref="Uri"/>.
         /// </summary>
-        /// <param name="target">The navigation target</param>
+        /// <param name="target">The navigation target (typically a view name or URI)</param>
         /// <param name="navigationCallback">The callback executed when the navigation request is completed.</param>
         /// <param name="navigationParameters">The navigation parameters specific to the navigation request.</param>
         /// <remarks>
+        /// <para>
+        /// This method performs asynchronous navigation. The navigationCallback will be invoked after navigation completes,
+        /// whether successfully or with an error.
+        /// </para>
+        /// <para>
         /// Convenience overloads for this method can be found as extension methods on the
         /// <see cref="NavigationAsyncExtensions"/> class.
+        /// </para>
         /// </remarks>
         void RequestNavigate(Uri target, Action<NavigationResult> navigationCallback, INavigationParameters navigationParameters);
     }

--- a/src/Prism.Core/Navigation/Regions/IRegion.cs
+++ b/src/Prism.Core/Navigation/Regions/IRegion.cs
@@ -6,36 +6,63 @@ namespace Prism.Navigation.Regions
     /// <summary>
     /// Defines a model that can be used to compose views.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IRegion"/> is a key component of Prism's Region-based composition pattern. Regions act as named placeholders
+    /// where views can be dynamically added, removed, or swapped at runtime. This allows for flexible UI composition without
+    /// tightly coupling different parts of an application.
+    /// </para>
+    /// <para>
+    /// Views in a region can be managed individually or as a group. Only one view can be "Active" at a time (in most region adapters),
+    /// allowing for tab-like or carousel-like UI patterns. Each region has a <see cref="Context"/> that can be used to share data
+    /// between the region and its views.
+    /// </para>
+    /// </remarks>
     public interface IRegion : INavigateAsync, INotifyPropertyChanged
     {
         /// <summary>
         /// Gets a readonly view of the collection of views in the region.
         /// </summary>
         /// <value>An <see cref="IViewsCollection"/> of all the added views.</value>
+        /// <remarks>
+        /// This collection includes all views that have been added to the region, regardless of whether they are currently active.
+        /// </remarks>
         IViewsCollection Views { get; }
 
         /// <summary>
         /// Gets a readonly view of the collection of all the active views in the region.
         /// </summary>
         /// <value>An <see cref="IViewsCollection"/> of all the active views.</value>
+        /// <remarks>
+        /// In most region adapters, this collection will contain 0 or 1 items, as only one view is typically active at a time.
+        /// </remarks>
         IViewsCollection ActiveViews { get; }
 
         /// <summary>
         /// Gets or sets a context for the region. This value can be used by the user to share context with the views.
         /// </summary>
         /// <value>The context value to be shared.</value>
+        /// <remarks>
+        /// The context is typically used to pass data to views or to allow views to communicate back through the region.
+        /// </remarks>
         object Context { get; set; }
 
         /// <summary>
         /// Gets the name of the region that uniquely identifies the region within a <see cref="IRegionManager"/>.
         /// </summary>
         /// <value>The name of the region.</value>
+        /// <remarks>
+        /// Region names are case-sensitive and must be unique within a region manager.
+        /// </remarks>
         string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the comparison used to sort the views.
         /// </summary>
         /// <value>The comparison to use.</value>
+        /// <remarks>
+        /// Setting this property allows you to control the order in which views appear in the Views collection.
+        /// </remarks>
         Comparison<object> SortComparison { get; set; }
 
         ///<overloads>Adds a new view to the region.</overloads>
@@ -44,6 +71,9 @@ namespace Prism.Navigation.Regions
         /// </summary>
         /// <param name="viewName">The view to add.</param>
         /// <returns>The <see cref="IRegionManager"/> that is set on the view. It will be the current region manager when using this overload.</returns>
+        /// <remarks>
+        /// The view is resolved from the container using the provided name.
+        /// </remarks>
         IRegionManager Add(string viewName);
 
         ///<overloads>Adds a new view to the region.</overloads>
@@ -52,6 +82,9 @@ namespace Prism.Navigation.Regions
         /// </summary>
         /// <param name="view">The view to add.</param>
         /// <returns>The <see cref="IRegionManager"/> that is set on the view. It will be the current region manager when using this overload.</returns>
+        /// <remarks>
+        /// The view instance is directly added to the region without resolving from the container.
+        /// </remarks>
         IRegionManager Add(object view);
 
         /// <summary>
@@ -60,6 +93,9 @@ namespace Prism.Navigation.Regions
         /// <param name="view">The view to add.</param>
         /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="GetView"/>.</param>
         /// <returns>The <see cref="IRegionManager"/> that is set on the view. It will be the current region manager when using this overload.</returns>
+        /// <remarks>
+        /// The view is associated with the specified name and can be retrieved later using GetView(viewName).
+        /// </remarks>
         IRegionManager Add(object view, string viewName);
 
         /// <summary>
@@ -69,29 +105,44 @@ namespace Prism.Navigation.Regions
         /// <param name="viewName">The name of the view. This can be used to retrieve it later by calling <see cref="GetView"/>.</param>
         /// <param name="createRegionManagerScope">When <see langword="true"/>, the added view will receive a new instance of <see cref="IRegionManager"/>, otherwise it will use the current region manager for this region.</param>
         /// <returns>The <see cref="IRegionManager"/> that is set on the view.</returns>
+        /// <remarks>
+        /// Creating a new scope is useful when you want the view and its child regions to have a hierarchical region management structure.
+        /// </remarks>
         IRegionManager Add(object view, string viewName, bool createRegionManagerScope);
 
         /// <summary>
         /// Removes the specified view from the region.
         /// </summary>
         /// <param name="view">The view to remove.</param>
+        /// <remarks>
+        /// If the view is currently active, it will be deactivated before removal.
+        /// </remarks>
         void Remove(object view);
 
         /// <summary>
         /// Removes all views from the region.
         /// </summary>
+        /// <remarks>
+        /// This clears the region of all views. Active views are deactivated before removal.
+        /// </remarks>
         void RemoveAll();
 
         /// <summary>
         /// Marks the specified view as active.
         /// </summary>
         /// <param name="view">The view to activate.</param>
+        /// <remarks>
+        /// In most region adapters, only one view can be active at a time. Activating a new view deactivates the previously active view.
+        /// </remarks>
         void Activate(object view);
 
         /// <summary>
         /// Marks the specified view as inactive.
         /// </summary>
         /// <param name="view">The view to deactivate.</param>
+        /// <remarks>
+        /// Deactivating a view removes it from the ActiveViews collection.
+        /// </remarks>
         void Deactivate(object view);
 
         /// <summary>

--- a/src/Prism.Core/Navigation/Regions/IRegionAware.cs
+++ b/src/Prism.Core/Navigation/Regions/IRegionAware.cs
@@ -3,27 +3,49 @@ namespace Prism.Navigation.Regions
     /// <summary>
     /// Provides a way for objects involved in navigation to be notified of navigation activities.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IRegionAware"/> is typically implemented by ViewModel classes that need to respond to navigation events.
+    /// It allows views and their ViewModels to participate in the navigation lifecycle.
+    /// </para>
+    /// <para>
+    /// When a view is navigated to or away from, the region will check if its ViewModel implements this interface
+    /// and call the appropriate methods.
+    /// </para>
+    /// </remarks>
     public interface IRegionAware
     {
         /// <summary>
         /// Called when the implementer has been navigated to.
         /// </summary>
-        /// <param name="navigationContext">The navigation context.</param>
+        /// <param name="navigationContext">The navigation context containing parameters and other navigation information.</param>
+        /// <remarks>
+        /// This method is called after the view has been added to the region and is about to be activated.
+        /// Use this method to initialize the view based on navigation parameters.
+        /// </remarks>
         void OnNavigatedTo(NavigationContext navigationContext);
 
         /// <summary>
         /// Called to determine if this instance can handle the navigation request.
         /// </summary>
-        /// <param name="navigationContext">The navigation context.</param>
+        /// <param name="navigationContext">The navigation context containing parameters and other navigation information.</param>
         /// <returns>
-        /// <see langword="true"/> if this instance accepts the navigation request; otherwise, <see langword="false"/>.
+        /// <see langword="true"/> if this instance accepts the navigation request and should be reused; otherwise, <see langword="false"/> to create a new instance.
         /// </returns>
+        /// <remarks>
+        /// Return <see langword="true"/> if this view should be reused for the navigation (e.g., showing the same item with updated parameters).
+        /// Return <see langword="false"/> if a new instance should be created.
+        /// </remarks>
         bool IsNavigationTarget(NavigationContext navigationContext);
 
         /// <summary>
         /// Called when the implementer is being navigated away from.
         /// </summary>
-        /// <param name="navigationContext">The navigation context.</param>
+        /// <param name="navigationContext">The navigation context containing parameters and other navigation information.</param>
+        /// <remarks>
+        /// This method is called when the view is about to be deactivated or removed from the region.
+        /// Use this method to clean up resources or save state if needed.
+        /// </remarks>
         void OnNavigatedFrom(NavigationContext navigationContext);
     }
 }


### PR DESCRIPTION
## Description of Change

Added missing XML documentation comments to navigation and region-related APIs to improve IntelliSense support and API discoverability.

This PR improves developer guidance when working with Prism navigation and region management.

### Bugs Fixed

- Fixes #1978

### API Changes

None

### Behavioral Changes

None

### Files Updated

- IDestructible
- INavigateAsync
- IRegion
- IRegionAware

### PR Checklist

- [ ] Has tests (not required for documentation-only changes)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard