### PR TITLE
Fix #1978 — Add XML docs for EventAggregator APIs

### DIFF
--- a/src/Prism.Events/IEventAggregator.cs
+++ b/src/Prism.Events/IEventAggregator.cs
@@ -7,13 +7,26 @@ namespace Prism.Events
     /// <summary>
     /// Defines an interface to get instances of an event type.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IEventAggregator"/> is the main entry point for the Pub/Sub event system in Prism.
+    /// It maintains a singleton collection of event instances and provides a way to retrieve or create events by type.
+    /// </para>
+    /// <para>
+    /// Typically, you inject <see cref="IEventAggregator"/> into your ViewModels and use it to publish and subscribe to loosely-coupled events.
+    /// </para>
+    /// </remarks>
     public interface IEventAggregator
     {
         /// <summary>
         /// Gets an instance of an event type.
         /// </summary>
-        /// <typeparam name="TEventType">The type of event to get.</typeparam>
-        /// <returns>An instance of an event object of type <typeparamref name="TEventType"/>.</returns>
+        /// <typeparam name="TEventType">The type of event to get. Must be a type that inherits from <see cref="EventBase"/> and has a parameterless constructor.</typeparam>
+        /// <returns>An instance of an event object of type <typeparamref name="TEventType"/>. Multiple calls with the same type return the same instance (singleton).</returns>
+        /// <remarks>
+        /// This method returns a singleton instance of the requested event type. If the event does not yet exist, it will be created.
+        /// Subsequent calls with the same type parameter will return the same instance.
+        /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         TEventType GetEvent<TEventType>() where TEventType : EventBase, new();
     }

--- a/src/Prism.Events/ThreadOption.cs
+++ b/src/Prism.Events/ThreadOption.cs
@@ -7,21 +7,37 @@ namespace Prism.Events
     /// <summary>
     /// Specifies on which thread a <see cref="PubSubEvent{TPayload}"/> subscriber will be called.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This enumeration is used when subscribing to Pub/Sub events to control where the subscription callback is executed.
+    /// The choice affects threading behavior and should be considered based on the nature of the work being performed.
+    /// </para>
+    /// </remarks>
     public enum ThreadOption
     {
         /// <summary>
         /// The call is done on the same thread on which the <see cref="PubSubEvent{TPayload}"/> was published.
         /// </summary>
+        /// <remarks>
+        /// This is the default and most performant option. Use this when the callback doesn't need to interact with the UI.
+        /// </remarks>
         PublisherThread,
 
         /// <summary>
         /// The call is done on the UI thread.
         /// </summary>
+        /// <remarks>
+        /// Use this option when the callback needs to update UI elements. On XAML platforms, this typically means the thread
+        /// that created the UI dispatcher. On non-UI platforms, this behaves like PublisherThread.
+        /// </remarks>
         UIThread,
 
         /// <summary>
         /// The call is done asynchronously on a background thread.
         /// </summary>
+        /// <remarks>
+        /// Use this option when the callback performs long-running operations that shouldn't block the publisher thread.
+        /// </remarks>
         BackgroundThread
     }
 }


### PR DESCRIPTION
## Description of Change

Added missing XML documentation comments to event-related APIs to improve IntelliSense support and API discoverability.

This PR enhances developer guidance when using Prism's EventAggregator.

### Bugs Fixed

- Fixes #1978

### API Changes

None

### Behavioral Changes

None

### Files Updated

- IEventAggregator
- ThreadOption

### PR Checklist

- [x] Has tests (not required for documentation-only changes)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard