### PR TITLE
Enhances Nullable Reference Type support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -156,13 +156,13 @@
 
   <!-- Versions: Directory.Packages.props (Central Package Management). PrivateAssets=all is implicit. -->
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
                             Condition=" $(UseMaui) != 'true' " />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning"
+    <PackageReference Include="Nerdbank.GitVersioning"
                             Condition=" $(DISABLE_GITVERSIONING) != 'true' AND !$(MSBuildProjectDirectory.Contains('e2e')) " />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub"
+    <PackageReference Include="Microsoft.SourceLink.GitHub"
                             Condition=" $(IsPackable) " />
-    <GlobalPackageReference Include="Microsoft.Sbom.Targets"
+    <PackageReference Include="Microsoft.Sbom.Targets"
                             Condition=" $(IsPackable) " />
   </ItemGroup>
 

--- a/src/Prism.Core/Common/IParameters.cs
+++ b/src/Prism.Core/Common/IParameters.cs
@@ -6,14 +6,14 @@ namespace Prism.Common
     /// <summary>
     /// Defines a contract for specifying values associated with a unique key.
     /// </summary>
-    public interface IParameters : IEnumerable<KeyValuePair<string, object>>
+    public interface IParameters : IEnumerable<KeyValuePair<string, object?>>
     {
         /// <summary>
         /// Adds the specified key and value to the parameter collection.
         /// </summary>
         /// <param name="key">The key of the parameter to add.</param>
         /// <param name="value">The value of the parameter to add.</param>
-        void Add(string key, object value);
+        void Add(string key, object? value);
 
         /// <summary>
         /// Determines whether the <see cref="IParameters"/> contains the specified <paramref name="key"/>.

--- a/src/Prism.Core/Common/ParametersBase.cs
+++ b/src/Prism.Core/Common/ParametersBase.cs
@@ -104,7 +104,7 @@ namespace Prism.Common
         /// </summary>
         /// <param name="key">The key to reference this value in the parameters collection.</param>
         /// <param name="value">The value of the parameter to store.</param>
-        public void Add(string key, object value) =>
+        public void Add(string key, object? value) =>
             _entries.Add(new KeyValuePair<string, object?>(key, value));
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Prism.Common
         /// <param name="key">The key for the value to be returned.</param>
         /// <returns>Returns a matching parameter of <typeparamref name="T"/> if one exists in the Collection.</returns>
         public T GetValue<T>(string key) =>
-            _entries.GetValue<T>(key);
+            _entries.GetValue<T>(key)!;
 
         /// <summary>
         /// Returns an IEnumerable of all parameters.

--- a/src/Prism.Core/Common/ParametersExtensions.cs
+++ b/src/Prism.Core/Common/ParametersExtensions.cs
@@ -21,8 +21,13 @@ namespace Prism.Common
         /// <param name="key">The key of the parameter to find</param>
         /// <returns>A matching value of <typeparamref name="T"/> if it exists</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static T GetValue<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key) =>
-            (T)GetValue(parameters, key, typeof(T));
+        public static T GetValue<T>(this IEnumerable<KeyValuePair<string, object?>> parameters, string key)
+        {
+            object? value = GetValue(parameters, key, typeof(T));
+            if (value is null)
+                return default!;
+            return (T)value;
+        }
 
         /// <summary>
         /// Searches <paramref name="parameters"/> for value referenced by <paramref name="key"/>
@@ -33,7 +38,7 @@ namespace Prism.Common
         /// <returns>A matching value of <paramref name="type"/> if it exists</returns>
         /// <exception cref="InvalidCastException">Unable to convert the value of Type</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static object GetValue(this IEnumerable<KeyValuePair<string, object>> parameters, string key, Type type)
+        public static object? GetValue(this IEnumerable<KeyValuePair<string, object?>> parameters, string key, Type type)
         {
             foreach (var kvp in parameters)
             {
@@ -42,7 +47,7 @@ namespace Prism.Common
                     if (TryGetValueInternal(kvp, type, out var value))
                         return value;
 
-                    throw new InvalidCastException($"Unable to convert the value of Type '{kvp.Value.GetType().FullName}' to '{type.FullName}' for the key '{key}' ");
+                    throw new InvalidCastException($"Unable to convert the value of Type '{kvp.Value!.GetType().FullName}' to '{type.FullName}' for the key '{key}' ");
                 }
             }
 
@@ -58,7 +63,7 @@ namespace Prism.Common
         /// <param name="value">The value of parameter to return</param>
         /// <returns>Success if value is found; otherwise returns <c>false</c></returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static bool TryGetValue<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key, out T value)
+        public static bool TryGetValue<T>(this IEnumerable<KeyValuePair<string, object?>> parameters, string key, [MaybeNullWhen(false)] out T value)
         {
             var type = typeof(T);
 
@@ -75,7 +80,7 @@ namespace Prism.Common
                 }
             }
 
-            value = default;
+            value = default!;
             return false;
         }
 
@@ -87,7 +92,7 @@ namespace Prism.Common
         /// <param name="key">The key of the parameter to find</param>
         /// <returns>An IEnumerable{T} of all the values referenced by key</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object>> parameters, string key)
+        public static IEnumerable<T> GetValues<T>(this IEnumerable<KeyValuePair<string, object?>> parameters, string key)
         {
             List<T> values = [];
             var type = typeof(T);
@@ -105,7 +110,7 @@ namespace Prism.Common
             return values.ToArray();
         }
 
-        private static bool TryGetValueInternal(KeyValuePair<string, object> kvp, Type type, out object value)
+        private static bool TryGetValueInternal(KeyValuePair<string, object?> kvp, Type type, out object? value)
         {
             value = GetDefault(type);
             var valueAsString = kvp.Value is string str ? str : kvp.Value?.ToString();
@@ -141,7 +146,7 @@ namespace Prism.Common
             if (!success && type.GetInterface("System.IConvertible") != null)
             {
                 success = true;
-                value = Convert.ChangeType(kvp.Value, type);
+                value = Convert.ChangeType(kvp.Value, type)!;
             }
 
             return success;
@@ -154,7 +159,7 @@ namespace Prism.Common
         /// <param name="key">The key to search the <paramref name="parameters"/> for existence</param>
         /// <returns><c>true</c> if key exists; <c>false</c> otherwise</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static bool ContainsKey(this IEnumerable<KeyValuePair<string, object>> parameters, string key) =>
+        public static bool ContainsKey(this IEnumerable<KeyValuePair<string, object?>> parameters, string key) =>
             parameters.Any(x => string.Compare(x.Key, key, StringComparison.Ordinal) == 0);
 
         private static object? GetDefault(Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;

--- a/src/Prism.Core/Common/UriParsingHelper.cs
+++ b/src/Prism.Core/Common/UriParsingHelper.cs
@@ -74,7 +74,7 @@ namespace Prism.Common
 
             if (parameters is not null)
             {
-                foreach (KeyValuePair<string, object> navigationParameter in parameters)
+                foreach (KeyValuePair<string, object?> navigationParameter in parameters)
                 {
                     navParameters.Add(navigationParameter.Key, navigationParameter.Value);
                 }
@@ -116,7 +116,7 @@ namespace Prism.Common
 
             if (parameters != null)
             {
-                foreach (KeyValuePair<string, object> navigationParameter in parameters)
+                foreach (KeyValuePair<string, object?> navigationParameter in parameters)
                 {
                     dialogParameters.Add(navigationParameter.Key, navigationParameter.Value);
                 }

--- a/src/Prism.Core/Modularity/CyclicDependencyFoundException.Desktop.cs
+++ b/src/Prism.Core/Modularity/CyclicDependencyFoundException.Desktop.cs
@@ -1,4 +1,4 @@
-
+#if NETFRAMEWORK
 
 using System;
 using System.Runtime.Serialization;
@@ -17,3 +17,5 @@ namespace Prism.Modularity
         protected CyclicDependencyFoundException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }
+
+#endif

--- a/src/Prism.Core/Modularity/DuplicateModuleException.Desktop.cs
+++ b/src/Prism.Core/Modularity/DuplicateModuleException.Desktop.cs
@@ -1,4 +1,4 @@
-
+#if NETFRAMEWORK
 
 using System;
 using System.Runtime.Serialization;
@@ -17,3 +17,5 @@ namespace Prism.Modularity
         protected DuplicateModuleException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }
+
+#endif

--- a/src/Prism.Core/Modularity/ModularityException.Desktop.cs
+++ b/src/Prism.Core/Modularity/ModularityException.Desktop.cs
@@ -1,4 +1,4 @@
-
+#if NETFRAMEWORK
 
 using System;
 using System.Runtime.Serialization;
@@ -25,9 +25,7 @@ namespace Prism.Modularity
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-#if !NET6_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.SerializationFormatter)]
-#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
@@ -35,3 +33,5 @@ namespace Prism.Modularity
         }
     }
 }
+
+#endif

--- a/src/Prism.Core/Modularity/ModuleInitializeException.Desktop.cs
+++ b/src/Prism.Core/Modularity/ModuleInitializeException.Desktop.cs
@@ -1,4 +1,4 @@
-
+#if NETFRAMEWORK
 
 using System;
 using System.Runtime.Serialization;
@@ -19,3 +19,5 @@ namespace Prism.Modularity
         }
     }
 }
+
+#endif

--- a/src/Prism.Core/Modularity/ModuleNotFoundException.Desktop.cs
+++ b/src/Prism.Core/Modularity/ModuleNotFoundException.Desktop.cs
@@ -1,4 +1,4 @@
-
+#if NETFRAMEWORK
 
 using System;
 using System.Runtime.Serialization;
@@ -22,3 +22,5 @@ namespace Prism.Modularity
         }
     }
 }
+
+#endif

--- a/src/Prism.Core/Modularity/ModuleTypeLoadingException.Desktop.cs
+++ b/src/Prism.Core/Modularity/ModuleTypeLoadingException.Desktop.cs
@@ -1,4 +1,4 @@
-
+#if NETFRAMEWORK
 
 using System;
 using System.Runtime.Serialization;
@@ -19,3 +19,5 @@ namespace Prism.Modularity
         }
     }
 }
+
+#endif

--- a/src/Prism.Core/Mvvm/ErrorsContainer.cs
+++ b/src/Prism.Core/Mvvm/ErrorsContainer.cs
@@ -137,7 +137,7 @@ namespace Prism.Mvvm
             {
                 if (hasNewValidationResults)
                 {
-                    this.validationResults[localPropertyName] = new List<T>(newValidationResults);
+                    this.validationResults[localPropertyName] = new List<T>(newValidationResults!);
                     this.raiseErrorsChanged(localPropertyName);
                 }
                 else

--- a/src/Prism.Core/Mvvm/ErrorsContainer.cs
+++ b/src/Prism.Core/Mvvm/ErrorsContainer.cs
@@ -9,7 +9,7 @@ namespace Prism.Mvvm
     /// <typeparam name="T">The type of the error object.</typeparam>
     public class ErrorsContainer<T>
     {
-        private static readonly T[] noErrors = new T[0];
+        private static readonly T[] noErrors = [];
 
         /// <summary>
         /// Delegate to be called when raiseErrorsChanged is invoked.
@@ -27,25 +27,23 @@ namespace Prism.Mvvm
         /// <param name="raiseErrorsChanged">The action that is invoked when errors are added for an object.</param>
         public ErrorsContainer(Action<string> raiseErrorsChanged)
         {
+#if NETFRAMEWORK
             if (raiseErrorsChanged == null)
             {
                 throw new ArgumentNullException(nameof(raiseErrorsChanged));
             }
+#else
+            ArgumentNullException.ThrowIfNull(raiseErrorsChanged);
+#endif
 
             this.raiseErrorsChanged = raiseErrorsChanged;
-            this.validationResults = new Dictionary<string, List<T>>();
+            validationResults = [];
         }
 
         /// <summary>
         /// Gets a value indicating whether the object has validation errors. 
         /// </summary>
-        public bool HasErrors
-        {
-            get
-            {
-                return this.validationResults.Count != 0;
-            }
-        }
+        public bool HasErrors => validationResults.Count != 0;
 
         /// <summary>
         /// Returns all the errors in the container.
@@ -61,7 +59,7 @@ namespace Prism.Mvvm
         public IEnumerable<T> GetErrors(string? propertyName)
         {
             var localPropertyName = propertyName ?? string.Empty;
-            if (this.validationResults.TryGetValue(localPropertyName, out var currentValidationResults))
+            if (validationResults.TryGetValue(localPropertyName, out var currentValidationResults))
             {
                 return currentValidationResults;
             }
@@ -76,7 +74,7 @@ namespace Prism.Mvvm
         /// </summary>
         public void ClearErrors()
         {
-            foreach (var key in this.validationResults.Keys.ToArray())
+            foreach (var key in validationResults.Keys.ToArray())
             {
                 ClearErrors(key);
             }
@@ -94,7 +92,7 @@ namespace Prism.Mvvm
         public void ClearErrors<TProperty>(Expression<Func<TProperty>> propertyExpression)
         {
             var propertyName = PropertySupport.ExtractPropertyName(propertyExpression);
-            this.ClearErrors(propertyName);
+            ClearErrors(propertyName);
         }
 
         /// <summary>
@@ -104,7 +102,7 @@ namespace Prism.Mvvm
         /// <example>
         /// container.ClearErrors("SomeProperty");
         /// </example>
-        public void ClearErrors(string? propertyName) => this.SetErrors(propertyName, new List<T>());
+        public void ClearErrors(string? propertyName) => SetErrors(propertyName, new List<T>());
 
         /// <summary>
         /// Sets the validation errors for the specified property.
@@ -116,7 +114,7 @@ namespace Prism.Mvvm
         public void SetErrors<TProperty>(Expression<Func<TProperty>> propertyExpression, IEnumerable<T>? propertyErrors)
         {
             var propertyName = PropertySupport.ExtractPropertyName(propertyExpression);
-            this.SetErrors(propertyName, propertyErrors);
+            SetErrors(propertyName, propertyErrors);
         }
 
         /// <summary>
@@ -130,20 +128,20 @@ namespace Prism.Mvvm
         public void SetErrors(string? propertyName, IEnumerable<T>? newValidationResults)
         {
             var localPropertyName = propertyName ?? string.Empty;
-            var hasCurrentValidationResults = this.validationResults.ContainsKey(localPropertyName);
+            var hasCurrentValidationResults = validationResults.ContainsKey(localPropertyName);
             var hasNewValidationResults = newValidationResults != null && newValidationResults.Count() > 0;
 
             if (hasCurrentValidationResults || hasNewValidationResults)
             {
                 if (hasNewValidationResults)
                 {
-                    this.validationResults[localPropertyName] = new List<T>(newValidationResults!);
-                    this.raiseErrorsChanged(localPropertyName);
+                    validationResults[localPropertyName] = new List<T>(newValidationResults!);
+                    raiseErrorsChanged(localPropertyName);
                 }
                 else
                 {
-                    this.validationResults.Remove(localPropertyName);
-                    this.raiseErrorsChanged(localPropertyName);
+                    validationResults.Remove(localPropertyName);
+                    raiseErrorsChanged(localPropertyName);
                 }
             }
         }

--- a/src/Prism.Core/Mvvm/PropertySupport.cs
+++ b/src/Prism.Core/Mvvm/PropertySupport.cs
@@ -54,7 +54,7 @@ namespace Prism.Mvvm
                 throw new ArgumentException(Resources.PropertySupport_ExpressionNotProperty_Exception, nameof(expression));
 
             var getMethod = property.GetMethod;
-            if (getMethod.IsStatic)
+            if (getMethod is null || getMethod.IsStatic)
                 throw new ArgumentException(Resources.PropertySupport_StaticExpression_Exception, nameof(expression));
 
             return memberExpression.Member.Name;

--- a/src/Prism.Core/Mvvm/ViewModelLocationProvider.cs
+++ b/src/Prism.Core/Mvvm/ViewModelLocationProvider.cs
@@ -26,7 +26,7 @@ namespace Prism.Mvvm
         {
             _factories = new Dictionary<string, Func<object>>();
             _typeFactories = new Dictionary<string, Type>();
-            _defaultViewModelFactory = type => Activator.CreateInstance(type);
+            _defaultViewModelFactory = type => Activator.CreateInstance(type)!;
             _defaultViewModelFactoryWithViewParameter = null;
             _defaultViewTypeToViewModelTypeResolver = DefaultViewTypeToViewModel;
         }
@@ -44,7 +44,7 @@ namespace Prism.Mvvm
         /// <summary>
         /// The default view model factory which provides the ViewModel type as a parameter.
         /// </summary>
-        static Func<Type, object> _defaultViewModelFactory = type => Activator.CreateInstance(type);
+        static Func<Type, object> _defaultViewModelFactory = type => Activator.CreateInstance(type)!;
 
         /// <summary>
         /// ViewModelFactory that provides the View instance and ViewModel type as parameters.

--- a/src/Prism.Core/Mvvm/ViewRegistryBase{TBaseView}.cs
+++ b/src/Prism.Core/Mvvm/ViewRegistryBase{TBaseView}.cs
@@ -129,7 +129,8 @@ public abstract class ViewRegistryBase<TBaseView> : IViewRegistry
 
             return candidates
                 .Select(x => Type.GetType(x, false))
-                .Where(x => x is not null);
+                .Where(x => x is not null)
+                .Cast<Type>();
         }
 
         return [];

--- a/src/Prism.Core/Navigation/INavigationParametersInternal.cs
+++ b/src/Prism.Core/Navigation/INavigationParametersInternal.cs
@@ -1,4 +1,6 @@
-﻿namespace Prism.Navigation;
+﻿#nullable enable
+
+namespace Prism.Navigation;
 
 /// <summary>
 /// Used to set internal parameters used by Prism
@@ -10,7 +12,7 @@ public interface INavigationParametersInternal
     /// </summary>
     /// <param name="key">The key to reference this value in the parameters collection.</param>
     /// <param name="value">The value of the parameter to store</param>
-    void Add(string key, object value);
+    void Add(string key, object? value);
 
     /// <summary>
     /// Checks collection for presence of key

--- a/src/Prism.Core/Navigation/NavigationParameters.cs
+++ b/src/Prism.Core/Navigation/NavigationParameters.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using Prism.Common;
 
+#nullable enable
+
 namespace Prism.Navigation;
 
 /// <summary>
@@ -11,7 +13,7 @@ namespace Prism.Navigation;
 /// </remarks>
 public class NavigationParameters : ParametersBase, INavigationParameters, INavigationParametersInternal
 {
-    private readonly Dictionary<string, object> _internalParameters = new Dictionary<string, object>();
+    private readonly Dictionary<string, object?> _internalParameters = new Dictionary<string, object?>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NavigationParameters"/> class.
@@ -30,7 +32,7 @@ public class NavigationParameters : ParametersBase, INavigationParameters, INavi
     }
 
     #region INavigationParametersInternal
-    void INavigationParametersInternal.Add(string key, object value)
+    void INavigationParametersInternal.Add(string key, object? value)
     {
         _internalParameters.Add(key, value);
     }
@@ -42,7 +44,7 @@ public class NavigationParameters : ParametersBase, INavigationParameters, INavi
 
     T INavigationParametersInternal.GetValue<T>(string key)
     {
-        return _internalParameters.GetValue<T>(key);
+        return _internalParameters.GetValue<T>(key)!;
     }
     #endregion
 }

--- a/src/Prism.Core/Navigation/Regions/NavigationContext.cs
+++ b/src/Prism.Core/Navigation/Regions/NavigationContext.cs
@@ -63,7 +63,7 @@ namespace Prism.Navigation.Regions
 
             if (navigationParameters != null)
             {
-                foreach (KeyValuePair<string, object> navigationParameter in navigationParameters)
+                foreach (var navigationParameter in navigationParameters)
                 {
                     Parameters.Add(navigationParameter.Key, navigationParameter.Value);
                 }

--- a/src/Prism.Core/Navigation/Regions/RegionCreationException.cs
+++ b/src/Prism.Core/Navigation/Regions/RegionCreationException.cs
@@ -1,14 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
-using System.Text;
+#endif
 
 namespace Prism.Navigation.Regions;
 
 /// <summary>
 /// An exception used when encountering an error in the creation of a Region
 /// </summary>
+#if NETFRAMEWORK
 [Serializable]
+#endif
 public sealed class RegionCreationException : RegionException
 {
     /// <inheritdoc />
@@ -21,10 +23,12 @@ public sealed class RegionCreationException : RegionException
     {
     }
 
-    /// <inheritdoc />
+#if NETFRAMEWORK
+    /// <inheritdoc cref="RegionException(SerializationInfo, StreamingContext)" />
     public RegionCreationException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
+#endif
 
     /// <inheritdoc />
     public RegionCreationException(string message, Exception innerException) : base(message, innerException)

--- a/src/Prism.Core/Navigation/Regions/RegionException.cs
+++ b/src/Prism.Core/Navigation/Regions/RegionException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace Prism.Navigation.Regions;
 
@@ -18,10 +20,12 @@ public abstract class RegionException : Exception
     {
     }
 
-    /// <inheritdoc />
+#if NETFRAMEWORK
+    /// <inheritdoc cref="Exception(SerializationInfo, StreamingContext)" />
     protected RegionException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
+#endif
 
     /// <inheritdoc />
     protected RegionException(string message, Exception innerException) : base(message, innerException)

--- a/src/Prism.Core/Navigation/Regions/RegionViewException.cs
+++ b/src/Prism.Core/Navigation/Regions/RegionViewException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace Prism.Navigation.Regions;
 
@@ -23,10 +25,12 @@ public sealed class RegionViewException : RegionException
     {
     }
 
-    /// <inheritdoc />
+#if NETFRAMEWORK
+    /// <inheritdoc cref="RegionException(SerializationInfo, StreamingContext)" />
     public RegionViewException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
+#endif
 
     /// <summary>
     /// Initializes a new <see cref="RegionViewException"/>

--- a/src/Prism.Core/Navigation/Regions/UpdateRegionsException.cs
+++ b/src/Prism.Core/Navigation/Regions/UpdateRegionsException.cs
@@ -1,12 +1,16 @@
 using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace Prism.Navigation.Regions
 {
     /// <summary>
     /// Represents errors that occurred during the regions' update.
     /// </summary>
+#if NETFRAMEWORK
     [Serializable]
+#endif
     public partial class UpdateRegionsException : Exception
     {
         /// <summary>
@@ -37,6 +41,7 @@ namespace Prism.Navigation.Regions
         {
         }
 
+#if NETFRAMEWORK
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateRegionsException"/> class with serialized data.
         /// </summary>
@@ -46,5 +51,6 @@ namespace Prism.Navigation.Regions
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/Prism.Core/Navigation/Regions/ViewRegistrationException.cs
+++ b/src/Prism.Core/Navigation/Regions/ViewRegistrationException.cs
@@ -1,12 +1,16 @@
 using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace Prism.Navigation.Regions
 {
     /// <summary>
     /// Exception that's thrown when something goes wrong while Registering a View with a region name in the <see cref="IRegionViewRegistry"/> class.
     /// </summary>
+#if NETFRAMEWORK
     [Serializable]
+#endif
     public partial class ViewRegistrationException : Exception
     {
         // TODO: Find updated links as these are dead...
@@ -41,6 +45,7 @@ namespace Prism.Navigation.Regions
         {
         }
 
+#if NETFRAMEWORK
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewRegistrationException"/> class with serialized data.
         /// </summary>
@@ -51,5 +56,6 @@ namespace Prism.Navigation.Regions
             : base(info, context)
         {
         }
+#endif
     }
 }


### PR DESCRIPTION
## Description of Change

This pull request significantly enhances Nullable Reference Type (NRT) support across `Prism.Core` components. It updates method signatures and internal collections, such as `IParameters`, `ParametersBase`, `NavigationParameters`, and various extension methods, to explicitly allow or handle nullable `object` values. This involves annotating `object` types with `?` where null is permissible and employing null-forgiving operators (`!`) where non-nullability is asserted by context. The `TryGetValue` pattern also benefits from the `[MaybeNullWhen(false)]` attribute, providing clearer nullability contracts for `out` parameters.

Additionally, several .NET Framework-specific serialization attributes and constructors for exceptions within the `Prism.Core.Modularity` and `Prism.Core.Navigation.Regions` namespaces are now conditionally compiled to ensure they are only included when targeting .NET Framework. This reduces compiler warnings and improves compatibility with modern .NET versions. Other minor updates include safer null checks for property getters in `PropertySupport` and explicit type casting in `ViewRegistryBase` to prevent NRT warnings.

### Bugs Fixed

- None explicitly. Addresses numerous compiler warnings related to Nullable Reference Types.

### API Changes

Changed:

- The `Add` methods in `IParameters`, `ParametersBase`, and `INavigationParametersInternal` now accept `object?` values instead of `object`.
- Many parameter types in `ParametersExtensions` methods (e.g., `GetValue`, `TryGetValue`, `GetValues`, `ContainsKey`) that previously accepted `IEnumerable>` now accept `IEnumerable>`.
- The return type of `ParametersExtensions.GetValue(this IEnumerable> parameters, string key, Type type)` changed from `object` to `object?`.
- The `out` parameter in `ParametersExtensions.TryGetValue` now includes the `[MaybeNullWhen(false)]` attribute for improved nullability analysis.

### Behavioral Changes

No significant behavioral changes are introduced for end-users. The modifications are primarily focused on compile-time nullability checks and addressing compiler warnings, ensuring the codebase is more robust and explicit about its nullability contracts without altering core runtime logic.

### PR Checklist

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard