### PR TITLE
Adopts Central Package Management and Enables SBOM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Brian Lagunas;Dan Siegel</Authors>
+    <Company>Prism Software, LLC</Company>
+    <Copyright Condition="'$(Copyright)'==''">Copyright (C) 2015-$([System.DateTime]::Now.ToString(`yyyy`)) Prism Software, LLC - all rights reserved</Copyright>
     <PackageProjectUrl>https://github.com/PrismLibrary/Prism</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>prism-logo.png</PackageIcon>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -152,26 +152,16 @@
           CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(UseMaui) != 'true' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(DISABLE_GITVERSIONING) != 'true' ">
-    <PackageReference Include="Nerdbank.GitVersioning"
-                      Condition=" !$(MSBuildProjectDirectory.Contains('e2e')) ">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(IsPackable) ">
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+  <!-- Versions: Directory.Packages.props (Central Package Management). PrivateAssets=all is implicit. -->
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
+                            Condition=" $(UseMaui) != 'true' " />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning"
+                            Condition=" $(DISABLE_GITVERSIONING) != 'true' AND !$(MSBuildProjectDirectory.Contains('e2e')) " />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub"
+                            Condition=" $(IsPackable) " />
+    <GlobalPackageReference Include="Microsoft.Sbom.Targets"
+                            Condition=" $(IsPackable) " />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" $(IsPackable) ">
+    <GenerateSBOM>true</GenerateSBOM>
     <!-- Nuget source link -->
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,8 @@
 
   <PropertyGroup Condition=" $(IsPackable) ">
     <GenerateSBOM>true</GenerateSBOM>
+    <SbomGenerationFetchLicenseInformation>true</SbomGenerationFetchLicenseInformation>
+    <SbomGenerationPackageSupplier>$(Company)</SbomGenerationPackageSupplier>
     <!-- Nuget source link -->
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -13,4 +15,11 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
+  <Target Name="SetSbomMetadata"
+          BeforeTargets="GenerateSbomTarget"
+          AfterTargets="GetBuildVersion">
+    <PropertyGroup>
+      <SbomGenerationPackageVersion>$(PackageVersion)</SbomGenerationPackageVersion>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,9 +99,10 @@
     <PackageVersion Include="Xamarin.UITest" Version="3.0.12" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Global Packages -->
+    <!-- GlobalPackageReference in Directory.Build.props — build-only; not transitive to package consumers -->
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,8 @@
     <IsPackable Condition=" '$(IsWpfProject)' ">!$(DisableWpfPublish)</IsPackable>
     <IsPackable Condition=" '$(IsFormsProject)' ">!$(DisableFormsPublish)</IsPackable>
     <IsPackable Condition=" '$(IsUnoProject)' ">!$(DisableUnoPublish)</IsPackable>
-    <ContinuousIntegrationBuild Condition="'$(BUILD_BUILDID)' != ''">true</ContinuousIntegrationBuild>
+    <!-- GitHub Actions sets GITHUB_ACTIONS and CI; other CI hosts often set CI. -->
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true' Or '$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description of Change

This change updates the project's build system to adopt Central Package Management (CPM) for global, build-time only dependencies. Existing `PackageReference` items for tools like `Microsoft.NETFramework.ReferenceAssemblies`, `Nerdbank.GitVersioning`, and `Microsoft.SourceLink.GitHub` are migrated to `GlobalPackageReference`, centralizing their version management in `Directory.Packages.props`.

Additionally, Software Bill of Material (SBOM) generation is enabled for all packable projects. This is achieved by incorporating the `Microsoft.Sbom.Targets` package and setting the `GenerateSBOM` property to `true`.

### Bugs Fixed

- None

### API Changes

None

### Behavioral Changes

Packable projects will now automatically generate an SBOM during the build process, which will be included in the build output. This is a change to the build system and does not affect the runtime behavior of applications.

### PR Checklist

- [ ] Has tests (No new tests are required as this change modifies build infrastructure.)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard